### PR TITLE
docs: sweep function docs to Google Style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ src/discordbot/
 │   ├── _gen_reply/
 │   │   └── prompts.py       # REPLY / ROUTE / SUMMARY / IMAGE / HISTORY prompts
 │   ├── help.py              # /help slash command (localized guide)
-│   ├── log_msg.py           # Message logging to SQLite (PostgreSQL ready)
+│   ├── log_msg.py           # Message logging to SQLite
 │   ├── maplestory.py        # /maple_* slash commands (8 commands)
 │   ├── _maplestory/
 │   │   ├── constants.py     # Display templates for stats
@@ -59,17 +59,17 @@ src/discordbot/
 │   └── video.py             # /download_video slash command
 ├── typings/                 # Pydantic configuration models
 │   ├── config.py            # DiscordConfig
-│   ├── database.py          # SQLite / PostgreSQL / Redis configs
 │   └── llm.py               # LLM endpoint config (OPENAI_BASE_URL / OPENAI_API_KEY)
 └── utils/
     ├── downloader.py        # yt-dlp video downloader wrapper
+    ├── images.py            # Image URL / data URI conversion helpers
+    ├── model_pricing.py     # LiteLLM model price cache and lookup helpers
     └── threads.py           # Threads.net content scraper
 
 scripts/
 ├── artale_data.py           # Scrape Artale MapleStory data from artalemaplestory.com
 ├── gen_docs.py              # Generate mkdocstrings reference pages
 ├── gpt.py                   # Azure GPT-5.4 sandbox comparing chat.completions vs responses API
-├── migrate.py               # Database migration helper (SQLite → PostgreSQL)
 ├── prompt_dev.py            # Prompt iteration / evaluation sandbox (OpenAI / Gemini / Anthropic SDK)
 ├── route_dev.py             # Route-classifier sandbox — client.responses.parse + Pydantic RouteDecision
 ├── test_fallback.py         # Sandbox for testing Litellm fallback behavior
@@ -189,7 +189,6 @@ uv run pytest -vv
 | ---------------------------------------- | --------------------------------------------------------------------- |
 | `uv run discordbot`                      | Run the bot                                                           |
 | `uv run python scripts/artale_data.py`   | Update MapleStory Artale data from `artalemaplestory.com`             |
-| `uv run python scripts/migrate.py`       | Migrate logged messages from SQLite to PostgreSQL                     |
 | `uv run python scripts/prompt_dev.py`    | Iterate prompts against OpenAI / Gemini / Anthropic SDKs              |
 | `uv run python scripts/gpt.py`           | Azure GPT-5.4 sandbox — compare chat.completions vs responses APIs    |
 | `uv run python scripts/route_dev.py`     | Route-classifier sandbox using `responses.parse` + Pydantic           |

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -170,7 +170,14 @@ class DocsGenerator(BaseModel):
     @computed_field
     @cached_property
     def source_files(self) -> list[Path]:
-        """The list of resolved source files to process."""
+        """The source files selected for documentation generation.
+
+        Returns:
+            Source files under `source_path`, excluding configured entries and
+            default skipped paths when `source_path` is a directory. Returns the
+            single source file when `source_path` is a file, or an empty list
+            when it is neither a valid file nor directory.
+        """
         if self.source_path.is_dir():
             if self.output_path.exists():
                 shutil.rmtree(self.output_path.absolute())

--- a/src/discordbot/__init__.py
+++ b/src/discordbot/__init__.py
@@ -17,12 +17,24 @@ class _TeeStream:
     """A stream that writes to both a console and a file, stripping ANSI codes for the file."""
 
     def __init__(self, console: TextIO, file: TextIO) -> None:
-        """Initialises the _TeeStream with console and file streams."""
+        """Initialises the stream wrapper.
+
+        Args:
+            console: Stream that receives the original data.
+            file: Stream that receives data with ANSI escape sequences removed.
+        """
         self._console = console
         self._file = file
 
     def write(self, data: str) -> int:
-        """Writes data to both streams."""
+        """Writes data to both streams and flushes them.
+
+        Args:
+            data: Text to write.
+
+        Returns:
+            The length of the original text.
+        """
         self._console.write(data)
         self._file.write(_ANSI_ESCAPE.sub(repl="", string=data))
         self._console.flush()
@@ -35,7 +47,11 @@ class _TeeStream:
         self._file.flush()
 
     def isatty(self) -> bool:
-        """Returns True if the console stream is a TTY."""
+        """Returns whether the console stream is attached to a TTY.
+
+        Returns:
+            True if the console stream reports that it is a TTY.
+        """
         return self._console.isatty()
 
 

--- a/src/discordbot/cli.py
+++ b/src/discordbot/cli.py
@@ -16,6 +16,13 @@ from discordbot.typings.config import DiscordConfig
 
 
 class DiscordBot(commands.Bot):
+    """Discord bot configured with project-specific intents and cogs.
+
+    Attributes:
+        discord_config: Runtime Discord configuration loaded from settings.
+        logger: Logger used by Nextcord state events.
+    """
+
     def __init__(self) -> None:
         """Initialises the Discord bot with specific intents and configuration."""
         # intents=Intents.default() 只啟用必要的 Intents
@@ -58,7 +65,12 @@ class DiscordBot(commands.Bot):
         return await super().on_guild_available(guild)
 
     async def get_cogs_names(self) -> list[str]:
-        """Returns a list of cog module names found in the cogs directory."""
+        """Returns cog module names found in the cogs directory.
+
+        Returns:
+            Fully-qualified module names for non-dunder Python files under the
+            cogs directory.
+        """
         cog_path = anyio.Path("./src/discordbot/cogs")
         cog_files = [
             f"discordbot.cogs.{f.stem}"

--- a/src/discordbot/cogs/_maplestory/embeds.py
+++ b/src/discordbot/cogs/_maplestory/embeds.py
@@ -35,7 +35,17 @@ SITE = "https://www.artalemaplestory.com"
 class TranslateFn(Protocol):
     """Protocol for translation functions."""
 
-    def __call__(self, category: str, name: str) -> str: ...
+    def __call__(self, category: str, name: str) -> str:
+        """Translates a MapleStory entity name for a category.
+
+        Args:
+            category: Translation category to look up.
+            name: Source name to translate.
+
+        Returns:
+            The translated name, or an implementation-defined fallback.
+        """
+        ...
 
 
 def _identity(category: str, name: str) -> str:

--- a/src/discordbot/cogs/_maplestory/models.py
+++ b/src/discordbot/cogs/_maplestory/models.py
@@ -19,42 +19,73 @@ class _Base(BaseModel):
 
 
 class RegionMaps(_Base):
-    """Represents maps within a region."""
+    """Represents maps within a region.
+
+    Attributes:
+        region: Region name.
+        maps: Map names in the region.
+    """
 
     region: str
     maps: list[str] = []
 
 
 class AcquisitionMonster(_Base):
-    """Represents a monster that an item can be acquired from."""
+    """Represents a monster that an item can be acquired from.
+
+    Attributes:
+        name: Monster name.
+        level: Monster level.
+    """
 
     name: str
     level: int = 0
 
 
 class AcquisitionNPC(_Base):
-    """Represents an NPC that an item can be acquired from."""
+    """Represents an NPC that an item can be acquired from.
+
+    Attributes:
+        name: NPC name.
+        price: Item price from the NPC.
+    """
 
     name: str
     price: int = 0
 
 
 class AcquisitionQuest(_Base):
-    """Represents a quest that an item can be acquired from."""
+    """Represents a quest that an item can be acquired from.
+
+    Attributes:
+        name: Quest name.
+        level: Quest level.
+    """
 
     name: str
     level: int = 0
 
 
 class CraftingMaterial(_Base):
-    """Represents a material required for crafting."""
+    """Represents a material required for crafting.
+
+    Attributes:
+        item: Material item name.
+        quantity: Required quantity.
+    """
 
     item: str = ""
     quantity: int = 0
 
 
 class CraftingRecipe(_Base):
-    """Represents a crafting recipe."""
+    """Represents a crafting recipe.
+
+    Attributes:
+        npc: NPC name associated with the recipe.
+        output: Crafted output name.
+        materials: Materials required by the recipe.
+    """
 
     npc: str = ""
     output: str = ""
@@ -62,7 +93,14 @@ class CraftingRecipe(_Base):
 
 
 class Acquisition(_Base):
-    """Represents all ways an item can be acquired."""
+    """Represents all ways an item can be acquired.
+
+    Attributes:
+        monsters: Monster acquisition entries.
+        npcs: NPC acquisition entries.
+        quests: Quest acquisition entries.
+        craftings: Crafting recipe entries.
+    """
 
     monsters: list[AcquisitionMonster] = []
     npcs: list[AcquisitionNPC] = []
@@ -74,7 +112,13 @@ class Acquisition(_Base):
 
 
 class DefenseStats(_Base):
-    """Represents monster defense statistics."""
+    """Represents monster defense statistics.
+
+    Attributes:
+        weapon: Weapon defense value.
+        magic: Magic defense value.
+        avoidability: Avoidability value.
+    """
 
     weapon: int = 0
     magic: int = 0
@@ -82,14 +126,26 @@ class DefenseStats(_Base):
 
 
 class AccuracyStats(_Base):
-    """Represents monster accuracy statistics."""
+    """Represents monster accuracy statistics.
+
+    Attributes:
+        required: Required accuracy value.
+        decrease: Accuracy decrease value.
+    """
 
     required: int = 0
     decrease: float = 0
 
 
 class DropItem(_Base):
-    """Represents an item dropped by a monster."""
+    """Represents an item dropped by a monster.
+
+    Attributes:
+        name: Dropped item name.
+        level: Dropped item level.
+        type: Dropped item type.
+        jobs: Jobs associated with the dropped item.
+    """
 
     name: str
     level: int = 0
@@ -98,7 +154,15 @@ class DropItem(_Base):
 
 
 class MonsterDrops(_Base):
-    """Represents all drops for a monster."""
+    """Represents all drops for a monster.
+
+    Attributes:
+        equipment_items: Equipment items dropped by the monster.
+        useable_items: Useable items dropped by the monster.
+        scrolls: Scrolls dropped by the monster.
+        misc_items: Miscellaneous items dropped by the monster.
+        meso_range: Meso range dropped by the monster.
+    """
 
     equipment_items: list[DropItem] = Field(default_factory=list, alias="equipmentItems")
     useable_items: list[DropItem] = Field(default_factory=list, alias="useableItems")
@@ -108,19 +172,43 @@ class MonsterDrops(_Base):
 
     @property
     def all_items(self) -> list[DropItem]:
-        """The list of all drop items."""
+        """Returns all non-meso drop items.
+
+        Returns:
+            Equipment, useable, scroll, and miscellaneous drop items.
+        """
         return self.equipment_items + self.useable_items + self.scrolls + self.misc_items
 
 
 class MonsterQuest(_Base):
-    """Represents a quest associated with a monster."""
+    """Represents a quest associated with a monster.
+
+    Attributes:
+        name: Quest name.
+        level: Quest level.
+    """
 
     name: str
     level: int = 0
 
 
 class Monster(_Base):
-    """Represents a MapleStory monster."""
+    """Represents a MapleStory monster.
+
+    Attributes:
+        name: Monster name.
+        name_zh: Chinese monster name.
+        level: Monster level.
+        hp: Monster HP.
+        mp: Monster MP.
+        exp: Monster EXP.
+        def_stats: Monster defense statistics.
+        accuracy: Monster accuracy statistics.
+        modifiers: Monster modifier names.
+        region_to_maps_list: Regions and maps where the monster appears.
+        drops: Monster drop data.
+        quests: Quests associated with the monster.
+    """
 
     name: str
     name_zh: str = Field(default="", alias="nameZh")
@@ -137,12 +225,20 @@ class Monster(_Base):
 
     @property
     def display_name(self) -> str:
-        """The display name of the monster."""
+        """Returns the monster display name.
+
+        Returns:
+            The Chinese name when present, otherwise the source name.
+        """
         return self.name_zh or self.name
 
     @property
     def all_maps(self) -> list[str]:
-        """The list of all maps the monster appears in."""
+        """Returns every map where the monster appears.
+
+        Returns:
+            Map names flattened from all region entries.
+        """
         return [m for r in self.region_to_maps_list for m in r.maps]
 
 
@@ -150,14 +246,38 @@ class Monster(_Base):
 
 
 class StatValue(_Base):
-    """Represents a stat value with a middle value and a range."""
+    """Represents a stat value with a middle value and a range.
+
+    Attributes:
+        middle: Middle stat value.
+        range: Stat value range.
+    """
 
     middle: int = 0
     range: list[int] = Field(default_factory=list)
 
 
 class EquipmentStats(_Base):
-    """Represents equipment statistics."""
+    """Represents equipment statistics.
+
+    Attributes:
+        str_stat: STR stat value.
+        dex: DEX stat value.
+        int_stat: INT stat value.
+        luk: LUK stat value.
+        hp: HP stat value.
+        mp: MP stat value.
+        atk: Attack stat value.
+        matk: Magic attack stat value.
+        def_stat: Defense stat value.
+        mdef: Magic defense stat value.
+        accuracy: Accuracy stat value.
+        avoidability: Avoidability stat value.
+        speed: Speed stat value.
+        jump: Jump stat value.
+        attack_speed: Attack speed value.
+        upgrade_slots: Upgrade slot count.
+    """
 
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
@@ -204,7 +324,14 @@ class EquipmentStats(_Base):
 
 
 class EquipmentRestriction(_Base):
-    """Represents equipment requirements."""
+    """Represents equipment requirements.
+
+    Attributes:
+        str_req: STR requirement.
+        dex: DEX requirement.
+        int_req: INT requirement.
+        luk: LUK requirement.
+    """
 
     str_req: int = Field(default=0, alias="str")
     dex: int = 0
@@ -221,7 +348,23 @@ class EquipmentRestriction(_Base):
 
 
 class Equipment(_Base):
-    """Represents a MapleStory equipment item."""
+    """Represents a MapleStory equipment item.
+
+    Attributes:
+        type: Equipment type.
+        name: Equipment name.
+        name_zh: Chinese equipment name.
+        level: Equipment level.
+        equipment_restriction: Equipment stat requirements.
+        stats: Equipment stat values.
+        jobs: Jobs associated with the equipment.
+        attack_speed: Attack speed label.
+        acquisition: Acquisition data for the equipment.
+        tradeable: Tradeability label.
+        event: Whether the equipment is marked as an event item.
+        limited_time: Whether the equipment is marked as limited time.
+        unavailable: Whether the equipment is marked as unavailable.
+    """
 
     type: str = ""
     name: str
@@ -241,7 +384,11 @@ class Equipment(_Base):
 
     @property
     def display_name(self) -> str:
-        """The display name of the equipment."""
+        """Returns the equipment display name.
+
+        Returns:
+            The Chinese name when present, otherwise the source name.
+        """
         return self.name_zh or self.name
 
 
@@ -249,7 +396,15 @@ class Equipment(_Base):
 
 
 class Scroll(_Base):
-    """Represents a MapleStory scroll."""
+    """Represents a MapleStory scroll.
+
+    Attributes:
+        name: Scroll name.
+        name_zh: Chinese scroll name.
+        stats: Stat bonuses keyed by stat name.
+        type: Scroll type.
+        acquisition: Acquisition data for the scroll.
+    """
 
     name: str
     name_zh: str = Field(default="", alias="nameZh")
@@ -259,7 +414,11 @@ class Scroll(_Base):
 
     @property
     def display_name(self) -> str:
-        """The display name of the scroll."""
+        """Returns the scroll display name.
+
+        Returns:
+            The Chinese name when present, otherwise the source name.
+        """
         return self.name_zh or self.name
 
 
@@ -267,13 +426,35 @@ class Scroll(_Base):
 
 
 class UseableStat(_Base):
-    """Represents a stat value for useable items."""
+    """Represents a stat value for useable items.
+
+    Attributes:
+        amount: Amount applied by the useable item stat.
+    """
 
     amount: int = 0
 
 
 class Useable(_Base):
-    """Represents a MapleStory useable item (e.g., potion)."""
+    """Represents a MapleStory useable item.
+
+    Attributes:
+        name: Useable item name.
+        name_zh: Chinese useable item name.
+        type: Useable item type.
+        description: Description data for the useable item.
+        acquisition: Acquisition data for the useable item.
+        hp: HP stat data.
+        mp: MP stat data.
+        atk: Attack stat data.
+        matk: Magic attack stat data.
+        def_stat: Defense stat data.
+        mdef: Magic defense stat data.
+        accuracy: Accuracy stat data.
+        avoidability: Avoidability stat data.
+        speed: Speed stat data.
+        jump: Jump stat data.
+    """
 
     name: str
     name_zh: str = Field(default="", alias="nameZh")
@@ -293,7 +474,11 @@ class Useable(_Base):
 
     @property
     def display_name(self) -> str:
-        """The display name of the useable item."""
+        """Returns the useable item display name.
+
+        Returns:
+            The Chinese name when present, otherwise the source name.
+        """
         return self.name_zh or self.name
 
 
@@ -301,14 +486,32 @@ class Useable(_Base):
 
 
 class NPCItem(_Base):
-    """Represents an item sold by an NPC."""
+    """Represents an item sold by an NPC.
+
+    Attributes:
+        name: Sold item name.
+        price: Sold item price.
+    """
 
     name: str
     price: int = 0
 
 
 class NPC(_Base):
-    """Represents a MapleStory NPC."""
+    """Represents a MapleStory NPC.
+
+    Attributes:
+        name: NPC name.
+        name_zh: Chinese NPC name.
+        type: NPC type.
+        region_to_maps_list: Regions and maps where the NPC appears.
+        equipment_items: Equipment items sold by the NPC.
+        useable_items: Useable items sold by the NPC.
+        scrolls: Scrolls sold by the NPC.
+        misc_items: Miscellaneous items sold by the NPC.
+        quests: Quests associated with the NPC.
+        recipes: Crafting recipes associated with the NPC.
+    """
 
     name: str
     name_zh: str = Field(default="", alias="nameZh")
@@ -323,12 +526,20 @@ class NPC(_Base):
 
     @property
     def display_name(self) -> str:
-        """The display name of the NPC."""
+        """Returns the NPC display name.
+
+        Returns:
+            The Chinese name when present, otherwise the source name.
+        """
         return self.name_zh or self.name
 
     @property
     def all_maps(self) -> list[str]:
-        """The list of all maps the NPC appears in."""
+        """Returns every map where the NPC appears.
+
+        Returns:
+            Map names flattened from all region entries.
+        """
         return [m for r in self.region_to_maps_list for m in r.maps]
 
 
@@ -336,21 +547,38 @@ class NPC(_Base):
 
 
 class HuntTarget(_Base):
-    """Represents a target to hunt for a quest."""
+    """Represents a target to hunt for a quest.
+
+    Attributes:
+        name: Hunt target name.
+        quantity: Required hunt quantity.
+    """
 
     name: str
     quantity: int = 0
 
 
 class CollectItem(_Base):
-    """Represents an item to collect for a quest."""
+    """Represents an item to collect for a quest.
+
+    Attributes:
+        name: Collected item name.
+        quantity: Required collection quantity.
+    """
 
     name: str = ""
     quantity: int = 0
 
 
 class QuestReward(_Base):
-    """Represents rewards for a quest."""
+    """Represents rewards for a quest.
+
+    Attributes:
+        exp: Reward EXP.
+        fame: Reward fame.
+        mesos: Reward mesos.
+        items: Reward item data.
+    """
 
     exp: int = 0
     fame: int = 0
@@ -359,7 +587,14 @@ class QuestReward(_Base):
 
 
 class QuestStep(_Base):
-    """Represents a step in a quest."""
+    """Represents a step in a quest.
+
+    Attributes:
+        start_npc: NPC that starts the quest step.
+        monsters_to_hunt: Monsters required by the quest step.
+        items_to_collect: Items required by the quest step.
+        reward: Reward data for the quest step.
+    """
 
     start_npc: str = Field(default="", alias="startNPC")
     monsters_to_hunt: list[HuntTarget] = Field(default_factory=list, alias="monstersToHunt")
@@ -370,7 +605,18 @@ class QuestStep(_Base):
 
 
 class Quest(_Base):
-    """Represents a MapleStory quest."""
+    """Represents a MapleStory quest.
+
+    Attributes:
+        name: Quest name.
+        name_zh: Chinese quest name.
+        frequency: Quest frequency label.
+        lv_lower: Lower level bound.
+        lv_upper: Upper level bound.
+        steps: Quest steps.
+        boss: Whether the quest is marked as a boss quest.
+        prerequisites: Prerequisite quest names.
+    """
 
     name: str
     name_zh: str = Field(default="", alias="nameZh")
@@ -383,7 +629,11 @@ class Quest(_Base):
 
     @property
     def display_name(self) -> str:
-        """The display name of the quest."""
+        """Returns the quest display name.
+
+        Returns:
+            The Chinese name when present, otherwise the source name.
+        """
         return self.name_zh or self.name
 
 
@@ -391,7 +641,13 @@ class Quest(_Base):
 
 
 class MapNPC(_Base):
-    """Represents an NPC on a map."""
+    """Represents an NPC on a map.
+
+    Attributes:
+        name: NPC name.
+        type: NPC type.
+        sub_map: Sub-map name.
+    """
 
     name: str
     type: str = ""
@@ -399,14 +655,33 @@ class MapNPC(_Base):
 
 
 class MapMonster(_Base):
-    """Represents a monster on a map."""
+    """Represents a monster on a map.
+
+    Attributes:
+        name: Monster name.
+        level: Monster level.
+    """
 
     name: str
     level: int = 0
 
 
 class MapEntry(_Base):
-    """Represents a MapleStory map."""
+    """Represents a MapleStory map.
+
+    Attributes:
+        region: Map region name.
+        name: Map name.
+        name_zh: Chinese map name.
+        x: Map x-coordinate.
+        y: Map y-coordinate.
+        npcs: NPCs on the map.
+        monsters: Monsters on the map.
+        hidden: Whether the map is hidden.
+        from_map: Source map name.
+        to_map: Destination map name.
+        to_region: Destination region name.
+    """
 
     region: str = ""
     name: str
@@ -422,7 +697,11 @@ class MapEntry(_Base):
 
     @property
     def display_name(self) -> str:
-        """The display name of the map."""
+        """Returns the map display name.
+
+        Returns:
+            The Chinese name when present, otherwise the source name.
+        """
         return self.name_zh or self.name
 
 
@@ -430,7 +709,14 @@ class MapEntry(_Base):
 
 
 class MiscItem(_Base):
-    """Represents a miscellaneous item."""
+    """Represents a miscellaneous item.
+
+    Attributes:
+        name: Miscellaneous item name.
+        name_zh: Chinese miscellaneous item name.
+        type: Miscellaneous item type.
+        acquisition: Acquisition data for the miscellaneous item.
+    """
 
     name: str
     name_zh: str = Field(default="", alias="nameZh")
@@ -439,7 +725,11 @@ class MiscItem(_Base):
 
     @property
     def display_name(self) -> str:
-        """The display name of the misc item."""
+        """Returns the miscellaneous item display name.
+
+        Returns:
+            The Chinese name when present, otherwise the source name.
+        """
         return self.name_zh or self.name
 
 
@@ -447,7 +737,20 @@ class MiscItem(_Base):
 
 
 class MapleStats(BaseModel):
-    """Represents database statistics."""
+    """Represents database statistics.
+
+    Attributes:
+        total_monsters: Total monster count.
+        total_equipment: Total equipment count.
+        total_scrolls: Total scroll count.
+        total_useable: Total useable item count.
+        total_npcs: Total NPC count.
+        total_quests: Total quest count.
+        total_maps: Total map count.
+        total_misc: Total miscellaneous item count.
+        level_distribution: Monster counts keyed by level range.
+        popular_items: Popular item names.
+    """
 
     total_monsters: int
     total_equipment: int

--- a/src/discordbot/cogs/_maplestory/service.py
+++ b/src/discordbot/cogs/_maplestory/service.py
@@ -95,6 +95,7 @@ class MapleStoryService:
         return cls.from_directory(file_path.parent)
 
     def _load_all(self, data_dir: Path) -> None:
+        """Loads all MapleStory JSON data and resets derived caches."""
         self._monsters = _load_json(path=data_dir / "monsters.json", model=Monster)
         self._equipment = _load_json(path=data_dir / "equipment.json", model=Equipment)
         self._scrolls = _load_json(path=data_dir / "scrolls.json", model=Scroll)
@@ -145,42 +146,74 @@ class MapleStoryService:
 
     @property
     def monsters(self) -> list[Monster]:
-        """The list of loaded monsters."""
+        """Returns the loaded monsters.
+
+        Returns:
+            The loaded monster models.
+        """
         return self._monsters
 
     @property
     def equipment(self) -> list[Equipment]:
-        """The list of loaded equipment."""
+        """Returns the loaded equipment.
+
+        Returns:
+            The loaded equipment models.
+        """
         return self._equipment
 
     @property
     def scrolls(self) -> list[Scroll]:
-        """The list of loaded scrolls."""
+        """Returns the loaded scrolls.
+
+        Returns:
+            The loaded scroll models.
+        """
         return self._scrolls
 
     @property
     def useable(self) -> list[Useable]:
-        """The list of loaded useable items."""
+        """Returns the loaded useable items.
+
+        Returns:
+            The loaded useable item models.
+        """
         return self._useable
 
     @property
     def npcs(self) -> list[NPC]:
-        """The list of loaded NPCs."""
+        """Returns the loaded NPCs.
+
+        Returns:
+            The loaded NPC models.
+        """
         return self._npcs
 
     @property
     def quests(self) -> list[Quest]:
-        """The list of loaded quests."""
+        """Returns the loaded quests.
+
+        Returns:
+            The loaded quest models.
+        """
         return self._quests
 
     @property
     def maps(self) -> list[MapEntry]:
-        """The list of loaded maps."""
+        """Returns the loaded maps.
+
+        Returns:
+            The loaded map models.
+        """
         return self._maps
 
     @property
     def misc(self) -> list[MiscItem]:
-        """The list of loaded misc items."""
+        """Returns the loaded misc items.
+
+        Returns:
+            The loaded miscellaneous item models.
+        """
         return self._misc
 
     # ── Monster searches ────────────────────────────────────────────

--- a/src/discordbot/cogs/_maplestory/views.py
+++ b/src/discordbot/cogs/_maplestory/views.py
@@ -76,7 +76,18 @@ def _resolve_map(service: MapleStoryService, name: str, tr: TranslateFn) -> Embe
 class _ResolverFn(Protocol):
     """Protocol for resolver functions."""
 
-    def __call__(self, service: MapleStoryService, name: str, tr: TranslateFn) -> Embed | None: ...
+    def __call__(self, service: MapleStoryService, name: str, tr: TranslateFn) -> Embed | None:
+        """Resolves a search result name into a Discord embed.
+
+        Args:
+            service: Service used to look up MapleStory data.
+            name: Selected result name to resolve.
+            tr: Translation function passed to embed builders.
+
+        Returns:
+            The embed for the selected result, or None when no match is found.
+        """
+        ...
 
 
 _RESOLVERS: dict[str, _ResolverFn] = {
@@ -121,7 +132,12 @@ class MapleDropSearchView(View):
         options=[SelectOption(label="載入中...", value="loading")],
     )
     async def select_result(self, select: Select, interaction: Interaction) -> None:
-        """Handles the selection of a search result."""
+        """Handles the selection of a search result.
+
+        Args:
+            select: Select menu that contains the chosen result value.
+            interaction: Discord interaction that triggered the callback.
+        """
         await interaction.response.defer()
 
         selected = select.values[0]

--- a/src/discordbot/cogs/gen_reply.py
+++ b/src/discordbot/cogs/gen_reply.py
@@ -100,10 +100,23 @@ def get_tools(model: str) -> list[ToolParam]:
 
 
 class RouteDecision(BaseModel):
+    """Structured routing decision returned by the model.
+
+    Attributes:
+        decision: The reply mode selected for the incoming Discord message.
+    """
+
     decision: Literal["IMAGE", "VIDEO", "QA", "SUMMARY"]
 
 
 class ReplyGeneratorCogs(commands.Cog):
+    """Generates AI replies for Discord messages.
+
+    Attributes:
+        bot: The Discord bot instance that owns this cog.
+        config: The LLM client configuration loaded for reply generation.
+    """
+
     def __init__(self, bot: commands.Bot) -> None:
         """Initializes the ReplyGeneratorCogs instance.
 
@@ -115,7 +128,11 @@ class ReplyGeneratorCogs(commands.Cog):
 
     @cached_property
     def client(self) -> AsyncOpenAI:
-        """The cached AsyncOpenAI client instance."""
+        """The cached AsyncOpenAI client instance.
+
+        Returns:
+            A configured AsyncOpenAI client reused across reply requests.
+        """
         client = AsyncOpenAI(base_url=self.config.base_url, api_key=self.config.api_key)
         return client
 

--- a/src/discordbot/cogs/help.py
+++ b/src/discordbot/cogs/help.py
@@ -100,6 +100,12 @@ _SECTIONS = ("ai_chat", "threads", "video", "maplestory", "ping")
 
 
 class HelpCogs(commands.Cog):
+    """Provides the localized help slash command.
+
+    Attributes:
+        bot: The Discord bot instance that owns this cog.
+    """
+
     def __init__(self, bot: commands.Bot):
         """Initializes the HelpCogs instance.
 

--- a/src/discordbot/cogs/log_msg.py
+++ b/src/discordbot/cogs/log_msg.py
@@ -17,6 +17,12 @@ _sql_engine: Engine = create_engine(url="sqlite:///data/messages.db")
 
 
 class MessageLogger(BaseModel):
+    """Persists a Discord message and its metadata to SQLite.
+
+    Attributes:
+        message: The Discord message being logged.
+    """
+
     model_config = ConfigDict(arbitrary_types_allowed=True)
     message: Message
 
@@ -37,7 +43,12 @@ class MessageLogger(BaseModel):
     @computed_field
     @property
     def table_name(self) -> str:
-        """The database table name for this message."""
+        """The database table name for this message.
+
+        Returns:
+            A DM-specific table name for direct messages, otherwise a
+            channel-specific table name.
+        """
         if isinstance(self.message.channel, DMChannel):
             return f"DM_{self.message.author.id}"
         return f"channel_{self.message.channel.id}"
@@ -45,7 +56,12 @@ class MessageLogger(BaseModel):
     @computed_field
     @property
     def channel_name_or_author_name(self) -> str:
-        """The channel name or author name for DM."""
+        """The channel name or DM author label for this message.
+
+        Returns:
+            A label containing the DM author display name and ID for direct
+            messages, otherwise the channel name and ID.
+        """
         if isinstance(self.message.channel, DMChannel):
             author_name = self.message.author.display_name
             return f"DM_{author_name}_{self.message.author.id}"
@@ -54,7 +70,11 @@ class MessageLogger(BaseModel):
     @computed_field
     @property
     def channel_id_or_author_id(self) -> str:
-        """The channel ID or author ID for DM."""
+        """The channel ID or DM author ID for this message.
+
+        Returns:
+            The author ID for direct messages, otherwise the channel ID.
+        """
         if isinstance(self.message.channel, DMChannel):
             return f"{self.message.author.id}"
         return f"{self.message.channel.id}"
@@ -109,6 +129,12 @@ class MessageLogger(BaseModel):
 
 
 class LogMessageCog(commands.Cog):
+    """Logs Discord messages and completed command messages.
+
+    Attributes:
+        bot: The Discord bot instance that owns this cog.
+    """
+
     def __init__(self, bot: commands.Bot) -> None:
         """Initializes the LogMessageCog instance.
 

--- a/src/discordbot/cogs/parse_threads.py
+++ b/src/discordbot/cogs/parse_threads.py
@@ -12,6 +12,14 @@ URL_REGEX = re.compile(r"https?://(?:www\.)?threads\.(?:net|com)/@[^/]+/post/[^\
 
 
 class ThreadsCogs(commands.Cog):
+    """Expands Threads links into Discord embeds and media attachments.
+
+    Attributes:
+        bot: The Discord bot instance that owns this cog.
+        output_folder: Directory where downloaded Threads media is stored.
+        downloader: Downloader used to parse Threads posts and fetch media.
+    """
+
     def __init__(self, bot: commands.Bot):
         """Initializes the ThreadsCogs instance.
 

--- a/src/discordbot/cogs/template.py
+++ b/src/discordbot/cogs/template.py
@@ -4,6 +4,12 @@ from nextcord.ext import commands
 
 
 class TemplateCogs(commands.Cog):
+    """Provides simple message reactions and the ping slash command.
+
+    Attributes:
+        bot: The Discord bot instance that owns this cog.
+    """
+
     def __init__(self, bot: commands.Bot):
         """Initializes the TemplateCogs instance.
 

--- a/src/discordbot/cogs/video.py
+++ b/src/discordbot/cogs/video.py
@@ -6,6 +6,12 @@ from discordbot.utils.downloader import VideoDownloader
 
 
 class VideoCogs(commands.Cog):
+    """Downloads videos from slash command requests.
+
+    Attributes:
+        bot: The Discord bot instance that owns this cog.
+    """
+
     def __init__(self, bot: commands.Bot):
         """Initializes the VideoCogs instance.
 

--- a/src/discordbot/utils/downloader.py
+++ b/src/discordbot/utils/downloader.py
@@ -14,6 +14,13 @@ console = get_console()
 
 
 class DownloadResult(BaseModel):
+    """Represents a downloaded video file.
+
+    Attributes:
+        title: Video title reported by yt-dlp.
+        filename: Local path of the downloaded file.
+    """
+
     title: str
     filename: Path
 
@@ -22,7 +29,11 @@ class DownloadResult(BaseModel):
         self.filename.unlink(missing_ok=True)
 
     def __enter__(self):
-        """Enter the context manager."""
+        """Enters the context manager.
+
+        Returns:
+            This download result.
+        """
         return self
 
     def __exit__(
@@ -31,11 +42,25 @@ class DownloadResult(BaseModel):
         exc_val: BaseException | None,
         exc_tb: types.TracebackType | None,
     ):
-        """Exit the context manager and cleanup."""
+        """Exits the context manager and deletes the downloaded file.
+
+        Args:
+            exc_type: Exception type raised inside the context, if any.
+            exc_val: Exception value raised inside the context, if any.
+            exc_tb: Traceback raised inside the context, if any.
+        """
         self.unlink()
 
 
 class VideoDownloader(BaseModel):
+    """Downloads videos with yt-dlp and local project defaults.
+
+    Attributes:
+        output_folder: Directory where downloaded files are written.
+        max_retries: Configured maximum retry count.
+        share_resolve_timeout: Timeout in seconds for resolving Facebook share URLs.
+    """
+
     output_folder: str = Field(default="./data/downloads", description="Download folder")
     max_retries: int = Field(default=5)
     share_resolve_timeout: int = Field(
@@ -45,7 +70,11 @@ class VideoDownloader(BaseModel):
     @computed_field
     @cached_property
     def quality_formats(self) -> dict[str, str]:
-        """The map of quality presets to yt-dlp format strings."""
+        """The map of quality presets to yt-dlp format strings.
+
+        Returns:
+            Preset names mapped to yt-dlp format selectors.
+        """
         quality_formats = {
             # Prefer separate video+audio with safe fallbacks to muxed or video-only streams
             "best": "bestvideo*+bestaudio/best/bestvideo*",

--- a/src/discordbot/utils/images.py
+++ b/src/discordbot/utils/images.py
@@ -40,9 +40,17 @@ def get_pil_image(image_file: str) -> Image.Image:
 
 
 @overload
-def get_image_data(image_file: str, use_b64: Literal[True] = ...) -> str: ...
+def get_image_data(image_file: str, use_b64: Literal[True] = ...) -> str:  # noqa: D418
+    """Returns image data as a base64 string."""
+    ...
+
+
 @overload
-def get_image_data(image_file: str, use_b64: Literal[False]) -> bytes: ...
+def get_image_data(image_file: str, use_b64: Literal[False]) -> bytes:  # noqa: D418
+    """Returns image data as raw bytes."""
+    ...
+
+
 def get_image_data(image_file: str, use_b64: bool = True) -> bytes | str:
     """Returns the underlying bytes of an image (or base64-encoded form).
 
@@ -57,6 +65,13 @@ def get_image_data(image_file: str, use_b64: bool = True) -> bytes | str:
         image_file: URL or data URI.
         use_b64: When ``True`` (default) return a base64 ``str``; when ``False``
             return raw ``bytes``.
+
+    Returns:
+        Base64-encoded image data when ``use_b64`` is True, otherwise raw image
+        bytes.
+
+    Raises:
+        ValueError: ``image_file`` is not a supported URL or image data URI.
     """
     if match := _DATA_URI_RE.match(string=image_file):
         payload = image_file[match.end() :]
@@ -76,6 +91,12 @@ def convert_base64_to_data_uri(base64_image: str) -> str:
 
     Sniffs the MIME type from the first 12 decoded bytes (enough for every
     format we recognise). Falls back to ``image/jpeg`` for unknown payloads.
+
+    Args:
+        base64_image: Base64-encoded image payload without a data URI prefix.
+
+    Returns:
+        A data URI containing the detected image MIME type and original payload.
     """
     header = base64.b64decode(s=base64_image[:16])
     if header.startswith(b"\xff\xd8\xff"):

--- a/src/discordbot/utils/model_pricing.py
+++ b/src/discordbot/utils/model_pricing.py
@@ -70,6 +70,12 @@ def get_token_rates(model_name: str) -> tuple[float, float]:
     Prefers the priority-tier rates when present (e.g. Gemini's burst pricing
     via the ``*_priority`` suffix). Returns ``(0.0, 0.0)`` for unknown models
     so the reply footer shows ``$0.00000000`` instead of an estimate.
+
+    Args:
+        model_name: Model identifier to look up in the cached price table.
+
+    Returns:
+        Input and output token rates for the model.
     """
     info = _load_model_prices().get(model_name) or {}
     default_input = info.get("input_cost_per_token", 0)

--- a/src/discordbot/utils/threads.py
+++ b/src/discordbot/utils/threads.py
@@ -19,14 +19,23 @@ console = get_console()
 
 
 class ThreadsURL(BaseModel):
-    """Parses and normalises a Threads post URL."""
+    """Parses and normalises a Threads post URL.
+
+    Attributes:
+        raw_url: Original Threads URL provided by the caller.
+    """
 
     raw_url: str
 
     @computed_field
     @cached_property
     def clean_url(self) -> str:
-        """The cleaned and normalised URL."""
+        """The cleaned and normalised URL.
+
+        Returns:
+            URL with ``threads.com`` hosts normalised to ``www.threads.net`` and
+            query parameters removed.
+        """
         parsed = urlparse(self.raw_url)
         netloc = parsed.netloc
         if netloc in ("www.threads.com", "threads.com"):
@@ -36,7 +45,12 @@ class ThreadsURL(BaseModel):
     @computed_field
     @cached_property
     def post_code(self) -> str:
-        """The post short code extracted from the URL."""
+        """The post short code extracted from the URL.
+
+        Returns:
+            The last path segment from the raw URL, or an empty string for an
+            empty path.
+        """
         parsed = urlparse(self.raw_url)
         path_parts = parsed.path.strip("/").split("/")
         return path_parts[-1] if path_parts else ""
@@ -48,29 +62,67 @@ class ThreadsURL(BaseModel):
 
 
 class User(BaseModel):
+    """Represents a Threads user.
+
+    Attributes:
+        username: User handle.
+        profile_pic_url: Profile picture URL.
+    """
+
     username: str = Field(default="", description="Username handle")
     profile_pic_url: str = Field(default="", description="Profile picture URL")
 
 
 class Caption(BaseModel):
+    """Represents caption text attached to a Threads post.
+
+    Attributes:
+        text: Caption text content.
+    """
+
     text: str = Field(default="", description="Caption text content")
 
 
 class VideoVersion(BaseModel):
+    """Represents an available video rendition.
+
+    Attributes:
+        url: Video file URL.
+    """
+
     url: str = Field(default="", description="Video file URL")
 
 
 class ImageCandidate(BaseModel):
+    """Represents an available image rendition.
+
+    Attributes:
+        url: Image URL.
+    """
+
     url: str = Field(default="", description="Image URL")
 
 
 class ImageVersions2(BaseModel):
+    """Holds available image renditions for a media object.
+
+    Attributes:
+        candidates: Available image resolutions.
+    """
+
     candidates: list[ImageCandidate] = Field(
         default_factory=list, description="Available image resolutions"
     )
 
 
 class CarouselMedia(BaseModel):
+    """Represents one media item in a Threads carousel.
+
+    Attributes:
+        video_versions: Available video renditions.
+        image_versions2: Available image renditions.
+    """
+
     video_versions: list[VideoVersion] | None = Field(
         default=None, description="Available video versions"
     )
@@ -80,6 +132,14 @@ class CarouselMedia(BaseModel):
 
 
 class MediaContainer(BaseModel):
+    """Contains media fields shared by posts and linked inline media.
+
+    Attributes:
+        carousel_media: Carousel media items.
+        video_versions: Available video renditions.
+        image_versions2: Available image renditions.
+    """
+
     carousel_media: list[CarouselMedia] | None = Field(
         default=None, description="Carousel media items"
     )
@@ -92,7 +152,12 @@ class MediaContainer(BaseModel):
 
     @property
     def media_urls(self) -> list[str]:
-        """The list of media URLs extracted from the container."""
+        """The list of media URLs extracted from the container.
+
+        Returns:
+            First media URL from each carousel item, or the first standalone
+            video or image URL, with empty values removed.
+        """
         urls: list[str] = []
         if self.carousel_media:
             for item in self.carousel_media:
@@ -108,27 +173,66 @@ class MediaContainer(BaseModel):
 
 
 class Fragment(BaseModel):
+    """Represents one text fragment from Threads structured text.
+
+    Attributes:
+        plaintext: Plain text content of the fragment.
+    """
+
     plaintext: str = Field(default="", description="Plain text content of the fragment")
 
 
 class TextFragments(BaseModel):
+    """Holds ordered structured text fragments.
+
+    Attributes:
+        fragments: Ordered list of text fragments.
+    """
+
     fragments: list[Fragment] = Field(
         default_factory=list, description="Ordered list of text fragments"
     )
 
 
 class LinkPreviewAttachment(BaseModel):
+    """Represents metadata for a link preview attachment.
+
+    Attributes:
+        title: Title shown in the link preview.
+        image_url: Image shown in the link preview.
+        url: Original link preview URL.
+    """
+
     title: str = Field(default="", description="Title shown in the link preview")
     image_url: str = Field(default="", description="Image shown in the link preview")
     url: str = Field(default="", description="Original link preview URL")
 
 
 class LinkedInlineMedia(MediaContainer):
+    """Represents media attached through a link preview.
+
+    Attributes:
+        code: Linked media short code.
+        caption: Linked media caption.
+    """
+
     code: str = Field(default="", description="Linked media short code")
     caption: Caption | None = Field(default=None, description="Linked media caption")
 
 
 class TextPostAppInfo(BaseModel):
+    """Represents Threads-specific post metadata and engagement fields.
+
+    Attributes:
+        direct_reply_count: Number of direct replies.
+        repost_count: Number of reposts.
+        quote_count: Number of quote posts.
+        reshare_count: Total reshare count.
+        text_fragments: Structured text fragments with links or mentions.
+        link_preview_attachment: Preview metadata for shared links.
+        linked_inline_media: Inline media attached through a link preview.
+    """
+
     direct_reply_count: int | None = Field(default=None, description="Number of direct replies")
     repost_count: int | None = Field(default=None, description="Number of reposts")
     quote_count: int | None = Field(default=None, description="Number of quote posts")
@@ -145,7 +249,16 @@ class TextPostAppInfo(BaseModel):
 
 
 class Post(MediaContainer):
-    """Represents a single Threads post parsed from the API JSON."""
+    """Represents a single Threads post parsed from the API JSON.
+
+    Attributes:
+        code: Post short code used in URLs.
+        caption: Post caption.
+        user: Post author.
+        text_post_app_info: Threads-specific post info and engagement metrics.
+        like_count: Number of likes.
+        taken_at: Post creation timestamp as a Unix epoch.
+    """
 
     code: str = Field(default="", description="Post short code used in URLs")
     caption: Caption | None = Field(default=None, description="Post caption")
@@ -160,7 +273,12 @@ class Post(MediaContainer):
 
     @property
     def caption_text(self) -> str:
-        """The extracted caption text or fallback link preview title."""
+        """The extracted caption text or fallback link preview title.
+
+        Returns:
+            Structured text fragments, caption text, link preview title, or an
+            empty string in that priority order.
+        """
         if self.text_post_app_info and self.text_post_app_info.text_fragments:
             fragments_text = "".join(
                 f.plaintext for f in self.text_post_app_info.text_fragments.fragments
@@ -177,37 +295,67 @@ class Post(MediaContainer):
 
     @property
     def author_name(self) -> str:
-        """The username of the post author."""
+        """The username of the post author.
+
+        Returns:
+            Author username, or an empty string when author data is missing.
+        """
         return self.user.username if self.user else ""
 
     @property
     def author_icon_url(self) -> str:
-        """The profile picture URL of the post author."""
+        """The profile picture URL of the post author.
+
+        Returns:
+            Author profile picture URL, or an empty string when author data is
+            missing.
+        """
         return self.user.profile_pic_url if self.user else ""
 
     @property
     def reply_count(self) -> int:
-        """The number of direct replies to the post."""
+        """The number of direct replies to the post.
+
+        Returns:
+            Direct reply count, or 0 when engagement data is missing.
+        """
         return (self.text_post_app_info.direct_reply_count or 0) if self.text_post_app_info else 0
 
     @property
     def repost_count(self) -> int:
-        """The number of reposts."""
+        """The number of reposts.
+
+        Returns:
+            Repost count, or 0 when engagement data is missing.
+        """
         return (self.text_post_app_info.repost_count or 0) if self.text_post_app_info else 0
 
     @property
     def quote_count(self) -> int:
-        """The number of quote posts."""
+        """The number of quote posts.
+
+        Returns:
+            Quote post count, or 0 when engagement data is missing.
+        """
         return (self.text_post_app_info.quote_count or 0) if self.text_post_app_info else 0
 
     @property
     def reshare_count(self) -> int:
-        """The total reshare count."""
+        """The total reshare count.
+
+        Returns:
+            Reshare count, or 0 when engagement data is missing.
+        """
         return (self.text_post_app_info.reshare_count or 0) if self.text_post_app_info else 0
 
     @property
     def media_urls(self) -> list[str]:
-        """The list of media URLs, including linked inline media and link preview images."""
+        """The list of media URLs, including inline media and link preview images.
+
+        Returns:
+            Deduplicated non-empty media URLs from post media, linked inline
+            media, or the link preview image fallback.
+        """
         urls = super().media_urls
         app_info = self.text_post_app_info
         if app_info and app_info.linked_inline_media:
@@ -223,10 +371,22 @@ class Post(MediaContainer):
 
 
 class ThreadItem(BaseModel):
+    """Represents one item in a Threads reply chain.
+
+    Attributes:
+        post: Parsed post for this thread item.
+    """
+
     post: Post | None = Field(default=None)
 
 
 class ThreadData(BaseModel):
+    """Represents Threads reply-chain data extracted from HTML JSON.
+
+    Attributes:
+        thread_items: Ordered thread items from the embedded JSON.
+    """
+
     thread_items: list[ThreadItem] = Field(default_factory=list)
 
     def find_post_with_parents(self, post_code: str) -> tuple[Post | None, list[Post]]:
@@ -257,7 +417,24 @@ class ThreadData(BaseModel):
 
 
 class ThreadsOutput(BaseModel):
-    """Output model for Threads downloader."""
+    """Output model for Threads downloader.
+
+    Attributes:
+        text: Extracted post text.
+        url: Source Threads URL.
+        image_urls: Image URLs extracted from the post.
+        video_urls: Video URLs extracted from the post.
+        video_paths: Local paths of downloaded videos.
+        author_name: Post author username.
+        author_icon_url: Post author profile picture URL.
+        like_count: Number of likes.
+        reply_count: Number of direct replies.
+        repost_count: Number of reposts.
+        quote_count: Number of quote posts.
+        reshare_count: Total reshare count.
+        taken_at: Post creation time.
+        parents: Ancestor posts in the reply chain, ordered oldest to newest.
+    """
 
     text: str = Field(default="")
     url: str = Field(default="")
@@ -284,15 +461,27 @@ class ThreadsOutput(BaseModel):
         for parent in self.parents:
             parent.unlink()
 
-    def __enter__(self):  # noqa: D105
+    def __enter__(self):
+        """Enters the context manager.
+
+        Returns:
+            This output object.
+        """
         return self
 
-    def __exit__(  # noqa: D105
+    def __exit__(
         self,
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: types.TracebackType | None,
     ):
+        """Exits the context manager and deletes downloaded video files.
+
+        Args:
+            exc_type: Exception type raised inside the context, if any.
+            exc_val: Exception value raised inside the context, if any.
+            exc_tb: Traceback raised inside the context, if any.
+        """
         self.unlink()
 
 
@@ -306,7 +495,11 @@ _SJS_PATTERN = re.compile(
 
 
 class ThreadsDownloader(BaseModel):
-    """A downloader for extracting text and media from Threads.net posts."""
+    """A downloader for extracting text and media from Threads.net posts.
+
+    Attributes:
+        output_folder: Directory where downloaded media files are written.
+    """
 
     output_folder: str = Field(default="./data/threads")
 

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -7,18 +7,26 @@ from discordbot.cogs.gen_reply import ReplyGeneratorCogs
 
 
 class FakeReply:
+    """Provides a fake reply object that records edited content."""
+
     def __init__(self) -> None:
+        """Initializes the fake reply with empty content."""
         self.content = ""
 
     async def edit(self, *, content: str) -> None:
+        """Records the replacement content passed to edit."""
         self.content = content
 
 
 class FakeMessage:
+    """Provides a fake message object that records created replies."""
+
     def __init__(self) -> None:
+        """Initializes the fake message with no recorded replies."""
         self.replies: list[FakeReply] = []
 
     async def reply(self, *, content: str) -> FakeReply:
+        """Creates and records a fake reply with the requested content."""
         reply = FakeReply()
         reply.content = content
         self.replies.append(reply)


### PR DESCRIPTION
## Summary

- Add and update Google Style docstrings for Python classes, functions, methods, properties, overloads, and test fakes.
- Refresh MapleStory and Threads Pydantic model docs with `Attributes:` sections that match current fields.
- Fix stale project structure entries in `CONTRIBUTING.md`.

## Verification

- `git diff --check`
- `uv run ruff check --no-fix scripts/gen_docs.py src/discordbot/__init__.py src/discordbot/cli.py src/discordbot/cogs/_maplestory/embeds.py src/discordbot/cogs/_maplestory/models.py src/discordbot/cogs/_maplestory/service.py src/discordbot/cogs/_maplestory/views.py src/discordbot/cogs/gen_reply.py src/discordbot/cogs/help.py src/discordbot/cogs/log_msg.py src/discordbot/cogs/parse_threads.py src/discordbot/cogs/template.py src/discordbot/cogs/video.py src/discordbot/utils/downloader.py src/discordbot/utils/images.py src/discordbot/utils/model_pricing.py src/discordbot/utils/threads.py tests/test_gen_reply.py`
- `uv run pytest tests/test_gen_reply.py --no-cov`

Note: `uv run pytest tests/test_gen_reply.py` passes the test itself but fails the command because the repo-wide coverage gate still applies to single-file runs and reports total coverage below 80%.
