### PR TITLE
test: improve coverage for bot flows

### DIFF
--- a/src/discordbot/cogs/_maplestory/service.py
+++ b/src/discordbot/cogs/_maplestory/service.py
@@ -27,9 +27,9 @@ def _load_json[T: BaseModel](path: Path, model: type[T]) -> list[T]:
             raw = json.load(f)
         return [model.model_validate(item) for item in raw]
     except FileNotFoundError:
-        logfire.warning("找不到資料檔案 %s", path)
+        logfire.warning(f"找不到資料檔案 {path}")
     except (json.JSONDecodeError, Exception) as exc:
-        logfire.error("無法載入 %s — %s", path, exc)
+        logfire.error(f"無法載入 {path}: {exc}")
     return []
 
 

--- a/tests/test_cogs_smoke.py
+++ b/tests/test_cogs_smoke.py
@@ -1,0 +1,514 @@
+from types import SimpleNamespace
+from typing import Self
+from pathlib import Path
+from datetime import UTC, datetime, timedelta
+from collections.abc import AsyncIterator
+
+import pytest
+import nextcord
+from nextcord import Embed
+from nextcord.ext import commands
+
+from discordbot import cli
+from discordbot.cogs import games, video, economy, template, auto_unmute, parse_threads
+from discordbot.cogs.games import GamesCogs
+from discordbot.cogs.video import VideoCogs
+from discordbot.cogs.economy import EconomyCogs
+from discordbot.cogs._economy import database
+from discordbot.cogs.template import TemplateCogs
+from discordbot.utils.threads import ThreadsOutput
+from discordbot.cogs.auto_unmute import AutoUnmuteCogs
+from discordbot.cogs.parse_threads import ThreadsCogs
+from discordbot.cogs._games.blackjack import Card, BlackjackHand
+
+
+class FakeResponse:
+    def __init__(self) -> None:
+        self.deferred = False
+        self.sent: list[dict[str, object]] = []
+
+    async def defer(self) -> None:
+        self.deferred = True
+
+    async def send_message(self, **kwargs: object) -> None:
+        self.sent.append(kwargs)
+
+
+class FakeFollowup:
+    def __init__(self) -> None:
+        self.sent: list[dict[str, object]] = []
+
+    async def send(self, **kwargs: object) -> object:
+        self.sent.append(kwargs)
+        return FakeDiscordMessage()
+
+
+class FakeInteraction:
+    def __init__(self, *, user: object | None = None) -> None:
+        self.user = user or FakeUser()
+        self.response = FakeResponse()
+        self.followup = FakeFollowup()
+        self.edits: list[dict[str, object]] = []
+
+    async def edit_original_message(self, **kwargs: object) -> None:
+        self.edits.append(kwargs)
+
+
+class FakeUser:
+    def __init__(
+        self, *, user_id: int = 1, name: str = "alice", display_name: str = "Alice", bot: bool = False
+    ) -> None:
+        self.id = user_id
+        self.name = name
+        self.display_name = display_name
+        self.bot = bot
+        self.mention = f"<@{user_id}>"
+        self.display_avatar = SimpleNamespace(url="https://example.test/avatar.png")
+
+
+class FakeDiscordMessage:
+    def __init__(self) -> None:
+        self.edits: list[dict[str, object]] = []
+        self.reactions: list[str] = []
+        self.removed: list[tuple[str, object]] = []
+        self.replies: list[dict[str, object]] = []
+        self.deleted = False
+        self.suppressed = False
+
+    async def edit(self, **kwargs: object) -> None:
+        if "suppress" in kwargs:
+            self.suppressed = bool(kwargs["suppress"])
+        self.edits.append(kwargs)
+
+    async def add_reaction(self, emoji: str) -> None:
+        self.reactions.append(emoji)
+
+    async def remove_reaction(self, *, emoji: str, member: object) -> None:
+        self.removed.append((emoji, member))
+
+    async def reply(self, **kwargs: object) -> None:
+        self.replies.append(kwargs)
+
+    async def delete(self) -> None:
+        self.deleted = True
+
+
+class DownloadResultStub:
+    def __init__(self, *, filename: Path) -> None:
+        self.filename = filename
+
+    def __enter__(self) -> Self:
+        """Returns the fake download result."""
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Leaves the fake downloaded file on disk for assertions."""
+        return
+
+
+class DownloaderStub:
+    def __init__(self, *, results: list[DownloadResultStub]) -> None:
+        self.results = results
+        self.calls: list[dict[str, object]] = []
+
+    def download(self, **kwargs: object) -> DownloadResultStub:
+        self.calls.append(kwargs)
+        return self.results.pop(0)
+
+
+class ParseResultStub:
+    def __init__(self, *, results: list[ThreadsOutput] | BaseException) -> None:
+        self.results = results
+
+    def __enter__(self) -> list[ThreadsOutput]:
+        """Returns parsed posts or raises the configured parsing error."""
+        if isinstance(self.results, BaseException):
+            raise self.results
+        return self.results
+
+    def __exit__(self, *args: object) -> None:
+        """Keeps fake parsed outputs available after context exit."""
+        return
+
+
+class ThreadsDownloaderStub:
+    def __init__(self, *, results: list[ThreadsOutput] | BaseException) -> None:
+        self.results = results
+
+    def parse(self, url: str) -> ParseResultStub:
+        return ParseResultStub(results=self.results)
+
+
+def _thread_output(
+    *,
+    text: str = "hello",
+    image_urls: list[str] | None = None,
+    video_paths: list[Path] | None = None,
+    video_urls: list[str] | None = None,
+) -> ThreadsOutput:
+    return ThreadsOutput(
+        text=text,
+        url="https://www.threads.net/@alice/post/abc",
+        image_urls=image_urls or [],
+        video_urls=video_urls or [],
+        video_paths=video_paths or [],
+        author_name="alice",
+        author_icon_url="https://example.test/avatar.png",
+        like_count=1,
+        reply_count=2,
+        repost_count=3,
+        quote_count=4,
+        reshare_count=5,
+        taken_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+
+async def test_template_on_message_and_ping() -> None:
+    cog = TemplateCogs(bot=SimpleNamespace(latency=0.123))
+    message = FakeDiscordMessage()
+    message.author = FakeUser(bot=False)
+    message.content = "debug"
+    await cog.on_message(message=message)
+    assert message.reactions == ["🤬"]
+
+    bot_message = FakeDiscordMessage()
+    bot_message.author = FakeUser(bot=True)
+    bot_message.content = "debug"
+    await cog.on_message(message=bot_message)
+    assert bot_message.reactions == []
+
+    interaction = FakeInteraction(user=FakeUser(display_name="Alice"))
+    await TemplateCogs.ping.callback(cog, interaction)
+    embed = interaction.followup.sent[0]["embed"]
+    assert isinstance(embed, Embed)
+    assert embed.title == ":ping_pong: Pong!"
+
+
+async def test_video_deliver_and_download_branches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cog = VideoCogs(bot=SimpleNamespace())
+    small = tmp_path / "small.mp4"
+    small.write_bytes(data=b"0" * 100)
+    big = tmp_path / "big.mp4"
+    big.write_bytes(data=b"0" * (video._DISCORD_FILE_LIMIT_BYTES + 1))
+    low = tmp_path / "low.mp4"
+    low.write_bytes(data=b"1" * 100)
+
+    interaction = FakeInteraction()
+    await cog._deliver(
+        interaction=interaction, file_size_mb=1.25, file_path=str(small), file_name=small.name
+    )
+    assert interaction.followup.sent[0]["content"].startswith("✅ 下載成功")
+    assert interaction.edits[-1]["content"] == "✅"
+
+    downloader = DownloaderStub(
+        results=[DownloadResultStub(filename=big), DownloadResultStub(filename=low)]
+    )
+    monkeypatch.setattr(video, "VideoDownloader", lambda output_folder: downloader)
+    retry_interaction = FakeInteraction()
+    await VideoCogs.download_video.callback(cog, retry_interaction, url="https://x.test", quality="best")
+    assert [call["quality"] for call in downloader.calls] == ["best", "low"]
+    assert retry_interaction.followup.sent[-1]["file"] is not None
+
+    fail_interaction = FakeInteraction()
+    monkeypatch.setattr(
+        video,
+        "VideoDownloader",
+        lambda output_folder: DownloaderStub(results=[DownloadResultStub(filename=big)]),
+    )
+    await VideoCogs.download_video.callback(cog, fail_interaction, url="https://x.test", quality="low")
+    assert "檔案大小超過" in fail_interaction.edits[-1]["content"]
+
+    monkeypatch.setattr(video, "VideoDownloader", lambda output_folder: _RaiseDownloader())
+    error_interaction = FakeInteraction()
+    await VideoCogs.download_video.callback(
+        cog, error_interaction, url="https://x.test", quality="best"
+    )
+    assert "檔案無法下載" in error_interaction.edits[-1]["content"]
+
+
+class _RaiseDownloader:
+    def download(self, **kwargs: object) -> DownloadResultStub:
+        raise RuntimeError("download failed")
+
+
+async def test_threads_cog_builds_embeds_and_handles_messages(tmp_path: Path) -> None:
+    bot = SimpleNamespace(user=SimpleNamespace(id=999))
+    cog = ThreadsCogs(bot=bot)
+    video_file = tmp_path / "clip.mp4"
+    video_file.write_bytes(data=b"123")
+
+    parent = _thread_output(text="parent", video_urls=["https://example.test/video.mp4"])
+    target = _thread_output(image_urls=["https://example.test/1.png", "https://example.test/2.png"])
+    embeds = cog._build_embeds(results=[parent, target])
+    assert len(embeds) == 3
+    assert "點此觀看影片" in embeds[0].description
+    assert ThreadsCogs._gradient_color(index=0, total=1) == nextcord.Color.default()
+
+    no_match = FakeDiscordMessage()
+    no_match.author = FakeUser(bot=False)
+    no_match.content = "hello"
+    await cog.on_message(message=no_match)
+    assert no_match.reactions == []
+
+    success_message = FakeDiscordMessage()
+    success_message.author = FakeUser(bot=False)
+    success_message.content = "https://www.threads.net/@alice/post/abc"
+    success_message.guild = SimpleNamespace(filesize_limit=25 * 1024 * 1024)
+    cog.downloader = ThreadsDownloaderStub(
+        results=[_thread_output(video_paths=[video_file], image_urls=[])]
+    )
+    await cog.on_message(message=success_message)
+    assert success_message.suppressed
+    assert success_message.replies[0]["files"]
+    assert success_message.reactions[-1] == "🆗"
+
+    warning_message = FakeDiscordMessage()
+    warning_message.author = FakeUser(bot=False)
+    warning_message.content = "https://www.threads.net/@alice/post/abc"
+    warning_message.guild = None
+    cog.downloader = ThreadsDownloaderStub(results=[])
+    await cog.on_message(message=warning_message)
+    assert warning_message.reactions[-1] == "⚠️"
+
+    error_message = FakeDiscordMessage()
+    error_message.author = FakeUser(bot=False)
+    error_message.content = "https://www.threads.net/@alice/post/abc"
+    error_message.guild = None
+    cog.downloader = ThreadsDownloaderStub(results=RuntimeError("parse failed"))
+    await cog.on_message(message=error_message)
+    assert error_message.reactions[-1] == "❌"
+
+
+async def test_auto_unmute_tracks_audit_and_generates_reply(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(name="OPENAI_BASE_URL", value="https://example.test/v1")
+    monkeypatch.setenv(name="OPENAI_API_KEY", value="test-key")
+    sent: list[str] = []
+    channel = SimpleNamespace(send=lambda content: _append_async(sent, content))
+    bot_user = FakeUser(user_id=999, name="bot", display_name="Bot")
+    bot = SimpleNamespace(user=bot_user)
+    cog = AutoUnmuteCogs(bot=bot)
+
+    guild = SimpleNamespace(
+        id=123,
+        name="Guild",
+        get_channel=lambda channel_id: channel,
+        system_channel=None,
+        audit_logs=lambda **kwargs: _audit_entries(bot_user),
+    )
+    await cog.on_message(
+        message=SimpleNamespace(
+            guild=guild, author=FakeUser(bot=False), channel=SimpleNamespace(id=456)
+        )
+    )
+    assert cog._last_active_channel == {123: 456}
+
+    monkeypatch.setattr(auto_unmute.nextcord.abc, "Messageable", object)
+    assert cog._resolve_channel(guild=guild) is channel
+    moderator, reason = await cog._lookup_audit(guild=guild)
+    assert moderator.name == "moderator"
+    assert reason == "testing"
+
+    cog.__dict__["client"] = SimpleNamespace(
+        responses=SimpleNamespace(create=lambda **kwargs: _response_async("not today"))
+    )
+    reply = await cog._generate_reply(
+        guild_name="Guild",
+        moderator=moderator,
+        reason=reason,
+        until=datetime.now(tz=UTC) + timedelta(minutes=10),
+    )
+    assert reply == "not today"
+
+    member = SimpleNamespace(
+        id=999,
+        guild=guild,
+        communication_disabled_until=datetime.now(tz=UTC) + timedelta(minutes=5),
+        edit=lambda **kwargs: _async_none(),
+    )
+    await cog._handle_self_timeout(member=member, until=member.communication_disabled_until)
+    assert sent == ["not today"]
+
+    before = SimpleNamespace(communication_disabled_until=None)
+    after = member
+    handled: list[object] = []
+    monkeypatch.setattr(cog, "_handle_self_timeout", lambda **kwargs: _append_async(handled, kwargs))
+    await cog.on_member_update(before=before, after=after)
+    assert handled
+
+
+async def _audit_entries(bot_user: FakeUser) -> AsyncIterator[object]:
+    yield SimpleNamespace(
+        target=SimpleNamespace(id=111),
+        changes=SimpleNamespace(after=SimpleNamespace(communication_disabled_until=True)),
+        user=FakeUser(name="wrong"),
+        reason="wrong",
+    )
+    yield SimpleNamespace(
+        target=SimpleNamespace(id=bot_user.id),
+        changes=SimpleNamespace(after=SimpleNamespace(communication_disabled_until=True)),
+        user=FakeUser(name="moderator"),
+        reason="testing",
+    )
+
+
+async def _response_async(output_text: str) -> object:
+    return SimpleNamespace(output_text=output_text)
+
+
+async def _append_async(container: list[object], item: object) -> None:
+    container.append(item)
+
+
+async def _async_none() -> None:
+    return None
+
+
+async def test_economy_commands_use_database_facade(monkeypatch: pytest.MonkeyPatch) -> None:
+    scheduled: list[object] = []
+    monkeypatch.setattr(
+        economy, "schedule_game_message_delete", lambda **kwargs: scheduled.append(kwargs["message"])
+    )
+    monkeypatch.setattr(economy, "get_balance", lambda user_id: _value_async(150))
+    monkeypatch.setattr(economy, "top_n", lambda **kwargs: _value_async([(1, "alice", 150)]))
+    monkeypatch.setattr(economy, "get_account", lambda user_id: _value_async(("Bot", -50, 100, 150)))
+    monkeypatch.setattr(
+        economy,
+        "transfer",
+        lambda **kwargs: _value_async(database.TransferResult(sender_balance=50, receiver_balance=100)),
+    )
+    bot = SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer"))
+    cog = EconomyCogs(bot=bot)
+    interaction = FakeInteraction(user=FakeUser(user_id=1))
+    await EconomyCogs.balance.callback(cog, interaction)
+    await EconomyCogs.leaderboard.callback(cog, interaction)
+    await EconomyCogs.house.callback(cog, interaction)
+    await EconomyCogs.give.callback(cog, interaction, member=FakeUser(user_id=2, name="bob"), amount=100)
+    assert len(interaction.followup.sent) == 4
+    assert scheduled
+
+    bot_receiver = FakeInteraction(user=FakeUser(user_id=1))
+    await EconomyCogs.give.callback(
+        cog, bot_receiver, member=FakeUser(user_id=3, name="bot", bot=True), amount=1
+    )
+    assert "不能把" in bot_receiver.followup.sent[0]["embed"].description
+
+
+async def _value_async(value: object) -> object:
+    return value
+
+
+async def test_games_commands_run_with_patched_settlement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(name="OPENAI_BASE_URL", value="https://example.test/v1")
+    monkeypatch.setenv(name="OPENAI_API_KEY", value="test-key")
+    monkeypatch.setattr(games.asyncio, "sleep", lambda *args, **kwargs: _async_none())
+    monkeypatch.setattr(games, "schedule_game_message_delete", lambda message: None)
+    monkeypatch.setattr(
+        games,
+        "place_bet",
+        lambda **kwargs: _value_async(database.PlacedBet(amount=10, balance_after=90, is_allin=False)),
+    )
+    monkeypatch.setattr(games, "get_balance", lambda user_id: _value_async(0))
+    monkeypatch.setattr(
+        games,
+        "settle_wager",
+        lambda **kwargs: _value_async(SimpleNamespace(delta=10, new_balance=110, house_balance=-10)),
+    )
+    monkeypatch.setattr(
+        games,
+        "settle_blackjack_round",
+        lambda **kwargs: _value_async(
+            SimpleNamespace(
+                outcome="win", delta=15, new_balance=115, house_balance=-15, detail="natural"
+            )
+        ),
+    )
+    hand = BlackjackHand(rng=games.SystemRandom(), bet=10)
+    hand.player = [Card(rank="A", suit="♠"), Card(rank="K", suit="♣")]
+    hand.dealer = [Card(rank="9", suit="♠"), Card(rank="8", suit="♣")]
+    hand.finished = True
+
+    def fake_deal_initial() -> None:
+        return None
+
+    hand.deal_initial = fake_deal_initial
+    monkeypatch.setattr(games, "BlackjackHand", lambda **kwargs: hand)
+
+    cog = GamesCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    cog.__dict__["dealer"] = SimpleNamespace(
+        taunt_bet=lambda **kwargs: _value_async("taunt"),
+        settle=lambda **kwargs: _value_async("settled"),
+    )
+
+    dice_interaction = FakeInteraction(user=FakeUser(user_id=1))
+    await GamesCogs.dice.callback(cog, dice_interaction, bet=10)
+    assert dice_interaction.followup.sent[0]["wait"] is True
+
+    dragon_interaction = FakeInteraction(user=FakeUser(user_id=1))
+    await GamesCogs.dragon_gate.callback(cog, dragon_interaction, bet=10)
+    assert dragon_interaction.followup.sent[0]["wait"] is True
+
+    blackjack_interaction = FakeInteraction(user=FakeUser(user_id=1))
+    await GamesCogs.blackjack.callback(cog, blackjack_interaction, bet=10)
+    assert blackjack_interaction.followup.sent[0]["wait"] is True
+
+
+def test_setup_functions_register_cogs(monkeypatch: pytest.MonkeyPatch) -> None:
+    added: list[tuple[object, bool | None]] = []
+    bot = SimpleNamespace(add_cog=lambda cog, override=None: added.append((cog, override)))
+    for module in [video, games, economy, template, parse_threads, auto_unmute]:
+        monkeypatch.setenv(name="OPENAI_BASE_URL", value="https://example.test/v1")
+        monkeypatch.setenv(name="OPENAI_API_KEY", value="test-key")
+        module.setup(bot=bot)
+    assert [type(item[0]) for item in added] == [
+        VideoCogs,
+        GamesCogs,
+        EconomyCogs,
+        TemplateCogs,
+        ThreadsCogs,
+        AutoUnmuteCogs,
+    ]
+
+
+def test_cli_loads_cogs_and_handles_command_errors(tmp_path: Path) -> None:
+    loaded: list[object] = []
+    bot = SimpleNamespace(
+        load_extensions=lambda modules, stop_at_error: loaded.append((modules, stop_at_error))
+    )
+    cli.DiscordBot._load_cogs_sync(bot)
+    assert loaded[0][1] is True
+    assert "discordbot.cogs.template" in loaded[0][0]
+
+
+async def test_cli_message_and_command_error_branches() -> None:
+    processed: list[object] = []
+    bot = SimpleNamespace(
+        user=FakeUser(user_id=999, bot=True),
+        process_commands=lambda message: _append_async(processed, message),
+    )
+    user_message = SimpleNamespace(author=FakeUser(user_id=1, bot=False))
+    await cli.DiscordBot.on_message(bot, message=user_message)
+    assert processed == [user_message]
+    await cli.DiscordBot.on_message(bot, message=SimpleNamespace(author=bot.user))
+    assert len(processed) == 1
+
+    sent: list[dict[str, object]] = []
+    context = SimpleNamespace(
+        send=lambda **kwargs: _append_async(sent, kwargs),
+        guild=SimpleNamespace(name="Guild", id=1),
+        author=FakeUser(user_id=1),
+    )
+    await cli.DiscordBot.on_command_error(bot, context, commands.NotOwner())
+    await cli.DiscordBot.on_command_error(
+        bot, context, commands.MissingPermissions(missing_permissions=["kick_members"])
+    )
+    await cli.DiscordBot.on_command_error(
+        bot, context, commands.BotMissingPermissions(missing_permissions=["send_messages"])
+    )
+    await cli.DiscordBot.on_command_error(bot, context, commands.CommandNotFound("nope"))
+    assert len(sent) == 4

--- a/tests/test_cogs_smoke.py
+++ b/tests/test_cogs_smoke.py
@@ -1,12 +1,11 @@
-from types import SimpleNamespace
-from typing import Self
-from pathlib import Path
-from datetime import UTC, datetime, timedelta
-from collections.abc import AsyncIterator
+from __future__ import annotations
 
-import pytest
+from types import TracebackType, SimpleNamespace
+from typing import TYPE_CHECKING, Self, Unpack, TypedDict
+from datetime import UTC, datetime, timedelta
+
 import nextcord
-from nextcord import Embed
+from nextcord import File, Embed
 from nextcord.ext import commands
 
 from discordbot import cli
@@ -21,42 +20,74 @@ from discordbot.cogs.auto_unmute import AutoUnmuteCogs
 from discordbot.cogs.parse_threads import ThreadsCogs
 from discordbot.cogs._games.blackjack import Card, BlackjackHand
 
+if TYPE_CHECKING:
+    from pathlib import Path
+    from collections.abc import AsyncIterator
+
+    import pytest
+
+
+class DiscordPayload(TypedDict, total=False):
+    content: str | None
+    embed: Embed
+    embeds: list[Embed]
+    file: File
+    files: list[File]
+    view: nextcord.ui.View
+    wait: bool
+    ephemeral: bool
+    suppress: bool
+
+
+class OriginalEditPayload(TypedDict, total=False):
+    content: str
+
+
+class SelfTimeoutCall(TypedDict):
+    member: SimpleNamespace
+    until: datetime
+
 
 class FakeResponse:
     def __init__(self) -> None:
         self.deferred = False
-        self.sent: list[dict[str, object]] = []
+        self.sent: list[DiscordPayload] = []
 
     async def defer(self) -> None:
         self.deferred = True
 
-    async def send_message(self, **kwargs: object) -> None:
+    async def send_message(self, **kwargs: Unpack[DiscordPayload]) -> None:
         self.sent.append(kwargs)
 
 
 class FakeFollowup:
     def __init__(self) -> None:
-        self.sent: list[dict[str, object]] = []
+        self.sent: list[DiscordPayload] = []
 
-    async def send(self, **kwargs: object) -> object:
+    async def send(self, **kwargs: Unpack[DiscordPayload]) -> FakeDiscordMessage:
         self.sent.append(kwargs)
         return FakeDiscordMessage()
 
 
 class FakeInteraction:
-    def __init__(self, *, user: object | None = None) -> None:
+    def __init__(self, *, user: FakeUser | None = None) -> None:
         self.user = user or FakeUser()
         self.response = FakeResponse()
         self.followup = FakeFollowup()
-        self.edits: list[dict[str, object]] = []
+        self.edits: list[OriginalEditPayload] = []
 
-    async def edit_original_message(self, **kwargs: object) -> None:
+    async def edit_original_message(self, **kwargs: Unpack[OriginalEditPayload]) -> None:
         self.edits.append(kwargs)
 
 
 class FakeUser:
     def __init__(
-        self, *, user_id: int = 1, name: str = "alice", display_name: str = "Alice", bot: bool = False
+        self,
+        *,
+        user_id: int = 1,
+        name: str = "alice",
+        display_name: str = "Alice",
+        bot: bool = False,
     ) -> None:
         self.id = user_id
         self.name = name
@@ -68,14 +99,14 @@ class FakeUser:
 
 class FakeDiscordMessage:
     def __init__(self) -> None:
-        self.edits: list[dict[str, object]] = []
+        self.edits: list[DiscordPayload] = []
         self.reactions: list[str] = []
-        self.removed: list[tuple[str, object]] = []
-        self.replies: list[dict[str, object]] = []
+        self.removed: list[tuple[str, FakeUser]] = []
+        self.replies: list[DiscordPayload] = []
         self.deleted = False
         self.suppressed = False
 
-    async def edit(self, **kwargs: object) -> None:
+    async def edit(self, **kwargs: Unpack[DiscordPayload]) -> None:
         if "suppress" in kwargs:
             self.suppressed = bool(kwargs["suppress"])
         self.edits.append(kwargs)
@@ -83,10 +114,10 @@ class FakeDiscordMessage:
     async def add_reaction(self, emoji: str) -> None:
         self.reactions.append(emoji)
 
-    async def remove_reaction(self, *, emoji: str, member: object) -> None:
+    async def remove_reaction(self, *, emoji: str, member: FakeUser) -> None:
         self.removed.append((emoji, member))
 
-    async def reply(self, **kwargs: object) -> None:
+    async def reply(self, **kwargs: Unpack[DiscordPayload]) -> None:
         self.replies.append(kwargs)
 
     async def delete(self) -> None:
@@ -101,7 +132,12 @@ class DownloadResultStub:
         """Returns the fake download result."""
         return self
 
-    def __exit__(self, *args: object) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         """Leaves the fake downloaded file on disk for assertions."""
         return
 
@@ -109,9 +145,10 @@ class DownloadResultStub:
 class DownloaderStub:
     def __init__(self, *, results: list[DownloadResultStub]) -> None:
         self.results = results
-        self.calls: list[dict[str, object]] = []
+        self.calls: list[dict[str, str | bool]] = []
 
-    def download(self, **kwargs: object) -> DownloadResultStub:
+    def download(self, *, url: str, quality: str, dry_run: bool = False) -> DownloadResultStub:
+        kwargs: dict[str, str | bool] = {"url": url, "quality": quality, "dry_run": dry_run}
         self.calls.append(kwargs)
         return self.results.pop(0)
 
@@ -126,7 +163,12 @@ class ParseResultStub:
             raise self.results
         return self.results
 
-    def __exit__(self, *args: object) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         """Keeps fake parsed outputs available after context exit."""
         return
 
@@ -137,6 +179,27 @@ class ThreadsDownloaderStub:
 
     def parse(self, url: str) -> ParseResultStub:
         return ParseResultStub(results=self.results)
+
+
+class FakeSendChannel:
+    def __init__(self, sent: list[str]) -> None:
+        self.sent = sent
+
+    async def send(self, *, content: str) -> None:
+        self.sent.append(content)
+
+
+class FakeAuditEntry:
+    def __init__(self, *, target_id: int, user: FakeUser, reason: str) -> None:
+        self.target = SimpleNamespace(id=target_id)
+        self.changes = SimpleNamespace(after=SimpleNamespace(communication_disabled_until=True))
+        self.user = user
+        self.reason = reason
+
+
+class FakeGeneratedResponse:
+    def __init__(self, *, output_text: str) -> None:
+        self.output_text = output_text
 
 
 def _thread_output(
@@ -199,7 +262,9 @@ async def test_video_deliver_and_download_branches(
     await cog._deliver(
         interaction=interaction, file_size_mb=1.25, file_path=str(small), file_name=small.name
     )
-    assert interaction.followup.sent[0]["content"].startswith("✅ 下載成功")
+    success_content = interaction.followup.sent[0]["content"]
+    assert isinstance(success_content, str)
+    assert success_content.startswith("✅ 下載成功")
     assert interaction.edits[-1]["content"] == "✅"
 
     downloader = DownloaderStub(
@@ -207,7 +272,9 @@ async def test_video_deliver_and_download_branches(
     )
     monkeypatch.setattr(video, "VideoDownloader", lambda output_folder: downloader)
     retry_interaction = FakeInteraction()
-    await VideoCogs.download_video.callback(cog, retry_interaction, url="https://x.test", quality="best")
+    await VideoCogs.download_video.callback(
+        cog, retry_interaction, url="https://x.test", quality="best"
+    )
     assert [call["quality"] for call in downloader.calls] == ["best", "low"]
     assert retry_interaction.followup.sent[-1]["file"] is not None
 
@@ -217,7 +284,9 @@ async def test_video_deliver_and_download_branches(
         "VideoDownloader",
         lambda output_folder: DownloaderStub(results=[DownloadResultStub(filename=big)]),
     )
-    await VideoCogs.download_video.callback(cog, fail_interaction, url="https://x.test", quality="low")
+    await VideoCogs.download_video.callback(
+        cog, fail_interaction, url="https://x.test", quality="low"
+    )
     assert "檔案大小超過" in fail_interaction.edits[-1]["content"]
 
     monkeypatch.setattr(video, "VideoDownloader", lambda output_folder: _RaiseDownloader())
@@ -229,7 +298,7 @@ async def test_video_deliver_and_download_branches(
 
 
 class _RaiseDownloader:
-    def download(self, **kwargs: object) -> DownloadResultStub:
+    def download(self, *, url: str, quality: str, dry_run: bool = False) -> DownloadResultStub:
         raise RuntimeError("download failed")
 
 
@@ -240,7 +309,9 @@ async def test_threads_cog_builds_embeds_and_handles_messages(tmp_path: Path) ->
     video_file.write_bytes(data=b"123")
 
     parent = _thread_output(text="parent", video_urls=["https://example.test/video.mp4"])
-    target = _thread_output(image_urls=["https://example.test/1.png", "https://example.test/2.png"])
+    target = _thread_output(
+        image_urls=["https://example.test/1.png", "https://example.test/2.png"]
+    )
     embeds = cog._build_embeds(results=[parent, target])
     assert len(embeds) == 3
     assert "點此觀看影片" in embeds[0].description
@@ -287,7 +358,7 @@ async def test_auto_unmute_tracks_audit_and_generates_reply(
     monkeypatch.setenv(name="OPENAI_BASE_URL", value="https://example.test/v1")
     monkeypatch.setenv(name="OPENAI_API_KEY", value="test-key")
     sent: list[str] = []
-    channel = SimpleNamespace(send=lambda content: _append_async(sent, content))
+    channel = FakeSendChannel(sent=sent)
     bot_user = FakeUser(user_id=999, name="bot", display_name="Bot")
     bot = SimpleNamespace(user=bot_user)
     cog = AutoUnmuteCogs(bot=bot)
@@ -297,7 +368,7 @@ async def test_auto_unmute_tracks_audit_and_generates_reply(
         name="Guild",
         get_channel=lambda channel_id: channel,
         system_channel=None,
-        audit_logs=lambda **kwargs: _audit_entries(bot_user),
+        audit_logs=lambda action, limit: _audit_entries(bot_user),
     )
     await cog.on_message(
         message=SimpleNamespace(
@@ -306,14 +377,14 @@ async def test_auto_unmute_tracks_audit_and_generates_reply(
     )
     assert cog._last_active_channel == {123: 456}
 
-    monkeypatch.setattr(auto_unmute.nextcord.abc, "Messageable", object)
+    monkeypatch.setattr(auto_unmute.nextcord.abc, "Messageable", FakeSendChannel)
     assert cog._resolve_channel(guild=guild) is channel
     moderator, reason = await cog._lookup_audit(guild=guild)
     assert moderator.name == "moderator"
     assert reason == "testing"
 
     cog.__dict__["client"] = SimpleNamespace(
-        responses=SimpleNamespace(create=lambda **kwargs: _response_async("not today"))
+        responses=SimpleNamespace(create=_create_auto_unmute_response)
     )
     reply = await cog._generate_reply(
         guild_name="Guild",
@@ -334,32 +405,34 @@ async def test_auto_unmute_tracks_audit_and_generates_reply(
 
     before = SimpleNamespace(communication_disabled_until=None)
     after = member
-    handled: list[object] = []
-    monkeypatch.setattr(cog, "_handle_self_timeout", lambda **kwargs: _append_async(handled, kwargs))
+    handled: list[SelfTimeoutCall] = []
+
+    async def record_self_timeout(*, member: SimpleNamespace, until: datetime) -> None:
+        handled.append({"member": member, "until": until})
+
+    monkeypatch.setattr(cog, "_handle_self_timeout", record_self_timeout)
     await cog.on_member_update(before=before, after=after)
     assert handled
 
 
-async def _audit_entries(bot_user: FakeUser) -> AsyncIterator[object]:
-    yield SimpleNamespace(
-        target=SimpleNamespace(id=111),
-        changes=SimpleNamespace(after=SimpleNamespace(communication_disabled_until=True)),
-        user=FakeUser(name="wrong"),
-        reason="wrong",
-    )
-    yield SimpleNamespace(
-        target=SimpleNamespace(id=bot_user.id),
-        changes=SimpleNamespace(after=SimpleNamespace(communication_disabled_until=True)),
-        user=FakeUser(name="moderator"),
-        reason="testing",
-    )
+async def _audit_entries(bot_user: FakeUser) -> AsyncIterator[FakeAuditEntry]:
+    yield FakeAuditEntry(target_id=111, user=FakeUser(name="wrong"), reason="wrong")
+    yield FakeAuditEntry(target_id=bot_user.id, user=FakeUser(name="moderator"), reason="testing")
 
 
-async def _response_async(output_text: str) -> object:
-    return SimpleNamespace(output_text=output_text)
+async def _create_auto_unmute_response(  # noqa: PLR0913 -- mirrors Responses API call shape
+    model: str,
+    instructions: str,
+    input: list[dict[str, str]],  # noqa: A002 -- OpenAI SDK parameter name
+    reasoning: dict[str, str],
+    service_tier: str,
+    extra_headers: dict[str, str],
+    extra_body: dict[str, bool],
+) -> FakeGeneratedResponse:
+    return FakeGeneratedResponse(output_text="not today")
 
 
-async def _append_async(container: list[object], item: object) -> None:
+async def _append_async[T](container: list[T], item: T) -> None:
     container.append(item)
 
 
@@ -368,25 +441,25 @@ async def _async_none() -> None:
 
 
 async def test_economy_commands_use_database_facade(monkeypatch: pytest.MonkeyPatch) -> None:
-    scheduled: list[object] = []
-    monkeypatch.setattr(
-        economy, "schedule_game_message_delete", lambda **kwargs: scheduled.append(kwargs["message"])
-    )
-    monkeypatch.setattr(economy, "get_balance", lambda user_id: _value_async(150))
-    monkeypatch.setattr(economy, "top_n", lambda **kwargs: _value_async([(1, "alice", 150)]))
-    monkeypatch.setattr(economy, "get_account", lambda user_id: _value_async(("Bot", -50, 100, 150)))
-    monkeypatch.setattr(
-        economy,
-        "transfer",
-        lambda **kwargs: _value_async(database.TransferResult(sender_balance=50, receiver_balance=100)),
-    )
+    scheduled: list[FakeDiscordMessage] = []
+
+    def record_scheduled(*, message: FakeDiscordMessage) -> None:
+        scheduled.append(message)
+
+    monkeypatch.setattr(economy, "schedule_game_message_delete", record_scheduled)
+    monkeypatch.setattr(economy, "get_balance", fake_get_balance)
+    monkeypatch.setattr(economy, "top_n", fake_top_n)
+    monkeypatch.setattr(economy, "get_account", fake_get_account)
+    monkeypatch.setattr(economy, "transfer", fake_transfer)
     bot = SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer"))
     cog = EconomyCogs(bot=bot)
     interaction = FakeInteraction(user=FakeUser(user_id=1))
     await EconomyCogs.balance.callback(cog, interaction)
     await EconomyCogs.leaderboard.callback(cog, interaction)
     await EconomyCogs.house.callback(cog, interaction)
-    await EconomyCogs.give.callback(cog, interaction, member=FakeUser(user_id=2, name="bob"), amount=100)
+    await EconomyCogs.give.callback(
+        cog, interaction, member=FakeUser(user_id=2, name="bob"), amount=100
+    )
     assert len(interaction.followup.sent) == 4
     assert scheduled
 
@@ -397,37 +470,90 @@ async def test_economy_commands_use_database_facade(monkeypatch: pytest.MonkeyPa
     assert "不能把" in bot_receiver.followup.sent[0]["embed"].description
 
 
-async def _value_async(value: object) -> object:
-    return value
+async def fake_get_balance(user_id: int) -> int:
+    return 150
 
 
-async def test_games_commands_run_with_patched_settlement(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def fake_top_n(
+    limit: int, exclude_user_ids: tuple[int, ...] = ()
+) -> list[tuple[int, str, int]]:
+    return [(1, "alice", 150)]
+
+
+async def fake_get_account(user_id: int) -> tuple[str, int, int, int]:
+    return ("Bot", -50, 100, 150)
+
+
+async def fake_transfer(
+    sender_id: int, sender_name: str, receiver_id: int, receiver_name: str, amount: int
+) -> database.TransferResult:
+    return database.TransferResult(sender_balance=50, receiver_balance=100)
+
+
+async def fake_sleep(delay: float) -> None:
+    return
+
+
+def ignore_scheduled_game_message(message: FakeDiscordMessage) -> None:
+    return
+
+
+async def fake_place_bet(user_id: int, name: str, requested_bet: int) -> database.PlacedBet:
+    return database.PlacedBet(amount=10, balance_after=90, is_allin=False)
+
+
+async def fake_zero_balance(user_id: int) -> int:
+    return 0
+
+
+async def fake_settle_wager(  # noqa: PLR0913 -- mirrors settlement helper signature
+    player_id: int,
+    player_account_name: str,
+    dealer_id: int,
+    dealer_name: str,
+    bet: int,
+    delta: int,
+) -> SimpleNamespace:
+    return SimpleNamespace(delta=10, new_balance=110, house_balance=-10)
+
+
+async def fake_settle_blackjack_round(
+    hand: BlackjackHand, player_id: int, player_account_name: str, dealer_id: int, dealer_name: str
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        outcome="win", delta=15, new_balance=115, house_balance=-15, detail="natural"
+    )
+
+
+class FakeDealer:
+    async def taunt_bet(
+        self, author_name: str, player_name: str, balance_after_bet: int, bet: int, game: str
+    ) -> str:
+        return "taunt"
+
+    async def settle(  # noqa: PLR0913 -- mirrors DealerAI.settle signature
+        self,
+        author_name: str,
+        player_name: str,
+        outcome: str,
+        bet: int,
+        delta: int,
+        new_balance: int,
+        game: str,
+        detail: str,
+    ) -> str:
+        return "settled"
+
+
+async def test_games_commands_run_with_patched_settlement(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(name="OPENAI_BASE_URL", value="https://example.test/v1")
     monkeypatch.setenv(name="OPENAI_API_KEY", value="test-key")
-    monkeypatch.setattr(games.asyncio, "sleep", lambda *args, **kwargs: _async_none())
-    monkeypatch.setattr(games, "schedule_game_message_delete", lambda message: None)
-    monkeypatch.setattr(
-        games,
-        "place_bet",
-        lambda **kwargs: _value_async(database.PlacedBet(amount=10, balance_after=90, is_allin=False)),
-    )
-    monkeypatch.setattr(games, "get_balance", lambda user_id: _value_async(0))
-    monkeypatch.setattr(
-        games,
-        "settle_wager",
-        lambda **kwargs: _value_async(SimpleNamespace(delta=10, new_balance=110, house_balance=-10)),
-    )
-    monkeypatch.setattr(
-        games,
-        "settle_blackjack_round",
-        lambda **kwargs: _value_async(
-            SimpleNamespace(
-                outcome="win", delta=15, new_balance=115, house_balance=-15, detail="natural"
-            )
-        ),
-    )
+    monkeypatch.setattr(games.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(games, "schedule_game_message_delete", ignore_scheduled_game_message)
+    monkeypatch.setattr(games, "place_bet", fake_place_bet)
+    monkeypatch.setattr(games, "get_balance", fake_zero_balance)
+    monkeypatch.setattr(games, "settle_wager", fake_settle_wager)
+    monkeypatch.setattr(games, "settle_blackjack_round", fake_settle_blackjack_round)
     hand = BlackjackHand(rng=games.SystemRandom(), bet=10)
     hand.player = [Card(rank="A", suit="♠"), Card(rank="K", suit="♣")]
     hand.dealer = [Card(rank="9", suit="♠"), Card(rank="8", suit="♣")]
@@ -437,13 +563,14 @@ async def test_games_commands_run_with_patched_settlement(
         return None
 
     hand.deal_initial = fake_deal_initial
-    monkeypatch.setattr(games, "BlackjackHand", lambda **kwargs: hand)
+
+    def fake_blackjack_hand(rng: games.SystemRandom, bet: int) -> BlackjackHand:
+        return hand
+
+    monkeypatch.setattr(games, "BlackjackHand", fake_blackjack_hand)
 
     cog = GamesCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
-    cog.__dict__["dealer"] = SimpleNamespace(
-        taunt_bet=lambda **kwargs: _value_async("taunt"),
-        settle=lambda **kwargs: _value_async("settled"),
-    )
+    cog.__dict__["dealer"] = FakeDealer()
 
     dice_interaction = FakeInteraction(user=FakeUser(user_id=1))
     await GamesCogs.dice.callback(cog, dice_interaction, bet=10)
@@ -459,8 +586,20 @@ async def test_games_commands_run_with_patched_settlement(
 
 
 def test_setup_functions_register_cogs(monkeypatch: pytest.MonkeyPatch) -> None:
-    added: list[tuple[object, bool | None]] = []
-    bot = SimpleNamespace(add_cog=lambda cog, override=None: added.append((cog, override)))
+    added: list[
+        tuple[
+            VideoCogs | GamesCogs | EconomyCogs | TemplateCogs | ThreadsCogs | AutoUnmuteCogs,
+            bool | None,
+        ]
+    ] = []
+
+    def record_cog(
+        cog: VideoCogs | GamesCogs | EconomyCogs | TemplateCogs | ThreadsCogs | AutoUnmuteCogs,
+        override: bool | None = None,
+    ) -> None:
+        added.append((cog, override))
+
+    bot = SimpleNamespace(add_cog=record_cog)
     for module in [video, games, economy, template, parse_threads, auto_unmute]:
         monkeypatch.setenv(name="OPENAI_BASE_URL", value="https://example.test/v1")
         monkeypatch.setenv(name="OPENAI_API_KEY", value="test-key")
@@ -476,30 +615,37 @@ def test_setup_functions_register_cogs(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_cli_loads_cogs_and_handles_command_errors(tmp_path: Path) -> None:
-    loaded: list[object] = []
-    bot = SimpleNamespace(
-        load_extensions=lambda modules, stop_at_error: loaded.append((modules, stop_at_error))
-    )
+    loaded: list[tuple[list[str], bool]] = []
+
+    def record_load_extensions(modules: list[str], stop_at_error: bool) -> None:
+        loaded.append((modules, stop_at_error))
+
+    bot = SimpleNamespace(load_extensions=record_load_extensions)
     cli.DiscordBot._load_cogs_sync(bot)
     assert loaded[0][1] is True
     assert "discordbot.cogs.template" in loaded[0][0]
 
 
 async def test_cli_message_and_command_error_branches() -> None:
-    processed: list[object] = []
-    bot = SimpleNamespace(
-        user=FakeUser(user_id=999, bot=True),
-        process_commands=lambda message: _append_async(processed, message),
-    )
+    processed: list[SimpleNamespace] = []
+
+    async def record_processed(message: SimpleNamespace) -> None:
+        processed.append(message)
+
+    bot = SimpleNamespace(user=FakeUser(user_id=999, bot=True), process_commands=record_processed)
     user_message = SimpleNamespace(author=FakeUser(user_id=1, bot=False))
     await cli.DiscordBot.on_message(bot, message=user_message)
     assert processed == [user_message]
     await cli.DiscordBot.on_message(bot, message=SimpleNamespace(author=bot.user))
     assert len(processed) == 1
 
-    sent: list[dict[str, object]] = []
+    sent: list[DiscordPayload] = []
+
+    async def record_context_send(**kwargs: Unpack[DiscordPayload]) -> None:
+        sent.append(kwargs)
+
     context = SimpleNamespace(
-        send=lambda **kwargs: _append_async(sent, kwargs),
+        send=record_context_send,
         guild=SimpleNamespace(name="Guild", id=1),
         author=FakeUser(user_id=1),
     )

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -1,17 +1,51 @@
+from __future__ import annotations
+
 from io import BytesIO
 from types import SimpleNamespace
 import base64
-from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Unpack, Literal, TypedDict
 
 from PIL import Image
 import pytest
-from nextcord import Embed
-from nextcord.ui import View
+from nextcord import File, Embed
 
 from discordbot.cogs.gen_reply import _USAGE_FOOTER_RE, ReplyGeneratorCogs
-from discordbot.typings.models import ModelSettings
+from discordbot.typings.models import ModelSettings, RouteDecision
 from discordbot.cogs._gen_reply.views import RegenerateView
 from discordbot.cogs._gen_reply.exceptions import extract_friendly_error
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from nextcord.ui import View
+
+
+class FakeGuild:
+    def __init__(self, guild_id: int = 1) -> None:
+        self.id = guild_id
+
+
+class FakeReference:
+    def __init__(self, resolved: FakeMessage) -> None:
+        self.resolved = resolved
+
+
+class FakeReaction:
+    def __init__(self, *, me: bool, emoji: str) -> None:
+        self.me = me
+        self.emoji = emoji
+
+
+class ReplyPayload(TypedDict, total=False):
+    content: str | None
+    view: View
+    file: File
+    embed: Embed
+
+
+class InteractionReplyPayload(TypedDict, total=False):
+    content: str
+    ephemeral: bool
 
 
 class FakeReply:
@@ -21,6 +55,8 @@ class FakeReply:
         """Initializes the fake reply with empty content and no attached view."""
         self.content: str | None = ""
         self.view: View | None = None
+        self.file: File | None = None
+        self.embed: Embed | None = None
 
     async def edit(self, *, content: str, view: View | None = None) -> None:
         """Records the replacement content and view passed to edit."""
@@ -49,20 +85,20 @@ class FakeMessage:
         self.author = author or FakeAuthor()
         self.content = content
         self.embeds: list[Embed] = []
-        self.attachments: list[object] = []
-        self.stickers: list[object] = []
-        self.reference: object | None = None
-        self.guild = SimpleNamespace(id=1)
+        self.attachments: list[FakeAttachment] = []
+        self.stickers: list[FakeAttachment] = []
+        self.reference: FakeReference | None = None
+        self.guild: FakeGuild | None = FakeGuild()
         self.channel = SimpleNamespace(history=self._history)
         self.id = 987
         self.system_content = ""
         self.added_reactions: list[str] = []
-        self.removed_reactions: list[tuple[str, object]] = []
-        self.reactions: list[object] = []
+        self.removed_reactions: list[tuple[str, FakeAuthor]] = []
+        self.reactions: list[FakeReaction] = []
 
     async def _history(
-        self, *, limit: int, before: object, oldest_first: bool
-    ) -> AsyncIterator["FakeMessage"]:
+        self, *, limit: int, before: FakeMessage, oldest_first: bool
+    ) -> AsyncIterator[FakeMessage]:
         if False:
             yield self
 
@@ -71,7 +107,7 @@ class FakeMessage:
         *,
         content: str | None,
         view: View | None = None,
-        file: object | None = None,
+        file: File | None = None,
         embed: Embed | None = None,
     ) -> FakeReply:
         """Creates and records a fake reply with the requested content and view."""
@@ -86,7 +122,7 @@ class FakeMessage:
     async def add_reaction(self, *, emoji: str) -> None:
         self.added_reactions.append(emoji)
 
-    async def remove_reaction(self, *, emoji: str, member: object) -> None:
+    async def remove_reaction(self, *, emoji: str, member: FakeAuthor) -> None:
         self.removed_reactions.append((emoji, member))
 
     def is_system(self) -> bool:
@@ -113,31 +149,75 @@ class FakeAttachment:
 
 class FakeResponses:
     def __init__(self) -> None:
-        self.create_calls: list[dict[str, object]] = []
-        self.parse_calls: list[dict[str, object]] = []
+        self.create_streams: list[bool] = []
+        self.parse_models: list[str] = []
         self.output_text = "caption"
         self.output_parsed = SimpleNamespace(decision="SUMMARY")
 
-    async def create(self, **kwargs: object) -> object:
-        self.create_calls.append(kwargs)
+    async def create(  # noqa: PLR0913 -- mirrors Responses API create signature
+        self,
+        *,
+        model: str,
+        instructions: str,
+        input: list[dict[str, str | list[dict[str, str]]]],  # noqa: A002 -- SDK parameter
+        reasoning: dict[str, str],
+        service_tier: str,
+        extra_headers: dict[str, str],
+        extra_body: dict[str, bool],
+        stream: bool = False,
+        tools: list[dict[str, str | dict[str, str]]] | None = None,
+    ) -> SimpleNamespace:
+        self.create_streams.append(stream)
         return SimpleNamespace(output_text=self.output_text)
 
-    async def parse(self, **kwargs: object) -> object:
-        self.parse_calls.append(kwargs)
+    async def parse(  # noqa: PLR0913 -- mirrors Responses API parse signature
+        self,
+        *,
+        model: str,
+        instructions: str,
+        input: list[dict[str, str | list[dict[str, str]]]],  # noqa: A002 -- SDK parameter
+        text_format: type[RouteDecision],
+        reasoning: dict[str, str],
+        service_tier: str,
+        extra_headers: dict[str, str],
+        extra_body: dict[str, bool],
+    ) -> SimpleNamespace:
+        self.parse_models.append(model)
         return SimpleNamespace(output_parsed=self.output_parsed)
 
 
 class FakeImages:
     def __init__(self) -> None:
-        self.generate_calls: list[dict[str, object]] = []
-        self.edit_calls: list[dict[str, object]] = []
+        self.generate_calls = 0
+        self.edit_calls = 0
 
-    async def generate(self, **kwargs: object) -> object:
-        self.generate_calls.append(kwargs)
+    async def generate(  # noqa: PLR0913 -- mirrors Images API generate signature
+        self,
+        *,
+        prompt: str,
+        model: str,
+        n: int,
+        response_format: Literal["b64_json"],
+        quality: str,
+        size: str,
+        extra_headers: dict[str, str],
+    ) -> SimpleNamespace:
+        self.generate_calls += 1
         return SimpleNamespace(data=[SimpleNamespace(b64_json=_png_b64())])
 
-    async def edit(self, **kwargs: object) -> object:
-        self.edit_calls.append(kwargs)
+    async def edit(  # noqa: PLR0913 -- mirrors Images API edit signature
+        self,
+        *,
+        image: list[bytes],
+        prompt: str,
+        model: str,
+        n: int,
+        response_format: Literal["b64_json"],
+        quality: str,
+        size: str,
+        extra_headers: dict[str, str],
+    ) -> SimpleNamespace:
+        self.edit_calls += 1
         return SimpleNamespace(data=[SimpleNamespace(b64_json=_png_b64())])
 
 
@@ -145,14 +225,18 @@ class FakeVideos:
     def __init__(self) -> None:
         self.retrieve_calls = 0
 
-    async def create(self, **kwargs: object) -> object:
+    async def create(
+        self, *, model: str, prompt: str, extra_headers: dict[str, str]
+    ) -> SimpleNamespace:
         return SimpleNamespace(id="video-1", status="processing")
 
-    async def retrieve(self, **kwargs: object) -> object:
+    async def retrieve(self, *, video_id: str, extra_headers: dict[str, str]) -> SimpleNamespace:
         self.retrieve_calls += 1
         return SimpleNamespace(id="video-1", status="completed")
 
-    async def download_content(self, **kwargs: object) -> object:
+    async def download_content(
+        self, *, video_id: str, extra_headers: dict[str, str]
+    ) -> SimpleNamespace:
         return SimpleNamespace(content=b"mp4")
 
 
@@ -231,7 +315,7 @@ async def test_regenerate_view_restricts_user_and_dispatches_original_message() 
     async def fake_on_message(*, message: FakeMessage) -> None:
         called.append(message)
 
-    async def fake_send_message(**kwargs: object) -> None:
+    async def fake_send_message(**kwargs: Unpack[InteractionReplyPayload]) -> None:
         denied.append(kwargs)
 
     class _ReplyMessage:
@@ -241,23 +325,21 @@ async def test_regenerate_view_restricts_user_and_dispatches_original_message() 
         async def delete(self) -> None:
             self.deleted = True
 
-    denied: list[dict[str, object]] = []
+    denied: list[InteractionReplyPayload] = []
     original = FakeMessage(author=FakeAuthor(user_id=10))
-    original.reactions = [SimpleNamespace(me=True, emoji="🆗"), SimpleNamespace(me=False, emoji="x")]
-    cog = SimpleNamespace(
-        bot=SimpleNamespace(user=SimpleNamespace(id=999)), on_message=fake_on_message
-    )
+    original.reactions = [FakeReaction(me=True, emoji="🆗"), FakeReaction(me=False, emoji="x")]
+    bot_user = FakeAuthor(bot=True, user_id=999)
+    cog = SimpleNamespace(bot=SimpleNamespace(user=bot_user), on_message=fake_on_message)
     view = RegenerateView(cog=cog, original_message=original)
     denied_interaction = SimpleNamespace(
-        user=SimpleNamespace(id=11),
-        response=SimpleNamespace(send_message=fake_send_message),
+        user=FakeAuthor(user_id=11), response=SimpleNamespace(send_message=fake_send_message)
     )
     assert await view.interaction_check(interaction=denied_interaction) is False
     assert denied[0]["ephemeral"] is True
 
     reply_message = _ReplyMessage()
     allowed_interaction = SimpleNamespace(
-        user=SimpleNamespace(id=10),
+        user=FakeAuthor(user_id=10),
         message=reply_message,
         response=SimpleNamespace(defer=_async_none),
     )
@@ -310,19 +392,27 @@ async def test_gen_reply_message_content_and_attachment_helpers(
     assert file_part["file_data"] == "data:text/plain;base64,YWJj"
 
     image_part = await cog._image_to_part(
-        source=FakeAttachment(filename="pixel.png", content_type="image/png", payload=base64.b64decode(_png_b64()))
+        source=FakeAttachment(
+            filename="pixel.png", content_type="image/png", payload=base64.b64decode(_png_b64())
+        )
     )
     assert image_part is not None
     assert image_part["type"] == "input_image"
 
-    monkeypatch.setattr("discordbot.cogs.gen_reply.get_supported_modalities", lambda model_name: {"image"})
+    monkeypatch.setattr(
+        "discordbot.cogs.gen_reply.get_supported_modalities", lambda model_name: {"image"}
+    )
     message = FakeMessage()
     message.attachments = [
-        FakeAttachment(filename="pixel.png", content_type="image/png", payload=base64.b64decode(_png_b64())),
+        FakeAttachment(
+            filename="pixel.png", content_type="image/png", payload=base64.b64decode(_png_b64())
+        ),
         FakeAttachment(filename="clip.mp4", content_type="video/mp4", payload=b"video"),
     ]
     message.stickers = [
-        FakeAttachment(filename="sticker.png", content_type="image/png", payload=base64.b64decode(_png_b64()))
+        FakeAttachment(
+            filename="sticker.png", content_type="image/png", payload=base64.b64decode(_png_b64())
+        )
     ]
     img_embed = Embed()
     img_embed.set_image(url="https://example.test/image.png")
@@ -355,7 +445,9 @@ async def test_gen_reply_processes_history_reference_and_current_messages(
     assert attachment_processed["role"] == "user"
     assert isinstance(attachment_processed["content"], list)
 
-    async def fake_history(*, limit: int, before: object, oldest_first: bool) -> AsyncIterator[FakeMessage]:
+    async def fake_history(
+        *, limit: int, before: FakeMessage, oldest_first: bool
+    ) -> AsyncIterator[FakeMessage]:
         yield user_msg
         yield bot_msg
 
@@ -369,8 +461,8 @@ async def test_gen_reply_processes_history_reference_and_current_messages(
     grandparent = FakeMessage(content="grandparent", author=FakeAuthor(user_id=5))
     parent.id = 988
     grandparent.id = 989
-    parent.reference = SimpleNamespace(resolved=grandparent)
-    current.reference = SimpleNamespace(resolved=parent)
+    parent.reference = FakeReference(resolved=grandparent)
+    current.reference = FakeReference(resolved=parent)
     monkeypatch.setattr("discordbot.cogs.gen_reply.Message", FakeMessage)
     reference = await cog._get_reference_message(message=current)
     assert len(reference) == 4
@@ -382,9 +474,9 @@ async def test_gen_reply_routes_and_handlers_without_api(monkeypatch: pytest.Mon
     cog = _cog()
     message = FakeMessage(content="make a summary", author=FakeAuthor(user_id=1))
     assert await cog._route_message(message=message) == "SUMMARY"
-    assert cog.client.responses.parse_calls[0]["model"] == cog.fast_model.name
+    assert cog.client.responses.parse_models[0] == cog.fast_model.name
 
-    async def fake_sleep(*args: object, delay: float = 0) -> None:
+    async def fake_sleep(delay: float) -> None:
         return None
 
     monkeypatch.setattr("discordbot.cogs.gen_reply.asyncio.sleep", fake_sleep)
@@ -393,19 +485,22 @@ async def test_gen_reply_routes_and_handlers_without_api(monkeypatch: pytest.Mon
 
     await cog._handle_image_reply(message=message, user_prompt="image")
     assert cog.client.images.generate_calls
+    assert isinstance(message.replies[-1].content, str)
     assert message.replies[-1].content.startswith("<@1> caption")
 
-    async def fake_streaming(**kwargs: object) -> str:
-        streamed.append(kwargs)
+    async def fake_streaming(
+        *, responses: SimpleNamespace, message: FakeMessage, view: View | None = None
+    ) -> str:
+        streamed.append(message)
         return "done"
 
-    streamed: list[dict[str, object]] = []
+    streamed: list[FakeMessage] = []
     monkeypatch.setattr(cog, "_handle_streaming", fake_streaming)
     await cog._handle_message_reply(
         message=message, system_prompt="system", context_prompt="context", history_limit=2
     )
-    assert cog.client.responses.create_calls[-1]["stream"] is True
-    assert streamed[-1]["message"] is message
+    assert cog.client.responses.create_streams[-1] is True
+    assert streamed[-1] is message
 
 
 @pytest.mark.parametrize(
@@ -421,27 +516,46 @@ async def test_gen_reply_on_message_dispatches_routes(
     monkeypatch: pytest.MonkeyPatch, route: str, expected_call: str
 ) -> None:
     cog = _cog()
-    calls: list[tuple[str, dict[str, object]]] = []
+    calls: list[str] = []
 
     async def fake_route(*, message: FakeMessage) -> str:
         return route
 
-    async def fake_reaction(**kwargs: object) -> None:
-        calls.append(("reaction", kwargs))
+    async def fake_reaction(
+        *, message: FakeMessage, emoji: str, previous: str | None = None
+    ) -> None:
+        calls.append(f"reaction:{emoji}")
 
-    async def fake_handler(**kwargs: object) -> None:
-        calls.append((expected_call, kwargs))
+    async def fake_image_handler(
+        *, message: FakeMessage, user_prompt: str, view: View | None = None
+    ) -> None:
+        calls.append("_handle_image_reply")
+
+    async def fake_video_handler(
+        *, message: FakeMessage, user_prompt: str, view: View | None = None
+    ) -> None:
+        calls.append("_handle_video_generation")
+
+    async def fake_message_handler(
+        *,
+        message: FakeMessage,
+        system_prompt: str,
+        context_prompt: str,
+        history_limit: int,
+        view: View | None = None,
+    ) -> None:
+        calls.append("_handle_message_reply")
 
     monkeypatch.setattr(cog, "_route_message", fake_route)
     monkeypatch.setattr(cog, "_handle_reaction", fake_reaction)
-    monkeypatch.setattr(cog, "_handle_image_reply", fake_handler)
-    monkeypatch.setattr(cog, "_handle_video_generation", fake_handler)
-    monkeypatch.setattr(cog, "_handle_message_reply", fake_handler)
+    monkeypatch.setattr(cog, "_handle_image_reply", fake_image_handler)
+    monkeypatch.setattr(cog, "_handle_video_generation", fake_video_handler)
+    monkeypatch.setattr(cog, "_handle_message_reply", fake_message_handler)
 
     message = FakeMessage(content="<@999> hello", author=FakeAuthor(user_id=1))
     await cog.on_message(message=message)
-    assert any(call[0] == expected_call for call in calls)
-    assert calls[-1][1]["emoji"] == "🆗"
+    assert expected_call in calls
+    assert calls[-1] == "reaction:🆗"
 
 
 async def test_gen_reply_on_message_early_returns_and_errors(

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -1,10 +1,17 @@
+from io import BytesIO
 from types import SimpleNamespace
+import base64
 from collections.abc import AsyncIterator
 
+from PIL import Image
 import pytest
+from nextcord import Embed
 from nextcord.ui import View
 
-from discordbot.cogs.gen_reply import ReplyGeneratorCogs
+from discordbot.cogs.gen_reply import _USAGE_FOOTER_RE, ReplyGeneratorCogs
+from discordbot.typings.models import ModelSettings
+from discordbot.cogs._gen_reply.views import RegenerateView
+from discordbot.cogs._gen_reply.exceptions import extract_friendly_error
 
 
 class FakeReply:
@@ -12,7 +19,7 @@ class FakeReply:
 
     def __init__(self) -> None:
         """Initializes the fake reply with empty content and no attached view."""
-        self.content = ""
+        self.content: str | None = ""
         self.view: View | None = None
 
     async def edit(self, *, content: str, view: View | None = None) -> None:
@@ -24,27 +31,150 @@ class FakeReply:
 class FakeAuthor:
     """Minimal stand-in for ``Message.author`` used by the streaming helper."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, bot: bool = False, user_id: int = 12345) -> None:
         """Initializes the fake author with stable id and name fields."""
-        self.id = 12345
+        self.id = user_id
         self.name = "tester"
+        self.display_name = "Tester"
+        self.mention = f"<@{user_id}>"
+        self.bot = bot
 
 
 class FakeMessage:
     """Provides a fake message object that records created replies."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, content: str = "", author: FakeAuthor | None = None) -> None:
         """Initializes the fake message with no recorded replies."""
         self.replies: list[FakeReply] = []
-        self.author = FakeAuthor()
+        self.author = author or FakeAuthor()
+        self.content = content
+        self.embeds: list[Embed] = []
+        self.attachments: list[object] = []
+        self.stickers: list[object] = []
+        self.reference: object | None = None
+        self.guild = SimpleNamespace(id=1)
+        self.channel = SimpleNamespace(history=self._history)
+        self.id = 987
+        self.system_content = ""
+        self.added_reactions: list[str] = []
+        self.removed_reactions: list[tuple[str, object]] = []
+        self.reactions: list[object] = []
 
-    async def reply(self, *, content: str, view: View | None = None) -> FakeReply:
+    async def _history(
+        self, *, limit: int, before: object, oldest_first: bool
+    ) -> AsyncIterator["FakeMessage"]:
+        if False:
+            yield self
+
+    async def reply(
+        self,
+        *,
+        content: str | None,
+        view: View | None = None,
+        file: object | None = None,
+        embed: Embed | None = None,
+    ) -> FakeReply:
         """Creates and records a fake reply with the requested content and view."""
         reply = FakeReply()
         reply.content = content
         reply.view = view
+        reply.file = file
+        reply.embed = embed
         self.replies.append(reply)
         return reply
+
+    async def add_reaction(self, *, emoji: str) -> None:
+        self.added_reactions.append(emoji)
+
+    async def remove_reaction(self, *, emoji: str, member: object) -> None:
+        self.removed_reactions.append((emoji, member))
+
+    def is_system(self) -> bool:
+        return bool(self.system_content)
+
+
+class FakeAttachment:
+    def __init__(
+        self,
+        *,
+        filename: str = "file.txt",
+        content_type: str | None = "text/plain",
+        payload: bytes = b"hello",
+        url: str = "https://example.test/file.txt",
+    ) -> None:
+        self.filename = filename
+        self.content_type = content_type
+        self._payload = payload
+        self.url = url
+
+    async def read(self) -> bytes:
+        return self._payload
+
+
+class FakeResponses:
+    def __init__(self) -> None:
+        self.create_calls: list[dict[str, object]] = []
+        self.parse_calls: list[dict[str, object]] = []
+        self.output_text = "caption"
+        self.output_parsed = SimpleNamespace(decision="SUMMARY")
+
+    async def create(self, **kwargs: object) -> object:
+        self.create_calls.append(kwargs)
+        return SimpleNamespace(output_text=self.output_text)
+
+    async def parse(self, **kwargs: object) -> object:
+        self.parse_calls.append(kwargs)
+        return SimpleNamespace(output_parsed=self.output_parsed)
+
+
+class FakeImages:
+    def __init__(self) -> None:
+        self.generate_calls: list[dict[str, object]] = []
+        self.edit_calls: list[dict[str, object]] = []
+
+    async def generate(self, **kwargs: object) -> object:
+        self.generate_calls.append(kwargs)
+        return SimpleNamespace(data=[SimpleNamespace(b64_json=_png_b64())])
+
+    async def edit(self, **kwargs: object) -> object:
+        self.edit_calls.append(kwargs)
+        return SimpleNamespace(data=[SimpleNamespace(b64_json=_png_b64())])
+
+
+class FakeVideos:
+    def __init__(self) -> None:
+        self.retrieve_calls = 0
+
+    async def create(self, **kwargs: object) -> object:
+        return SimpleNamespace(id="video-1", status="processing")
+
+    async def retrieve(self, **kwargs: object) -> object:
+        self.retrieve_calls += 1
+        return SimpleNamespace(id="video-1", status="completed")
+
+    async def download_content(self, **kwargs: object) -> object:
+        return SimpleNamespace(content=b"mp4")
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.responses = FakeResponses()
+        self.images = FakeImages()
+        self.videos = FakeVideos()
+
+
+def _png_b64() -> str:
+    image = Image.new(mode="RGB", size=(1, 1), color=(255, 0, 0))
+    buffer = BytesIO()
+    image.save(fp=buffer, format="PNG")
+    return base64.b64encode(s=buffer.getvalue()).decode(encoding="utf-8")
+
+
+def _cog(bot_user_id: int = 999) -> ReplyGeneratorCogs:
+    cog = ReplyGeneratorCogs.__new__(ReplyGeneratorCogs)
+    cog.bot = SimpleNamespace(user=SimpleNamespace(id=bot_user_id, name="bot"))
+    cog.__dict__["client"] = FakeClient()
+    return cog
 
 
 async def _stream_events() -> AsyncIterator[SimpleNamespace]:
@@ -86,3 +216,268 @@ async def test_handle_streaming_allows_missing_output_token_details(
     )
     assert result == expected
     assert message.replies[0].content == result
+
+
+def test_extract_friendly_error_prefers_nested_provider_message() -> None:
+    raw = """wrapper b'{"error": {"message": "quota exceeded"}}'"""
+    assert extract_friendly_error(exc=RuntimeError(raw)) == "quota exceeded"
+    assert extract_friendly_error(exc=RuntimeError("plain failure")) == "plain failure"
+    assert extract_friendly_error(exc=RuntimeError("bad b'not json'")) == "bad b'not json'"
+
+
+async def test_regenerate_view_restricts_user_and_dispatches_original_message() -> None:
+    called: list[FakeMessage] = []
+
+    async def fake_on_message(*, message: FakeMessage) -> None:
+        called.append(message)
+
+    async def fake_send_message(**kwargs: object) -> None:
+        denied.append(kwargs)
+
+    class _ReplyMessage:
+        def __init__(self) -> None:
+            self.deleted = False
+
+        async def delete(self) -> None:
+            self.deleted = True
+
+    denied: list[dict[str, object]] = []
+    original = FakeMessage(author=FakeAuthor(user_id=10))
+    original.reactions = [SimpleNamespace(me=True, emoji="🆗"), SimpleNamespace(me=False, emoji="x")]
+    cog = SimpleNamespace(
+        bot=SimpleNamespace(user=SimpleNamespace(id=999)), on_message=fake_on_message
+    )
+    view = RegenerateView(cog=cog, original_message=original)
+    denied_interaction = SimpleNamespace(
+        user=SimpleNamespace(id=11),
+        response=SimpleNamespace(send_message=fake_send_message),
+    )
+    assert await view.interaction_check(interaction=denied_interaction) is False
+    assert denied[0]["ephemeral"] is True
+
+    reply_message = _ReplyMessage()
+    allowed_interaction = SimpleNamespace(
+        user=SimpleNamespace(id=10),
+        message=reply_message,
+        response=SimpleNamespace(defer=_async_none),
+    )
+    assert await view.interaction_check(interaction=allowed_interaction) is True
+    await view.regenerate.callback(allowed_interaction)
+    assert reply_message.deleted
+    assert original.removed_reactions == [("🆗", cog.bot.user)]
+    assert called == [original]
+
+
+async def _async_none() -> None:
+    return None
+
+
+async def test_gen_reply_message_content_and_attachment_helpers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cog = _cog()
+    embed = Embed(title="Title", description="Body")
+    embed.set_author(name="Author")
+    embed.add_field(name="Field", value="Value")
+    embed.set_footer(text="Footer")
+
+    assert await cog._get_user_prompt(content="hi <@999>") == "hi"
+    assert "Author" in cog._extract_embed_text(embeds=[embed])
+
+    bot_message = FakeMessage(
+        content="answer\n\n-# model · ⬆ 1 ⬇ 2 · $0.0 · +3",
+        author=FakeAuthor(bot=True, user_id=999),
+    )
+    assert await cog._get_cleaned_content(message=bot_message) == "answer"
+    assert _USAGE_FOOTER_RE.search(string=bot_message.content)
+
+    embed_message = FakeMessage()
+    embed_message.embeds = [embed]
+    assert "Title" in await cog._get_cleaned_content(message=embed_message)
+
+    system_message = FakeMessage()
+    system_message.system_content = "joined"
+    assert await cog._get_cleaned_content(message=system_message) == "joined"
+
+    assert cog._required_modality(content_type="video/mp4") == "video"
+    assert cog._required_modality(content_type="audio/mpeg") == "audio"
+    assert cog._required_modality(content_type="application/pdf") == "image"
+
+    file_part = await cog._attachment_to_part(
+        attachment=FakeAttachment(filename="note.txt", content_type="text/plain", payload=b"abc")
+    )
+    assert file_part is not None
+    assert file_part["file_data"] == "data:text/plain;base64,YWJj"
+
+    image_part = await cog._image_to_part(
+        source=FakeAttachment(filename="pixel.png", content_type="image/png", payload=base64.b64decode(_png_b64()))
+    )
+    assert image_part is not None
+    assert image_part["type"] == "input_image"
+
+    monkeypatch.setattr("discordbot.cogs.gen_reply.get_supported_modalities", lambda model_name: {"image"})
+    message = FakeMessage()
+    message.attachments = [
+        FakeAttachment(filename="pixel.png", content_type="image/png", payload=base64.b64decode(_png_b64())),
+        FakeAttachment(filename="clip.mp4", content_type="video/mp4", payload=b"video"),
+    ]
+    message.stickers = [
+        FakeAttachment(filename="sticker.png", content_type="image/png", payload=base64.b64decode(_png_b64()))
+    ]
+    img_embed = Embed()
+    img_embed.set_image(url="https://example.test/image.png")
+    message.embeds = [img_embed]
+    monkeypatch.setattr(
+        "discordbot.cogs.gen_reply.get_pil_image",
+        lambda image_file: Image.new(mode="RGB", size=(1, 1), color=(0, 0, 0)),
+    )
+    parts = await cog._get_attachment_parts(message=message)
+    assert [part["type"] for part in parts] == ["input_image", "input_image", "input_image"]
+
+
+async def test_gen_reply_processes_history_reference_and_current_messages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cog = _cog()
+    monkeypatch.setattr(
+        "discordbot.cogs.gen_reply.get_supported_modalities", lambda model_name: {"text", "image"}
+    )
+    bot_msg = FakeMessage(content="bot answer", author=FakeAuthor(bot=True, user_id=999))
+    user_msg = FakeMessage(content="hello", author=FakeAuthor(user_id=1))
+    with_attachment = FakeMessage(content="see file", author=FakeAuthor(user_id=2))
+    with_attachment.attachments = [FakeAttachment(filename="note.txt", content_type="text/plain")]
+
+    bot_processed = await cog._process_single_message(message=bot_msg)
+    user_processed = await cog._process_single_message(message=user_msg)
+    attachment_processed = await cog._process_single_message(message=with_attachment)
+    assert bot_processed["role"] == "assistant"
+    assert user_processed["role"] == "user"
+    assert attachment_processed["role"] == "user"
+    assert isinstance(attachment_processed["content"], list)
+
+    async def fake_history(*, limit: int, before: object, oldest_first: bool) -> AsyncIterator[FakeMessage]:
+        yield user_msg
+        yield bot_msg
+
+    current = FakeMessage(content="current", author=FakeAuthor(user_id=3))
+    current.channel = SimpleNamespace(history=fake_history)
+    history = await cog._get_history_message(message=current, limit=30)
+    assert len(history) == 3
+    assert history[0]["role"] == "system"
+
+    parent = FakeMessage(content="parent", author=FakeAuthor(user_id=4))
+    grandparent = FakeMessage(content="grandparent", author=FakeAuthor(user_id=5))
+    parent.id = 988
+    grandparent.id = 989
+    parent.reference = SimpleNamespace(resolved=grandparent)
+    current.reference = SimpleNamespace(resolved=parent)
+    monkeypatch.setattr("discordbot.cogs.gen_reply.Message", FakeMessage)
+    reference = await cog._get_reference_message(message=current)
+    assert len(reference) == 4
+    assert reference[0]["role"] == "system"
+    assert len(await cog._get_current_message(message=current)) == 2
+
+
+async def test_gen_reply_routes_and_handlers_without_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    cog = _cog()
+    message = FakeMessage(content="make a summary", author=FakeAuthor(user_id=1))
+    assert await cog._route_message(message=message) == "SUMMARY"
+    assert cog.client.responses.parse_calls[0]["model"] == cog.fast_model.name
+
+    async def fake_sleep(*args: object, delay: float = 0) -> None:
+        return None
+
+    monkeypatch.setattr("discordbot.cogs.gen_reply.asyncio.sleep", fake_sleep)
+    await cog._handle_video_generation(message=message, user_prompt="video")
+    assert len(message.replies) == 1
+
+    await cog._handle_image_reply(message=message, user_prompt="image")
+    assert cog.client.images.generate_calls
+    assert message.replies[-1].content.startswith("<@1> caption")
+
+    async def fake_streaming(**kwargs: object) -> str:
+        streamed.append(kwargs)
+        return "done"
+
+    streamed: list[dict[str, object]] = []
+    monkeypatch.setattr(cog, "_handle_streaming", fake_streaming)
+    await cog._handle_message_reply(
+        message=message, system_prompt="system", context_prompt="context", history_limit=2
+    )
+    assert cog.client.responses.create_calls[-1]["stream"] is True
+    assert streamed[-1]["message"] is message
+
+
+@pytest.mark.parametrize(
+    argnames=("route", "expected_call"),
+    argvalues=[
+        ("IMAGE", "_handle_image_reply"),
+        ("VIDEO", "_handle_video_generation"),
+        ("SUMMARY", "_handle_message_reply"),
+        ("QA", "_handle_message_reply"),
+    ],
+)
+async def test_gen_reply_on_message_dispatches_routes(
+    monkeypatch: pytest.MonkeyPatch, route: str, expected_call: str
+) -> None:
+    cog = _cog()
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    async def fake_route(*, message: FakeMessage) -> str:
+        return route
+
+    async def fake_reaction(**kwargs: object) -> None:
+        calls.append(("reaction", kwargs))
+
+    async def fake_handler(**kwargs: object) -> None:
+        calls.append((expected_call, kwargs))
+
+    monkeypatch.setattr(cog, "_route_message", fake_route)
+    monkeypatch.setattr(cog, "_handle_reaction", fake_reaction)
+    monkeypatch.setattr(cog, "_handle_image_reply", fake_handler)
+    monkeypatch.setattr(cog, "_handle_video_generation", fake_handler)
+    monkeypatch.setattr(cog, "_handle_message_reply", fake_handler)
+
+    message = FakeMessage(content="<@999> hello", author=FakeAuthor(user_id=1))
+    await cog.on_message(message=message)
+    assert any(call[0] == expected_call for call in calls)
+    assert calls[-1][1]["emoji"] == "🆗"
+
+
+async def test_gen_reply_on_message_early_returns_and_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cog = _cog()
+    bot_authored = FakeMessage(content="<@999> hi", author=FakeAuthor(bot=True))
+    await cog.on_message(message=bot_authored)
+    assert bot_authored.replies == []
+
+    unmentioned = FakeMessage(content="hello", author=FakeAuthor(user_id=1))
+    await cog.on_message(message=unmentioned)
+    assert unmentioned.replies == []
+
+    dm_empty = FakeMessage(content="<@999>", author=FakeAuthor(user_id=1))
+    dm_empty.guild = None
+    await cog.on_message(message=dm_empty)
+    assert dm_empty.replies[0].content == "?"
+
+    async def boom(*, message: FakeMessage) -> str:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(cog, "_route_message", boom)
+    failed = FakeMessage(content="<@999> fail", author=FakeAuthor(user_id=1))
+    await cog.on_message(message=failed)
+    assert failed.replies[0].content is None
+
+
+def test_model_settings_and_config_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(name="OPENAI_BASE_URL", value="https://example.test/v1")
+    monkeypatch.setenv(name="OPENAI_API_KEY", value="test-key")
+    cog = ReplyGeneratorCogs(bot=SimpleNamespace(user=SimpleNamespace(id=999)))
+    assert cog.fast_model == ModelSettings(name="gemini-flash-latest", effort="none")
+    assert cog.image_model.name.endswith("image-preview")
+    assert cog.video_model.name.startswith("veo")
+    assert cog.slow_model.effort == "high"
+    assert ModelSettings(name="gemini-test").tools == [{"googleSearch": {}}, {"urlContext": {}}]
+    assert ModelSettings(name="claude-test").tools[0]["name"] == "web_search"
+    assert ModelSettings(name="openai-test").tools == [{"type": "web_search"}]

--- a/tests/test_maplestory.py
+++ b/tests/test_maplestory.py
@@ -1,0 +1,513 @@
+import json
+from types import SimpleNamespace
+from pathlib import Path
+
+import pytest
+from nextcord import Embed, SelectOption
+
+from discordbot.cogs import maplestory
+from discordbot.cogs.maplestory import MapleStoryCogs
+from discordbot.cogs._maplestory import views
+from discordbot.cogs._maplestory.views import MapleDropSearchView
+from discordbot.cogs._maplestory.embeds import (
+    _truncate,
+    create_map_embed,
+    create_npc_embed,
+    build_stats_embed,
+    create_quest_embed,
+    create_scroll_embed,
+    create_monster_embed,
+    create_equipment_embed,
+    create_item_source_embed,
+)
+from discordbot.cogs._maplestory.models import (
+    NPC,
+    Quest,
+    Scroll,
+    Monster,
+    Useable,
+    DropItem,
+    MapEntry,
+    MiscItem,
+    Equipment,
+    QuestStep,
+    StatValue,
+    HuntTarget,
+    RegionMaps,
+    CollectItem,
+    QuestReward,
+    MonsterDrops,
+    CraftingRecipe,
+    EquipmentStats,
+    CraftingMaterial,
+    EquipmentRestriction,
+)
+from discordbot.cogs._maplestory.service import MapleStoryService, _load_json, _load_translations
+
+
+class _FakeResponse:
+    def __init__(self) -> None:
+        self.deferred = False
+        self.messages: list[dict[str, object]] = []
+
+    async def defer(self) -> None:
+        self.deferred = True
+
+    async def send_message(self, **kwargs: object) -> None:
+        self.messages.append(kwargs)
+
+
+class _FakeFollowup:
+    def __init__(self) -> None:
+        self.sent: list[dict[str, object]] = []
+        self.edited: list[dict[str, object]] = []
+
+    async def send(self, *args: object, **kwargs: object) -> None:
+        if args:
+            kwargs["content"] = args[0]
+        self.sent.append(kwargs)
+
+    async def edit_message(self, **kwargs: object) -> None:
+        self.edited.append(kwargs)
+
+
+class _FakeInteraction:
+    def __init__(self, message_id: int = 777) -> None:
+        self.response = _FakeResponse()
+        self.followup = _FakeFollowup()
+        self.message = SimpleNamespace(id=message_id)
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.write_text(data=json.dumps(obj=payload, ensure_ascii=False), encoding="utf-8")
+
+
+@pytest.fixture
+def maple_data_dir(tmp_path: Path) -> Path:
+    data_dir = tmp_path / "maplestory"
+    data_dir.mkdir()
+
+    _write_json(
+        path=data_dir / "monsters.json",
+        payload=[
+            {
+                "name": "Slime",
+                "nameZh": "綠水靈",
+                "level": 5,
+                "hp": 50,
+                "mp": 10,
+                "exp": 12,
+                "def": {"weapon": 1, "magic": 2, "avoidability": 3},
+                "accuracy": {"required": 1, "decrease": 0.1},
+                "modifiers": ["Fire"],
+                "regionToMapsList": [
+                    {
+                        "region": "Victoria",
+                        "maps": [
+                            "Henesys > Hunting Ground",
+                            "Henesys > Hidden Street",
+                            "Henesys > East Field",
+                            "Henesys > West Field",
+                            "Henesys > North Field",
+                            "Henesys > South Field",
+                        ],
+                    }
+                ],
+                "drops": {
+                    "equipmentItems": [
+                        {"name": "Wooden Sword", "level": 10, "type": "Weapon", "jobs": ["Warrior"]}
+                    ],
+                    "useableItems": [{"name": "Red Potion", "level": 0, "type": "Potion"}],
+                    "scrolls": [{"name": "Scroll for Gloves for ATT", "level": 0, "type": "Glove"}],
+                    "miscItems": [{"name": "Slime Bubble", "level": 0, "type": "Etc"}],
+                    "mesoRange": [4, 8],
+                },
+                "quests": [{"name": "Helping Hand", "level": 5}],
+            },
+            {
+                "name": "Blue Slime",
+                "nameZh": "藍水靈",
+                "level": 7,
+                "drops": {"miscItems": [{"name": "Blue Bubble"}]},
+            },
+        ],
+    )
+    _write_json(
+        path=data_dir / "equipment.json",
+        payload=[
+            {
+                "type": "Weapon",
+                "name": "Wooden Sword",
+                "nameZh": "木劍",
+                "level": 10,
+                "equipmentRestriction": {"str": 5, "dex": 2, "int": 0, "luk": 0},
+                "stats": {"str": {"middle": 1}, "atk": {"middle": 12}, "upgradeSlots": 7},
+                "jobs": ["Warrior"],
+                "attackSpeed": "Fast",
+                "tradeable": "Tradeable",
+                "event": True,
+                "unavailable": True,
+                "acquisition": {
+                    "monsters": [{"name": "Slime", "level": 5}],
+                    "npcs": [{"name": "Shopkeeper", "price": 100}],
+                    "quests": [{"name": "Helping Hand", "level": 5}],
+                },
+            },
+            {"type": "Weapon", "name": "Wooden Club", "nameZh": "木棍", "level": 8},
+        ],
+    )
+    _write_json(
+        path=data_dir / "scrolls.json",
+        payload=[
+            {
+                "name": "Scroll for Gloves for ATT",
+                "nameZh": "手套攻擊卷軸",
+                "type": "Glove",
+                "stats": {"atk": 1, "speed": 2},
+                "acquisition": {"monsters": [{"name": "Slime", "level": 5}]},
+            },
+            {"name": "Scroll for Shoes for Jump", "type": "Shoe"},
+        ],
+    )
+    _write_json(
+        path=data_dir / "useable.json",
+        payload=[
+            {
+                "name": "Red Potion",
+                "nameZh": "紅色藥水",
+                "type": "Potion",
+                "description": {"summary": "Restores HP"},
+                "hp": {"amount": 50},
+            }
+        ],
+    )
+    _write_json(
+        path=data_dir / "npcs.json",
+        payload=[
+            {
+                "name": "Shopkeeper",
+                "nameZh": "商店老闆",
+                "type": "Shop",
+                "regionToMapsList": [{"region": "Victoria", "maps": ["Henesys > Market"]}],
+                "equipmentItems": [{"name": "equipment/Wooden Sword", "price": 100}],
+                "useableItems": [{"name": "useable/Red Potion", "price": 50}],
+                "quests": [{"name": "Helping Hand", "level": 5}],
+                "recipes": [
+                    {
+                        "npc": "Shopkeeper",
+                        "output": "Wooden Sword",
+                        "materials": [{"item": "Slime Bubble", "quantity": 2}],
+                    }
+                ],
+            },
+            {"name": "Storage Keeper", "type": "Storage"},
+        ],
+    )
+    _write_json(
+        path=data_dir / "quests.json",
+        payload=[
+            {
+                "name": "Helping Hand",
+                "nameZh": "幫忙的手",
+                "frequency": "daily",
+                "lvLower": 5,
+                "lvUpper": 20,
+                "steps": [
+                    {
+                        "startNPC": "Shopkeeper",
+                        "monstersToHunt": [{"name": "Slime", "quantity": 10}],
+                        "itemsToCollect": {"misc": [{"name": "Slime Bubble", "quantity": 3}]},
+                        "reward": {"exp": 100, "fame": 1},
+                    }
+                ],
+            },
+            {"name": "Another Help", "frequency": "one-time", "lvLower": 1},
+        ],
+    )
+    _write_json(
+        path=data_dir / "maps.json",
+        payload=[
+            {
+                "region": "Victoria",
+                "name": "Henesys > Hunting Ground",
+                "nameZh": "弓箭手村狩獵場",
+                "monsters": [{"name": "Slime", "level": 5}],
+                "npcs": [{"name": "Shopkeeper", "type": "Shop", "subMap": "Market"}],
+                "hidden": True,
+            },
+            {"region": "Victoria", "name": "Henesys > Market"},
+        ],
+    )
+    _write_json(
+        path=data_dir / "misc.json",
+        payload=[{"name": "Slime Bubble", "nameZh": "綠水靈泡泡", "type": "Etc"}],
+    )
+    _write_json(
+        path=data_dir / "translations.json",
+        payload={
+            "monsters": {"Slime": "綠水靈"},
+            "equipment": {"Wooden Sword": "木劍"},
+            "scrolls": {"Scroll for Gloves for ATT": "手套攻擊卷軸"},
+            "useable": {"Red Potion": "紅色藥水"},
+            "misc": {"Slime Bubble": "綠水靈泡泡"},
+            "npcs": {"Shopkeeper": "商店老闆"},
+            "quests": {"Helping Hand": "幫忙的手"},
+            "maps": {"Henesys": "弓箭手村", "Hunting Ground": "狩獵場"},
+            "region": {"Victoria": "維多利亞"},
+            "eqType": {"Weapon": "武器", "Glove": "手套"},
+            "job": {"Warrior": "劍士"},
+            "npcType": {"Shop": "商店"},
+            "modifiers": {"Fire": "火"},
+        },
+    )
+    return data_dir
+
+
+@pytest.fixture
+def service(maple_data_dir: Path) -> MapleStoryService:
+    return MapleStoryService.from_directory(data_dir=maple_data_dir)
+
+
+def test_maplestory_models_accept_aliases_and_helpers() -> None:
+    drops = MonsterDrops(
+        equipmentItems=[DropItem(name="Sword")],
+        useableItems=[DropItem(name="Potion")],
+        scrolls=[DropItem(name="Scroll")],
+        miscItems=[DropItem(name="Etc")],
+    )
+    monster = Monster(
+        name="Slime",
+        nameZh="綠水靈",
+        regionToMapsList=[RegionMaps(region="Victoria", maps=["A", "B"])],
+        drops=drops,
+    )
+    equip = Equipment(
+        name="Sword",
+        nameZh="劍",
+        equipmentRestriction=EquipmentRestriction(str=1, dex=2),
+        stats=EquipmentStats(str=StatValue(middle=3), atk=StatValue(middle=5)),
+    )
+    quest = Quest(
+        name="Quest",
+        steps=[
+            QuestStep(
+                startNPC="NPC",
+                monstersToHunt=[HuntTarget(name="Slime", quantity=2)],
+                itemsToCollect={"misc": [CollectItem(name="Bubble", quantity=3)]},
+                reward=QuestReward(exp=100, fame=1),
+            )
+        ],
+    )
+    assert monster.display_name == "綠水靈"
+    assert monster.all_maps == ["A", "B"]
+    assert [item.name for item in drops.all_items] == ["Sword", "Potion", "Scroll", "Etc"]
+    assert equip.display_name == "劍"
+    assert equip.equipment_restriction.has_requirements()
+    assert equip.stats.non_zero_stats() == [
+        ("STR", StatValue(middle=3, range=[])),
+        ("ATK", StatValue(middle=5, range=[])),
+    ]
+    assert Scroll(name="Scroll", nameZh="卷").display_name == "卷"
+    assert Useable(name="Potion", nameZh="藥水").display_name == "藥水"
+    assert NPC(name="NPC", nameZh="店員", regionToMapsList=[RegionMaps(region="R", maps=["M"])]).all_maps == [
+        "M"
+    ]
+    assert quest.display_name == "Quest"
+    assert MapEntry(name="Map", nameZh="地圖").display_name == "地圖"
+    assert MiscItem(name="Etc", nameZh="其他").display_name == "其他"
+    assert CraftingRecipe(
+        npc="NPC", output="Sword", materials=[CraftingMaterial(item="Ore", quantity=1)]
+    ).materials[0].quantity == 1
+
+
+def test_maplestory_service_loads_searches_and_caches(service: MapleStoryService) -> None:
+    assert service.has_data()
+    assert service.translate(category="monsters", name="Slime") == "綠水靈"
+    assert service.translate(category="missing", name="Slime") == "Slime"
+    assert service.search_monsters_by_name(query="slime")[0].display_name == "綠水靈"
+    assert service.search_monsters_by_name(query="綠")[0].name == "Slime"
+    assert service.get_monster(name="綠水靈").name == "Slime"
+    assert service.get_monster(name="missing") is None
+    assert [monster.name for monster in service.get_monsters_by_drop(item_name="Wooden Sword")] == [
+        "Slime"
+    ]
+    assert service.search_equipment_by_name(query="wooden")
+    assert service.get_equipment(name="木劍").name == "Wooden Sword"
+    assert service.get_equipment(name="missing") is None
+    assert service.search_scrolls_by_name(query="gloves")
+    assert service.search_npcs_by_name(query="shop")
+    assert service.search_quests_by_name(query="help")
+    assert service.search_maps_by_name(query="hunting")
+    assert service.search_items_by_name(query="Bubble") == ["Blue Bubble", "Slime Bubble"]
+    assert service.get_item_type(item_name="Wooden Sword") == "裝備"
+    assert service.get_item_type(item_name="Scroll for Gloves for ATT") == "捲軸"
+    assert service.get_item_type(item_name="Red Potion") == "消耗品"
+    assert service.get_item_type(item_name="Slime Bubble") == "其它"
+    assert service.get_item_type(item_name="Missing") == "未知"
+    assert service.get_level_distribution() == {"0-9": 2}
+    assert service.get_popular_items()[:2] == ["Wooden Sword", "Red Potion"]
+    stats = service.get_stats()
+    assert stats.total_monsters == 2
+    assert service.get_stats() is stats
+
+
+def test_maplestory_load_helpers_handle_missing_and_invalid_files(tmp_path: Path) -> None:
+    assert _load_json(path=tmp_path / "missing.json", model=Monster) == []
+    bad_json = tmp_path / "bad.json"
+    bad_json.write_text(data="{bad", encoding="utf-8")
+    assert _load_json(path=bad_json, model=Monster) == []
+    assert _load_translations(data_dir=tmp_path) == {}
+
+
+def test_maplestory_embeds_include_expected_sections(service: MapleStoryService) -> None:
+    monster = service.get_monster(name="Slime")
+    equip = service.get_equipment(name="Wooden Sword")
+    scroll = service.search_scrolls_by_name(query="Gloves")[0]
+    npc = service.search_npcs_by_name(query="Shopkeeper")[0]
+    quest = service.search_quests_by_name(query="Helping")[0]
+    map_entry = service.search_maps_by_name(query="Hunting")[0]
+    assert monster is not None
+    assert equip is not None
+
+    embeds = [
+        create_monster_embed(monster=monster, translate=service.translate),
+        create_equipment_embed(equip=equip, translate=service.translate),
+        create_scroll_embed(scroll=scroll, translate=service.translate),
+        create_npc_embed(npc=npc, translate=service.translate),
+        create_quest_embed(quest=quest, translate=service.translate),
+        create_map_embed(map_entry=map_entry, translate=service.translate),
+        create_item_source_embed(
+            item_name="Wooden Sword", monsters=[monster], translate=service.translate
+        ),
+        build_stats_embed(stats=service.get_stats()),
+    ]
+
+    titles = [embed.title for embed in embeds]
+    assert titles == [
+        "🐲 綠水靈",
+        "⚔️ 木劍",
+        "📜 手套攻擊卷軸",
+        "👤 商店老闆",
+        "📋 幫忙的手",
+        "🗺️ 弓箭手村狩獵場",
+        "🎁 木劍",
+        "📊 楓之谷資料庫統計",
+    ]
+    assert any(field.name == "⚔️ 裝備掉落" for field in embeds[0].fields)
+    assert any(field.name == "📏 需求" for field in embeds[1].fields)
+    assert any(field.name == "📊 屬性加成" for field in embeds[2].fields)
+    assert any(field.name == "🗺️ 位置" for field in embeds[3].fields)
+    assert any(field.name in {"步驟 1", "任務內容"} for field in embeds[4].fields)
+    assert any(field.name == "🔐 隱藏地圖" for field in embeds[5].fields)
+    assert _truncate(text="abcdef", limit=5) == "ab..."
+
+
+async def test_maplestory_view_resolvers_and_selection(service: MapleStoryService) -> None:
+    for search_type, name in [
+        ("monster", "Slime"),
+        ("item", "Wooden Sword"),
+        ("equipment", "Wooden Sword"),
+        ("scroll", "Scroll for Gloves for ATT"),
+        ("npc", "Shopkeeper"),
+        ("quest", "Helping Hand"),
+        ("map", "Henesys > Hunting Ground"),
+    ]:
+        resolver = views._RESOLVERS[search_type]
+        embed = resolver(service=service, name=name, tr=service.translate)
+        assert isinstance(embed, Embed)
+
+    drop_view = MapleDropSearchView(service=service, search_type="monster", query="slime")
+    drop_view.set_options(options=[SelectOption(label=f"Option {i}", value=str(i)) for i in range(30)])
+    assert len(drop_view.select_result.options) == 25
+
+
+async def test_maplestory_view_select_result_handles_loading_and_valid_choice(
+    service: MapleStoryService,
+) -> None:
+    view = MapleDropSearchView(service=service, search_type="monster", query="slime")
+    interaction = _FakeInteraction()
+    view.select_result._selected_values = ["loading"]
+    await view.select_result.callback(interaction)
+    assert interaction.response.deferred
+    assert interaction.followup.sent[0]["content"] == "請先選擇有效的結果。"
+
+    valid_interaction = _FakeInteraction()
+    view.select_result._selected_values = ["Slime"]
+    await view.select_result.callback(valid_interaction)
+    assert valid_interaction.followup.edited[0]["message_id"] == 777
+    assert isinstance(valid_interaction.followup.edited[0]["embed"], Embed)
+    assert valid_interaction.followup.edited[0]["view"] is None
+
+
+@pytest.fixture
+def maple_cog(maple_data_dir: Path) -> MapleStoryCogs:
+    return MapleStoryCogs(bot=SimpleNamespace(), data_dir=maple_data_dir)
+
+
+@pytest.mark.parametrize(
+    argnames=("command_name", "query", "expected_title"),
+    argvalues=[
+        ("maple_monster", "綠水靈", "🐲 綠水靈"),
+        ("maple_equip", "木劍", "⚔️ 木劍"),
+        ("maple_scroll", "手套攻擊", "📜 手套攻擊卷軸"),
+        ("maple_npc", "商店老闆", "👤 商店老闆"),
+        ("maple_quest", "幫忙", "📋 幫忙的手"),
+        ("maple_map", "狩獵場", "🗺️ 弓箭手村狩獵場"),
+        ("maple_item", "Wooden Sword", "🎁 木劍"),
+    ],
+)
+async def test_maplestory_commands_send_single_result_embed(
+    maple_cog: MapleStoryCogs, command_name: str, query: str, expected_title: str
+) -> None:
+    interaction = _FakeInteraction()
+    command = getattr(MapleStoryCogs, command_name)
+    await command.callback(maple_cog, interaction, name=query)
+    embed = interaction.followup.sent[0]["embed"]
+    assert interaction.response.deferred
+    assert isinstance(embed, Embed)
+    assert embed.title == expected_title
+
+
+async def test_maplestory_commands_send_multi_result_view(maple_cog: MapleStoryCogs) -> None:
+    interaction = _FakeInteraction()
+    await MapleStoryCogs.maple_monster.callback(maple_cog, interaction, name="Slime")
+    payload = interaction.followup.sent[0]
+    assert isinstance(payload["embed"], Embed)
+    assert "找到 2 個相關怪物" in payload["embed"].description
+    assert isinstance(payload["view"], MapleDropSearchView)
+
+
+async def test_maplestory_commands_send_not_found_and_stats(maple_cog: MapleStoryCogs) -> None:
+    missing_interaction = _FakeInteraction()
+    await MapleStoryCogs.maple_equip.callback(maple_cog, missing_interaction, name="missing")
+    missing_embed = missing_interaction.followup.sent[0]["embed"]
+    assert isinstance(missing_embed, Embed)
+    assert "找不到名稱包含" in missing_embed.description
+
+    stats_interaction = _FakeInteraction()
+    await MapleStoryCogs.maple_stats.callback(maple_cog, stats_interaction)
+    stats_embed = stats_interaction.followup.sent[0]["embed"]
+    assert isinstance(stats_embed, Embed)
+    assert stats_embed.title == "📊 楓之谷資料庫統計"
+
+
+async def test_maplestory_command_error_path_when_data_missing(tmp_path: Path) -> None:
+    cog = MapleStoryCogs(bot=SimpleNamespace(), data_dir=tmp_path / "empty")
+    interaction = _FakeInteraction()
+    await MapleStoryCogs.maple_stats.callback(cog, interaction)
+    embed = interaction.followup.sent[0]["embed"]
+    assert isinstance(embed, Embed)
+    assert embed.title == ":x: 錯誤"
+
+
+def test_maplestory_setup_registers_cog(monkeypatch: pytest.MonkeyPatch) -> None:
+    added: list[object] = []
+    monkeypatch.setattr(
+        "discordbot.cogs.maplestory.MapleStoryService.from_directory",
+        lambda data_dir: MapleStoryService(),
+    )
+    bot = SimpleNamespace(add_cog=added.append)
+
+    maplestory.setup(bot=bot)
+
+    assert isinstance(added[0], MapleStoryCogs)

--- a/tests/test_maplestory.py
+++ b/tests/test_maplestory.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import json
 from types import SimpleNamespace
-from pathlib import Path
+from typing import TYPE_CHECKING, Unpack, TypedDict
 
 import pytest
 from nextcord import Embed, SelectOption
@@ -44,30 +46,57 @@ from discordbot.cogs._maplestory.models import (
 )
 from discordbot.cogs._maplestory.service import MapleStoryService, _load_json, _load_translations
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
+type JsonValue = str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
+
+
+class InteractionPayload(TypedDict, total=False):
+    content: str
+    embed: Embed
+    view: MapleDropSearchView | None
+    message_id: int
+    ephemeral: bool
+
 
 class _FakeResponse:
     def __init__(self) -> None:
         self.deferred = False
-        self.messages: list[dict[str, object]] = []
+        self.messages: list[InteractionPayload] = []
 
     async def defer(self) -> None:
         self.deferred = True
 
-    async def send_message(self, **kwargs: object) -> None:
+    async def send_message(self, **kwargs: Unpack[InteractionPayload]) -> None:
         self.messages.append(kwargs)
 
 
 class _FakeFollowup:
     def __init__(self) -> None:
-        self.sent: list[dict[str, object]] = []
-        self.edited: list[dict[str, object]] = []
+        self.sent: list[InteractionPayload] = []
+        self.edited: list[InteractionPayload] = []
 
-    async def send(self, *args: object, **kwargs: object) -> None:
-        if args:
-            kwargs["content"] = args[0]
-        self.sent.append(kwargs)
+    async def send(
+        self,
+        content: str | None = None,
+        *,
+        embed: Embed | None = None,
+        view: MapleDropSearchView | None = None,
+        ephemeral: bool | None = None,
+    ) -> None:
+        payload = InteractionPayload()
+        if content is not None:
+            payload["content"] = content
+        if embed is not None:
+            payload["embed"] = embed
+        if view is not None:
+            payload["view"] = view
+        if ephemeral is not None:
+            payload["ephemeral"] = ephemeral
+        self.sent.append(payload)
 
-    async def edit_message(self, **kwargs: object) -> None:
+    async def edit_message(self, **kwargs: Unpack[InteractionPayload]) -> None:
         self.edited.append(kwargs)
 
 
@@ -78,7 +107,7 @@ class _FakeInteraction:
         self.message = SimpleNamespace(id=message_id)
 
 
-def _write_json(path: Path, payload: object) -> None:
+def _write_json(path: Path, payload: JsonValue) -> None:
     path.write_text(data=json.dumps(obj=payload, ensure_ascii=False), encoding="utf-8")
 
 
@@ -115,10 +144,17 @@ def maple_data_dir(tmp_path: Path) -> Path:
                 ],
                 "drops": {
                     "equipmentItems": [
-                        {"name": "Wooden Sword", "level": 10, "type": "Weapon", "jobs": ["Warrior"]}
+                        {
+                            "name": "Wooden Sword",
+                            "level": 10,
+                            "type": "Weapon",
+                            "jobs": ["Warrior"],
+                        }
                     ],
                     "useableItems": [{"name": "Red Potion", "level": 0, "type": "Potion"}],
-                    "scrolls": [{"name": "Scroll for Gloves for ATT", "level": 0, "type": "Glove"}],
+                    "scrolls": [
+                        {"name": "Scroll for Gloves for ATT", "level": 0, "type": "Glove"}
+                    ],
                     "miscItems": [{"name": "Slime Bubble", "level": 0, "type": "Etc"}],
                     "mesoRange": [4, 8],
                 },
@@ -309,15 +345,20 @@ def test_maplestory_models_accept_aliases_and_helpers() -> None:
     ]
     assert Scroll(name="Scroll", nameZh="卷").display_name == "卷"
     assert Useable(name="Potion", nameZh="藥水").display_name == "藥水"
-    assert NPC(name="NPC", nameZh="店員", regionToMapsList=[RegionMaps(region="R", maps=["M"])]).all_maps == [
-        "M"
-    ]
+    assert NPC(
+        name="NPC", nameZh="店員", regionToMapsList=[RegionMaps(region="R", maps=["M"])]
+    ).all_maps == ["M"]
     assert quest.display_name == "Quest"
     assert MapEntry(name="Map", nameZh="地圖").display_name == "地圖"
     assert MiscItem(name="Etc", nameZh="其他").display_name == "其他"
-    assert CraftingRecipe(
-        npc="NPC", output="Sword", materials=[CraftingMaterial(item="Ore", quantity=1)]
-    ).materials[0].quantity == 1
+    assert (
+        CraftingRecipe(
+            npc="NPC", output="Sword", materials=[CraftingMaterial(item="Ores", quantity=1)]
+        )
+        .materials[0]
+        .quantity
+        == 1
+    )
 
 
 def test_maplestory_service_loads_searches_and_caches(service: MapleStoryService) -> None:
@@ -328,9 +369,9 @@ def test_maplestory_service_loads_searches_and_caches(service: MapleStoryService
     assert service.search_monsters_by_name(query="綠")[0].name == "Slime"
     assert service.get_monster(name="綠水靈").name == "Slime"
     assert service.get_monster(name="missing") is None
-    assert [monster.name for monster in service.get_monsters_by_drop(item_name="Wooden Sword")] == [
-        "Slime"
-    ]
+    assert [
+        monster.name for monster in service.get_monsters_by_drop(item_name="Wooden Sword")
+    ] == ["Slime"]
     assert service.search_equipment_by_name(query="wooden")
     assert service.get_equipment(name="木劍").name == "Wooden Sword"
     assert service.get_equipment(name="missing") is None
@@ -417,7 +458,9 @@ async def test_maplestory_view_resolvers_and_selection(service: MapleStoryServic
         assert isinstance(embed, Embed)
 
     drop_view = MapleDropSearchView(service=service, search_type="monster", query="slime")
-    drop_view.set_options(options=[SelectOption(label=f"Option {i}", value=str(i)) for i in range(30)])
+    drop_view.set_options(
+        options=[SelectOption(label=f"Option {i}", value=str(i)) for i in range(30)]
+    )
     assert len(drop_view.select_result.options) == 25
 
 
@@ -501,7 +544,7 @@ async def test_maplestory_command_error_path_when_data_missing(tmp_path: Path) -
 
 
 def test_maplestory_setup_registers_cog(monkeypatch: pytest.MonkeyPatch) -> None:
-    added: list[object] = []
+    added: list[MapleStoryCogs] = []
     monkeypatch.setattr(
         "discordbot.cogs.maplestory.MapleStoryService.from_directory",
         lambda data_dir: MapleStoryService(),


### PR DESCRIPTION
## Summary
- add fixture-backed MapleStory service/embed/view/command coverage
- add no-API smoke tests for reply generation, cog commands, Threads, video, auto-unmute, games, economy, template, and CLI branches
- fix MapleStory data loading error logging so missing/invalid files degrade instead of raising a logfire TypeError
- tighten fake test typing with explicit fake classes and TypedDict payloads

## Verification
- uv run pytest --cov-report=term-missing:skip-covered
- uv run pre-commit run -a