### PR TITLE
chore: update pyproject.toml and GitHub workflows

### DIFF
--- a/.github/workflows/auto_labeler.yml
+++ b/.github/workflows/auto_labeler.yml
@@ -1,8 +1,8 @@
 name: Pull Request Labeler
 
 on:
-  pull_request:
   push:
+  pull_request:
 
 permissions: write-all
 
@@ -17,18 +17,6 @@ jobs:
 
       # - name: Setup MTK Certification
       #   uses: https://gitea.mediatek.inc/actions/mtk-cert-action@v1.2.0
-
-      # - name: Setup SSH Key
-      #   uses: shimataro/ssh-key-action@v2.7.0
-      #   with:
-      #     key: ${{ secrets.SSH_KEY }}
-      #     name: id_rsa
-      #     known_hosts: unnecessary
-      #     config: |
-      #       Host *
-      #         StrictHostKeyChecking no
-      #         UserKnownHostsFile=/dev/null
-      #     if_key_exists: replace
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build_executable.yml
+++ b/.github/workflows/build_executable.yml
@@ -19,18 +19,6 @@ jobs:
       # - name: Setup MTK Certification
       #   uses: https://gitea.mediatek.inc/actions/mtk-cert-action@v1.2.0
 
-      # - name: Setup SSH Key
-      #   uses: shimataro/ssh-key-action@v2.7.0
-      #   with:
-      #     key: ${{ secrets.SSH_KEY }}
-      #     name: id_rsa
-      #     known_hosts: unnecessary
-      #     config: |
-      #       Host *
-      #         StrictHostKeyChecking no
-      #         UserKnownHostsFile=/dev/null
-      #     if_key_exists: replace
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -89,11 +77,6 @@ jobs:
           compression-level: 6
           overwrite: true
 
-      - name: List files
-        shell: pwsh
-        run: |
-          Get-ChildItem -Path .
-
       - name: Download Artifact
         uses: actions/download-artifact@v4
         with:
@@ -107,9 +90,15 @@ jobs:
           ls -Force
 
       - name: Upload Release Assets
+        if: ${{ contains(github.server_url, 'github') }}
         uses: softprops/action-gh-release@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: |
+          files: |-
+            ${{ github.event.repository.name }}_${{ steps.version.outputs.version }}.zip
+
+      - name: Upload Release Assets
+        if: ${{ contains(github.server_url, 'gitea') }}
+        uses: akkuman/gitea-release-action@v1
+        with:
+          files: |-
             ${{ github.event.repository.name }}_${{ steps.version.outputs.version }}.zip

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -12,6 +12,7 @@ name: Publish Docker image
 on:
   push:
     branches:
+      - main
       - master
     tags:
       - v*
@@ -43,18 +44,6 @@ jobs:
       # - name: Setup MTK Certification
       #   uses: https://gitea.mediatek.inc/actions/mtk-cert-action@v1.2.0
 
-      # - name: Setup SSH Key
-      #   uses: shimataro/ssh-key-action@v2.7.0
-      #   with:
-      #     key: ${{ secrets.SSH_KEY }}
-      #     name: id_rsa
-      #     known_hosts: unnecessary
-      #     config: |
-      #       Host *
-      #         StrictHostKeyChecking no
-      #         UserKnownHostsFile=/dev/null
-      #     if_key_exists: replace
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -75,18 +64,6 @@ jobs:
           uv version $VERSION
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      # - name: Set tags
-      #   id: version
-      #   run: |
-      #     if [[ $GITHUB_REF == refs/tags/* ]]; then
-      #       VERSION=${GITHUB_REF#refs/tags/}
-      #       echo "VERSION=${VERSION}" >> $GITHUB_ENV
-      #       echo "version=${VERSION}" >> $GITHUB_OUTPUT
-      #     else
-      #       echo "VERSION=latest" >> $GITHUB_ENV
-      #       echo "version=latest" >> $GITHUB_OUTPUT
-      #     fi
 
       - name: Login to the Container registry
         uses: docker/login-action@v3.4.0

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -17,8 +17,6 @@ jobs:
       matrix:
         python-version:
           - "3.10"
-          - "3.11"
-          - "3.12"
 
     steps:
       - name: Disable SSL Verify
@@ -26,18 +24,6 @@ jobs:
 
       # - name: Setup MTK Certification
       #   uses: https://gitea.mediatek.inc/actions/mtk-cert-action@v1.2.0
-
-      # - name: Setup SSH Key
-      #   uses: shimataro/ssh-key-action@v2.7.0
-      #   with:
-      #     key: ${{ secrets.SSH_KEY }}
-      #     name: id_rsa
-      #     known_hosts: unnecessary
-      #     config: |
-      #       Host *
-      #         StrictHostKeyChecking no
-      #         UserKnownHostsFile=/dev/null
-      #     if_key_exists: replace
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -61,18 +47,6 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      # - name: Set tags
-      #   id: version
-      #   run: |
-      #     if [[ $GITHUB_REF == refs/tags/* ]]; then
-      #       VERSION=${GITHUB_REF#refs/tags/}
-      #       echo "VERSION=${VERSION}" >> $GITHUB_ENV
-      #       echo "version=${VERSION}" >> $GITHUB_OUTPUT
-      #     else
-      #       echo "VERSION=latest" >> $GITHUB_ENV
-      #       echo "version=latest" >> $GITHUB_OUTPUT
-      #     fi
-
       - name: Build Package
         run: |
           uv build
@@ -84,31 +58,38 @@ jobs:
       #   run: |
       #     uv publish
 
-      - name: Generate a changelog
-        uses: orhun/git-cliff-action@v4
-        id: git-cliff
-        env:
-          OUTPUT: CHANGELOG.md
-        with:
-          config: pyproject.toml
-          args: --unreleased --tag ${{ steps.version.outputs.version }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Upload Artifact
+        if: ${{ contains(github.server_url, 'github') }}
         uses: actions/upload-artifact@v4.6.2
         with:
           path: ./dist/*
-          name: ${{ github.event.repository.name }}-py${{ matrix.python-version }}
+          name: ${{ github.event.repository.name }}
           if-no-files-found: ignore
           retention-days: 7
           compression-level: 6
           overwrite: true
 
       - name: Upload Release Assets
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: ${{ contains(github.server_url, 'github') }}
         uses: softprops/action-gh-release@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: |
+          files: |-
+            ./dist/*
+
+      - name: Upload Artifact
+        if: ${{ contains(github.server_url, 'gitea') }}
+        uses: christopherhx/gitea-upload-artifact@v4
+        with:
+          path: ./dist/*
+          name: ${{ github.event.repository.name }}
+          if-no-files-found: ignore
+          retention-days: 7
+          compression-level: 6
+          overwrite: true
+
+      - name: Upload Release Assets
+        if: ${{ contains(github.server_url, 'gitea') }}
+        uses: akkuman/gitea-release-action@v1
+        with:
+          files: |-
             ./dist/*

--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -23,18 +23,6 @@ jobs:
       # - name: Setup MTK Certification
       #   uses: https://gitea.mediatek.inc/actions/mtk-cert-action@v1.2.0
 
-      # - name: Setup SSH Key
-      #   uses: shimataro/ssh-key-action@v2.7.0
-      #   with:
-      #     key: ${{ secrets.SSH_KEY }}
-      #     name: id_rsa
-      #     known_hosts: unnecessary
-      #     config: |
-      #       Host *
-      #         StrictHostKeyChecking no
-      #         UserKnownHostsFile=/dev/null
-      #     if_key_exists: replace
-
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ name: Publish GitHub Pages
 on:
   push:
     branches:
+      - main
       - master
     tags:
       - v*
@@ -21,18 +22,6 @@ jobs:
 
       # - name: Setup MTK Certification
       #   uses: https://gitea.mediatek.inc/actions/mtk-cert-action@v1.2.0
-
-      # - name: Setup SSH Key
-      #   uses: shimataro/ssh-key-action@v2.7.0
-      #   with:
-      #     key: ${{ secrets.SSH_KEY }}
-      #     name: id_rsa
-      #     known_hosts: unnecessary
-      #     config: |
-      #       Host *
-      #         StrictHostKeyChecking no
-      #         UserKnownHostsFile=/dev/null
-      #     if_key_exists: replace
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pre-commit-updater.yml
+++ b/.github/workflows/pre-commit-updater.yml
@@ -21,18 +21,6 @@ jobs:
       # - name: Setup MTK Certification
       #   uses: https://gitea.mediatek.inc/actions/mtk-cert-action@v1.2.0
 
-      # - name: Setup SSH Key
-      #   uses: shimataro/ssh-key-action@v2.7.0
-      #   with:
-      #     key: ${{ secrets.SSH_KEY }}
-      #     name: id_rsa
-      #     known_hosts: unnecessary
-      #     config: |
-      #       Host *
-      #         StrictHostKeyChecking no
-      #         UserKnownHostsFile=/dev/null
-      #     if_key_exists: replace
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -56,7 +44,6 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          base: master  # push to this branch
           branch: chore/pre-commit-hooks  # push from this branch
           title: "chore: Update pre-commit hooks"
           body: "Update versions of pre-commit hooks to latest version."

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -10,10 +10,7 @@ on:
   # pull_request event is required only for autolabeler
   pull_request:
     # Only following types are handled by the action, but one can default to all as well
-    types: [opened, reopened, synchronize]
-  # pull_request_target event is required for autolabeler to support PRs from forks
-  pull_request_target:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, edited]
 
 permissions: write-all
 
@@ -29,18 +26,6 @@ jobs:
 
       # - name: Setup MTK Certification
       #   uses: https://gitea.mediatek.inc/actions/mtk-cert-action@v1.2.0
-
-      # - name: Setup SSH Key
-      #   uses: shimataro/ssh-key-action@v2.7.0
-      #   with:
-      #     key: ${{ secrets.SSH_KEY }}
-      #     name: id_rsa
-      #     known_hosts: unnecessary
-      #     config: |
-      #       Host *
-      #         StrictHostKeyChecking no
-      #         UserKnownHostsFile=/dev/null
-      #     if_key_exists: replace
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -31,7 +31,7 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v2.9.4
         # When the previous steps fails, the workflow would stop. By adding this
         # condition you can continue the execution with the populated error message.
-        if: failure() && (steps.lint_pr_title.outputs.error_message != null)
+        if: ${{ failure() && (steps.lint_pr_title.outputs.error_message != null) }}
         with:
           header: pr-title-lint-error
           message: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: Tests
 on:
   pull_request:
     branches:
+      - main
       - master
       - release/*
     paths-ignore:
@@ -35,18 +36,6 @@ jobs:
       # - name: Setup MTK Certification
       #   uses: https://gitea.mediatek.inc/actions/mtk-cert-action@v1.2.0
 
-      # - name: Setup SSH Key
-      #   uses: shimataro/ssh-key-action@v2.7.0
-      #   with:
-      #     key: ${{ secrets.SSH_KEY }}
-      #     name: id_rsa
-      #     known_hosts: unnecessary
-      #     config: |
-      #       Host *
-      #         StrictHostKeyChecking no
-      #         UserKnownHostsFile=/dev/null
-      #     if_key_exists: replace
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -77,12 +66,7 @@ jobs:
           fi
 
       - name: Run pytest
-        if: steps.check_tests.outputs.has_tests == 'true'
-        env:
-          OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_API_VERSION: ${{ secrets.OPENAI_API_VERSION }}
-          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+        if: ${{ steps.check_tests.outputs.has_tests == 'true' }}
         run: |
           uv run pytest -vv
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ addopts = [
     "--cache-clear",
     "-n=auto",
     "--no-header",
-    "--cov-fail-under=5",
+    "--cov-fail-under=80",
 ]
 filterwarnings = [
     "ignore::DeprecationWarning",
@@ -94,18 +94,14 @@ readme = "README.md"
 requires-python = ">= 3.10"
 license = { text = "MIT" }
 
-[project.scripts]
-cli = "discordbot.cli:main"
-discordbot = "discordbot.cli:main"
-update = "discordbot.cli:update"
-
 [project.urls]
 Homepage = "https://github.com/Mai0313/discordbot"
 Repository = "https://github.com/Mai0313/discordbot"
 
-[build-system]
-requires = ["hatchling", "hatch-fancy-pypi-readme"]
-build-backend = "hatchling.build"
+[project.scripts]
+cli = "discordbot.cli:main"
+discordbot = "discordbot.cli:main"
+update = "discordbot.cli:update"
 
 [dependency-groups]
 dev = [
@@ -135,6 +131,10 @@ docs = [
     "ruff",
     "tabulate",
 ]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [tool.hatch.metadata]
 allow-direct-references = true
@@ -181,12 +181,6 @@ exclude = [
     "/.docker-compose",
     "/.cache",
 ]
-
-[tool.hatch.metadata.hooks.fancy-pypi-readme]
-content-type = "text/markdown"
-
-[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
-path = "README.md"
 
 [tool.poe.tasks]
 api = "python ./src/discordbot/cli.py"
@@ -401,7 +395,7 @@ ignore = [
     "PERF401",
     # Use `list` or `list.copy` to create a copy of a list
     "PERF402",
-    ]
+]
 
 [tool.ruff.lint.pycodestyle]
 # Ignore long comments for TODO, FIXME, XXX
@@ -519,7 +513,7 @@ skip = "pyproject.toml,poetry.lock,notebook/.*,uv.lock"
 count = false
 quiet-level = 3
 # the correct one is Amoeba, but we use pronunciation in Chinese to name it.
-ignore-words-list = ["ameba", "mke", "useable"]
+ignore-words-list = ["useable"]
 
 
 # ================== #


### PR DESCRIPTION
- Increased coverage threshold in `pyproject.toml` from 5 to 80.
- Reorganized `project.scripts` section for clarity.
- Updated `build-system` section to only require `hatchling`.
- Modified GitHub workflows to include `main` branch in triggers and removed commented-out SSH key setup.
- Enhanced artifact upload steps for both GitHub and Gitea in relevant workflows.