### PR TITLE
Add missing pytest tests

### DIFF
--- a/tests/test_log_message.py
+++ b/tests/test_log_message.py
@@ -1,0 +1,78 @@
+from datetime import datetime
+
+import pytest
+from src.sdk.log_message import MessageLogger
+
+
+class DummyUser:
+    def __init__(self, user_id: int, name: str, nick: str | None = None) -> None:
+        self.id = user_id
+        self.name = name
+        self.nick = nick
+        self.bot = False
+
+
+class DummyDMChannel:
+    def __init__(self, channel_id: int) -> None:
+        self.id = channel_id
+        self.name = "dm"
+
+
+class DummyTextChannel:
+    def __init__(self, channel_id: int, name: str) -> None:
+        self.id = channel_id
+        self.name = name
+
+
+class DummyAttachment:
+    def __init__(self, url: str) -> None:
+        self.url = url
+
+
+class DummyMessage:
+    def __init__(self, author, channel) -> None:
+        self.author = author
+        self.channel = channel
+        self.content = "hello"
+        self.created_at = datetime.utcnow()
+        self.attachments: list[DummyAttachment] = []
+        self.stickers: list[DummyAttachment] = []
+
+
+@pytest.mark.asyncio
+async def test_computed_fields_dm_channel() -> None:
+    author = DummyUser(1, "tester", "tester_nick")
+    message = DummyMessage(author, DummyDMChannel(10))
+    logger = MessageLogger(message=message)
+
+    assert logger.table_name == "DM_1"
+    assert logger.channel_name_or_author_name == "DM_tester_nick_1"
+    assert logger.channel_id_or_author_id == "1"
+
+
+@pytest.mark.asyncio
+async def test_computed_fields_text_channel() -> None:
+    author = DummyUser(2, "tester")
+    channel = DummyTextChannel(20, "general")
+    message = DummyMessage(author, channel)
+    logger = MessageLogger(message=message)
+
+    assert logger.table_name == "channel_20"
+    assert logger.channel_name_or_author_name == "channel_general_20"
+    assert logger.channel_id_or_author_id == "20"
+
+
+@pytest.mark.asyncio
+async def test_save_attachments_and_stickers() -> None:
+    author = DummyUser(3, "tester")
+    channel = DummyTextChannel(30, "general")
+    message = DummyMessage(author, channel)
+    message.attachments = [DummyAttachment("a.png"), DummyAttachment("b.png")]
+    message.stickers = [DummyAttachment("s.png")]
+    logger = MessageLogger(message=message)
+
+    attachments = await logger._save_attachments()  # noqa: SLF001
+    stickers = await logger._save_stickers()  # noqa: SLF001
+
+    assert attachments == ["a.png", "b.png"]
+    assert stickers == ["s.png"]

--- a/tests/test_video_downloader.py
+++ b/tests/test_video_downloader.py
@@ -1,0 +1,20 @@
+import pytest
+from src.utils.downloader import VideoDownloader
+
+
+@pytest.fixture
+def downloader() -> VideoDownloader:
+    return VideoDownloader()
+
+
+def test_check_if_tiktok(downloader: VideoDownloader) -> None:
+    tiktok_url = "https://www.tiktok.com/@user/video/123"
+    youtube_url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    assert downloader.check_if_tiktok(tiktok_url) is True
+    assert downloader.check_if_tiktok(youtube_url) is False
+
+
+def test_quality_formats_contains_keys(downloader: VideoDownloader) -> None:
+    formats = downloader.quality_formats
+    expected = {"best", "high", "medium", "low", "audio"}
+    assert expected.issubset(set(formats))


### PR DESCRIPTION
## Summary
- add tests for `MessageLogger` computed fields and attachments
- add tests for `VideoDownloader`

## Testing
- `ruff check tests/test_log_message.py tests/test_video_downloader.py`
- `pytest tests/test_log_message.py tests/test_video_downloader.py -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6847916a1d3483219eb862b452727e4b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **测试**
  - 新增了针对消息日志功能的单元测试，覆盖了私信频道和文本频道下的字段计算，以及附件和贴纸的保存逻辑。
  - 新增了视频下载器的单元测试，验证了对 TikTok 链接的识别能力和视频质量格式的完整性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->