### PR TITLE
fix: keep help guide in sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ make gen-docs                    # regenerate docs/ from sources
 - Cog = `commands.Cog` subclass + module-level **sync** `def setup(bot): bot.add_cog(..., override=True)`.
 - Cogs don't import peers directly; cross-cog calls go through the bot instance or shared typings.
 - Slash commands need `name_localizations` / `description_localizations` for `en-US`, `zh-TW`, `ja`. See `cogs/help.py` and `cogs/maplestory.py` for the pattern.
+- Every user-facing feature or behavior change must update `cogs/help.py` (`_HELP_CONTENT`) in the same change so `/help` stays accurate; keep `tests/test_help.py` passing.
 - Cog-private helpers live in sibling `_<cog>/` packages (e.g. `_gen_reply/`, `_maplestory/`).
 
 ### AI pipeline (`cogs/gen_reply.py` + `cogs/_gen_reply/prompts.py`)

--- a/src/discordbot/cogs/help.py
+++ b/src/discordbot/cogs/help.py
@@ -12,20 +12,23 @@ _HELP_CONTENT = {
             "**AI Chat**\n"
             "Mention me or send a DM to start a conversation.\n"
             "- Send text to ask questions\n"
-            "- Attach images for analysis\n"
+            "- Attach images or supported files for analysis\n"
             "- Ask me to generate images or videos\n"
-            "- Send a long article / URL and ask for a summary"
+            "- Send a long article / URL and ask for a summary\n"
+            f"- Earn {CURRENCY_NAME} from streaming AI replies"
         ),
         "threads": (
             "**Threads Parser**\n"
-            "Paste a Threads.net link and I'll automatically "
+            "Paste a Threads.net or Threads.com link and I'll automatically "
             "extract the content with media for you. "
             "Reply links also pull in the original post and any intermediate replies "
-            "as context, with a grey gradient stripe so each layer is easy to tell apart."
+            "as context, with a grey gradient stripe so each layer is easy to tell apart. "
+            "If the result is too large for Discord, I'll mark it with a warning reaction."
         ),
         "video": (
             "**Video Download** — `/download_video`\n"
-            "Download videos from YouTube, Facebook, Instagram, X, TikTok, and more."
+            "Download videos from YouTube, Facebook, Instagram, X, TikTok, and more. "
+            "Use the optional quality setting; oversized files retry once at low quality."
         ),
         "maplestory": (
             "**MapleStory Artale** — `/maple_*`\n"
@@ -36,16 +39,18 @@ _HELP_CONTENT = {
         ),
         "points": (
             f"**{CURRENCY_NAME}**\n"
-            f"Earn {CURRENCY_NAME} by chatting with me, then use them across servers.\n"
+            f"Earn {CURRENCY_NAME} from AI chat replies, then use them across servers.\n"
             "`/balance` check your balance · `/leaderboard` show the global top 10\n"
-            f"`/give` transfer {CURRENCY_NAME} · `/house` show the dealer's running P&L"
+            f"`/give` transfer {CURRENCY_NAME} · `/house` show the dealer's running P&L\n"
+            "`/balance`, `/leaderboard`, and `/house` results clean themselves up after 3 minutes."
         ),
         "games": (
             "**Games**\n"
             "`/dice` roll three dice against the dealer.\n"
-            "`/dragon_gate` shoot one card between two gate cards.\n"
+            "`/dragon_gate` shoot one card strictly between two gate cards.\n"
             "`/blackjack` play one round of 21. Bets are withdrawn up front, "
-            "over-bets auto all-in, and idle hands auto-stand after 180 seconds."
+            "over-bets auto all-in, idle hands auto-stand after 180 seconds, "
+            "and final game messages are cleaned up after 3 minutes."
         ),
         "ping": "**Ping** — `/ping`\nCheck the bot's response latency.",
     },
@@ -56,19 +61,22 @@ _HELP_CONTENT = {
             "**AI 對話**\n"
             "tag 我或私訊我即可開始對話。\n"
             "- 傳送文字來問問題\n"
-            "- 附加圖片進行分析\n"
+            "- 附加圖片或支援的檔案進行分析\n"
             "- 請我生成圖片或影片\n"
-            "- 傳送長文 / 網址請我做摘要"
+            "- 傳送長文 / 網址請我做摘要\n"
+            f"- AI 串流回覆會獎勵{CURRENCY_NAME}"
         ),
         "threads": (
             "**Threads 解析**\n"
-            "貼上 Threads.net 的連結，我會自動擷取內容與媒體。"
+            "貼上 Threads.net 或 Threads.com 的連結，我會自動擷取內容與媒體。"
             "如果是回覆的連結，我也會把原始貼文與中間每一層回覆一起帶出來當作上下文，"
             "並用灰階漸層色帶區分層級。"
+            "如果內容超過 Discord 限制，會用 warning reaction 標記。"
         ),
         "video": (
             "**影片下載** — `/download_video`\n"
             "支援從 YouTube、Facebook、Instagram、X、TikTok 等平台下載影片。"
+            "可以選 quality；檔案太大時會自動 retry 一次低畫質。"
         ),
         "maplestory": (
             "**MapleStory Artale** — `/maple_*`\n"
@@ -79,16 +87,17 @@ _HELP_CONTENT = {
         ),
         "points": (
             f"**{CURRENCY_NAME}**\n"
-            f"跟我聊天可以累積{CURRENCY_NAME}，{CURRENCY_NAME}跨 server 共用。\n"
+            f"AI chat 回覆會累積{CURRENCY_NAME}，{CURRENCY_NAME}跨 server 共用。\n"
             "`/balance` 查餘額 · `/leaderboard` 看 global 前 10 名\n"
-            "`/give` 轉虛擬歡樂豆 · `/house` 看莊家累積 P&L"
+            "`/give` 轉虛擬歡樂豆 · `/house` 看莊家累積 P&L\n"
+            "`/balance`、`/leaderboard`、`/house` 查詢結果會在 3 分鐘後自動清掉。"
         ),
         "games": (
             "**小遊戲**\n"
             "`/dice` 用三顆骰子跟莊家比大小。\n"
-            "`/dragon_gate` 射一張牌進兩張門牌中間。\n"
+            "`/dragon_gate` 射一張牌嚴格落在兩張門牌中間。\n"
             "`/blackjack` 跟莊家玩一局 21 點。bet 會先扣，超過餘額會自動 all-in，"
-            "不操作 180 秒會自動 stand 結算。"
+            "不操作 180 秒會自動 stand 結算，final game message 會在 3 分鐘後清掉。"
         ),
         "ping": "**延遲測試** — `/ping`\n檢查機器人的回應延遲。",
     },
@@ -99,19 +108,23 @@ _HELP_CONTENT = {
             "**AI チャット**\n"
             "メンションまたはDMで会話を開始できます。\n"
             "- テキストで質問\n"
-            "- 画像を添付して分析\n"
+            "- 画像や対応ファイルを添付して分析\n"
             "- 画像や動画の生成をリクエスト\n"
-            "- 長文 / URLを送って要約をリクエスト"
+            "- 長文 / URLを送って要約をリクエスト\n"
+            f"- AIのストリーミング返信で{CURRENCY_NAME}を獲得"
         ),
         "threads": (
             "**Threads パーサー**\n"
-            "Threads.net のリンクを貼ると、自動的にコンテンツとメディアを取得します。"
+            "Threads.net または Threads.com のリンクを貼ると、"
+            "自動的にコンテンツとメディアを取得します。"
             "返信へのリンクの場合は、元の投稿と途中の返信もすべて文脈として展開し、"
             "グレースケールのグラデーションで各レイヤーを区別します。"
+            "Discord の制限を超える場合は warning reaction で知らせます。"
         ),
         "video": (
             "**動画ダウンロード** — `/download_video`\n"
             "YouTube、Facebook、Instagram、X、TikTok などから動画をダウンロードします。"
+            "quality を選択でき、ファイルが大きすぎる場合は一度 low quality で retry します。"
         ),
         "maplestory": (
             "**MapleStory Artale** — `/maple_*`\n"
@@ -122,16 +135,18 @@ _HELP_CONTENT = {
         ),
         "points": (
             f"**{CURRENCY_NAME}**\n"
-            f"チャットで{CURRENCY_NAME}を獲得し、サーバーをまたいで使えます。\n"
+            f"AI チャット返信で{CURRENCY_NAME}を獲得し、サーバーをまたいで使えます。\n"
             "`/balance` 残高確認 · `/leaderboard` グローバルトップ10\n"
-            f"`/give` {CURRENCY_NAME}送付 · `/house` ディーラーの累計損益"
+            f"`/give` {CURRENCY_NAME}送付 · `/house` ディーラーの累計損益\n"
+            "`/balance`、`/leaderboard`、`/house` の結果は3分後に自動削除されます。"
         ),
         "games": (
             "**ゲーム**\n"
             "`/dice` 3個のサイコロでディーラーと勝負します。\n"
-            "`/dragon_gate` 2枚のゲートカードの間に1枚を通します。\n"
+            "`/dragon_gate` 2枚のゲートカードの間に厳密に1枚を通します。\n"
             "`/blackjack` 21を1ラウンド遊びます。ベットは先に差し引かれ、"
-            "残高超過は自動 all-in、180秒操作がない場合は自動 stand で精算されます。"
+            "残高超過は自動 all-in、180秒操作がない場合は自動 stand で精算され、"
+            "final game message は3分後に削除されます。"
         ),
         "ping": "**Ping** — `/ping`\nボットの応答遅延を確認します。",
     },

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,0 +1,38 @@
+"""Tests for keeping the localized help guide aligned with slash commands."""
+
+import ast
+from pathlib import Path
+
+from nextcord import Locale
+
+from discordbot.cogs.help import _HELP_CONTENT
+
+
+def _slash_command_names() -> set[str]:
+    """Returns slash command names declared by top-level cogs."""
+    names: set[str] = set()
+    cogs_dir = Path(__file__).resolve().parents[1] / "src" / "discordbot" / "cogs"
+    for path in cogs_dir.glob(pattern="*.py"):
+        parsed = ast.parse(source=path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(node=parsed):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Attribute) or node.func.attr != "slash_command":
+                continue
+            for keyword in node.keywords:
+                if keyword.arg != "name" or not isinstance(keyword.value, ast.Constant):
+                    continue
+                if isinstance(keyword.value.value, str):
+                    names.add(keyword.value.value)
+    return names
+
+
+def test_help_mentions_every_non_help_slash_command() -> None:
+    """Every non-help slash command should be discoverable from every localized help body."""
+    commands = _slash_command_names() - {"help"}
+    for locale in ("default", Locale.zh_TW, Locale.ja):
+        body = "\n".join(
+            value for value in _HELP_CONTENT[locale].values() if isinstance(value, str)
+        )
+        missing = sorted(f"/{command}" for command in commands if f"/{command}" not in body)
+        assert not missing, f"{locale} help is missing slash commands: {missing}"


### PR DESCRIPTION
## Summary
- Refresh localized `/help` copy for AI attachments, Threads.com support, video quality fallback, economy cleanup, and game cleanup behavior.
- Add a regression test that ensures every non-help slash command is discoverable in all localized help content.
- Document that user-facing feature or behavior changes must update `cogs/help.py`.

## Tests
- `uv run ruff check src/discordbot/cogs/help.py tests/test_help.py`
- `uv run ruff format --check src/discordbot/cogs/help.py tests/test_help.py`
- `uv run pytest tests/test_help.py --no-cov`
- `uv run pytest --no-cov` (93 passed)

Note: `uv run pytest` runs all 93 tests successfully but still fails the repository coverage gate because current total coverage is 35%, below the configured 80% threshold.
