### PR TITLE
refactor: remove object hints and module-prefixed imports

### DIFF
--- a/scripts/artale_data.py
+++ b/scripts/artale_data.py
@@ -15,8 +15,9 @@ from rich.console import Console
 
 console = Console()
 
-# Raw JSON record from the website RSC payload
-type JsonRecord = dict[str, str | int | float | bool | list | dict | None]
+# Raw JSON values from the website RSC payload
+type JsonValue = str | int | float | bool | list[JsonValue] | dict[str, JsonValue] | None
+type JsonRecord = dict[str, JsonValue]
 
 BASE_URL = "https://www.artalemaplestory.com"
 LOCALE = "zh"
@@ -109,14 +110,16 @@ def extract_json_list(text: str, key: str) -> list[JsonRecord] | None:
     return value if isinstance(value, list) else None
 
 
-def _get_nested_dict(d: Mapping[str, object], *keys: str) -> dict[str, str]:
+def _get_nested_dict(d: Mapping[str, JsonValue], *keys: str) -> dict[str, str]:
     """Traverse nested dicts safely, returning {} if any key is missing."""
-    current: object = d
+    current: JsonValue | Mapping[str, JsonValue] = d
     for k in keys:
-        if not isinstance(current, dict):
+        if not isinstance(current, Mapping):
             return {}
         current = current.get(k, {})
-    return current if isinstance(current, dict) else {}
+    if not isinstance(current, dict):
+        return {}
+    return {key: value for key, value in current.items() if isinstance(value, str)}
 
 
 def extract_translations(rsc_text: str) -> dict[str, dict[str, str]]:

--- a/scripts/manage_admin.py
+++ b/scripts/manage_admin.py
@@ -15,7 +15,7 @@ from collections.abc import Sequence
 from pydantic import BaseModel, ConfigDict
 from rich.console import Console
 
-from discordbot.cogs._economy import database
+from discordbot.cogs._economy.database import get_admin, set_admin, list_admins
 
 console = Console()
 
@@ -64,33 +64,31 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 async def grant_admin(user_id: int, name: str = "", avatar_url: str = "") -> AdminChange:
     """Grants economy admin access to a Discord user."""
-    applied = await database.set_admin(
-        user_id=user_id, name=name, avatar_url=avatar_url, is_admin=True
-    )
+    applied = await set_admin(user_id=user_id, name=name, avatar_url=avatar_url, is_admin=True)
     return AdminChange(
         user_id=user_id,
         name=name or str(user_id),
         action="grant",
         applied=applied,
-        is_admin=await database.get_admin(user_id=user_id),
+        is_admin=await get_admin(user_id=user_id),
     )
 
 
 async def revoke_admin(user_id: int, name: str = "") -> AdminChange:
     """Revokes economy admin access from an existing Discord user."""
-    applied = await database.set_admin(user_id=user_id, name=name, is_admin=False)
+    applied = await set_admin(user_id=user_id, name=name, is_admin=False)
     return AdminChange(
         user_id=user_id,
         name=name or str(user_id),
         action="revoke",
         applied=applied,
-        is_admin=await database.get_admin(user_id=user_id),
+        is_admin=await get_admin(user_id=user_id),
     )
 
 
 async def list_admin_accounts() -> list[tuple[int, str]]:
     """Lists all economy admins."""
-    return await database.list_admins()
+    return await list_admins()
 
 
 def _print_change(change: AdminChange) -> None:

--- a/scripts/modify_balance.py
+++ b/scripts/modify_balance.py
@@ -16,7 +16,7 @@ from collections.abc import Sequence
 from pydantic import BaseModel, ConfigDict
 from rich.console import Console
 
-from discordbot.cogs._economy import database
+from discordbot.cogs._economy.database import top_n, get_account, adjust_balance
 from discordbot.cogs._economy.presentation import CURRENCY_NAME, currency_text
 
 console = Console()
@@ -113,7 +113,7 @@ async def modify_balance(
     Returns:
         A `BalanceChange` summary describing the requested and applied change.
     """
-    account = await database.get_account(user_id=user_id)
+    account = await get_account(user_id=user_id)
     created = account is None
     existing_name = account[0] if account is not None else ""
     before = account[1] if account is not None else 0
@@ -134,7 +134,7 @@ async def modify_balance(
             dry_run=dry_run,
         )
 
-    adjustment = await database.adjust_balance(
+    adjustment = await adjust_balance(
         user_id=user_id, name=effective_name, delta=delta, allow_negative=allow_negative
     )
     actual_before = adjustment.new_balance - adjustment.applied_delta
@@ -168,7 +168,7 @@ async def modify_all_balances(
     Returns:
         A `BulkBalanceChange` summary for the requested operation.
     """
-    accounts = await database.top_n(limit=2_147_483_647)
+    accounts = await top_n(limit=2_147_483_647)
     changes: list[BalanceChange] = []
     for account in accounts:
         changes.append(

--- a/src/discordbot/cogs/_games/dragon_gate_views.py
+++ b/src/discordbot/cogs/_games/dragon_gate_views.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 import asyncio
 import contextlib
 
@@ -431,9 +431,7 @@ class DragonGateView(ui.View):
         if self._settled or interaction.user is None:
             return False
         data = (
-            cast("dict[str, object]", interaction.data)
-            if isinstance(interaction.data, dict)
-            else {}
+            cast("dict[str, Any]", interaction.data) if isinstance(interaction.data, dict) else {}
         )
         custom_id_value = data.get("custom_id", "")
         custom_id = custom_id_value if isinstance(custom_id_value, str) else ""

--- a/src/discordbot/cogs/_games/interactions.py
+++ b/src/discordbot/cogs/_games/interactions.py
@@ -21,7 +21,7 @@ async def send_ephemeral_notice(interaction: Interaction, content: str, log_mess
 
 
 def disable_view_components(
-    children: Iterable[ui.Item], component_types: tuple[type[object], ...]
+    children: Iterable[ui.Item], component_types: tuple[type[ui.Item], ...]
 ) -> None:
     """Disables view children matching any supplied component type."""
     for child in children:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from collections.abc import AsyncIterator
 import pytest
 from sqlalchemy.ext.asyncio import create_async_engine
 
-from discordbot.cogs._economy import database
+from discordbot.cogs._economy.database import Base
 
 
 @pytest.fixture
@@ -21,7 +21,7 @@ async def economy_isolated_db(
     db_path = tmp_path / "economy.db"
     engine = create_async_engine(url=f"sqlite+aiosqlite:///{db_path}")
     async with engine.begin() as conn:
-        await conn.run_sync(database.Base.metadata.create_all)
-    monkeypatch.setattr(target=database, name="_engine", value=engine)
+        await conn.run_sync(Base.metadata.create_all)
+    monkeypatch.setattr("discordbot.cogs._economy.database._engine", engine)
     yield
     await engine.dispose()

--- a/tests/test_blackjack.py
+++ b/tests/test_blackjack.py
@@ -3,10 +3,10 @@
 # ruff: noqa: S311 -- seeded Random() in tests is for determinism, not cryptography
 
 from random import Random
+from unittest.mock import patch
 
 import pytest
 
-from discordbot.cogs._games import blackjack as blackjack_module
 from discordbot.typings.games import GameParticipant
 from discordbot.cogs._games.blackjack import (
     Card,
@@ -640,12 +640,8 @@ def test_deal_initial_offers_insurance_when_dealer_shows_ace() -> None:
     def fake_draw(rng: Random) -> Card:
         return queue.pop(0)
 
-    original_draw = blackjack_module.draw_card
-    blackjack_module.draw_card = fake_draw
-    try:
+    with patch("discordbot.cogs._games.blackjack.draw_card", fake_draw):
         round_state.deal_initial()
-    finally:
-        blackjack_module.draw_card = original_draw
 
     assert round_state.phase == "insurance"
     assert round_state.insurance_offered is True
@@ -667,12 +663,8 @@ def test_dealer_peek_blackjack_settles_round_immediately() -> None:
     def fake_draw(rng: Random) -> Card:
         return queue.pop(0)
 
-    original_draw = blackjack_module.draw_card
-    blackjack_module.draw_card = fake_draw
-    try:
+    with patch("discordbot.cogs._games.blackjack.draw_card", fake_draw):
         round_state.deal_initial()
-    finally:
-        blackjack_module.draw_card = original_draw
 
     assert round_state.peeked_blackjack is True
     assert round_state.phase == "settled"
@@ -694,14 +686,10 @@ def test_insurance_phase_closes_after_all_decisions_and_peeks() -> None:
     def fake_draw(rng: Random) -> Card:
         return queue.pop(0)
 
-    original_draw = blackjack_module.draw_card
-    blackjack_module.draw_card = fake_draw
-    try:
+    with patch("discordbot.cogs._games.blackjack.draw_card", fake_draw):
         round_state.deal_initial()
         assert round_state.phase == "insurance"
         round_state.take_insurance(user_id=1, amount=50)
-    finally:
-        blackjack_module.draw_card = original_draw
 
     assert round_state.peeked_blackjack is True
     assert round_state.phase == "settled"

--- a/tests/test_cogs_smoke.py
+++ b/tests/test_cogs_smoke.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from types import TracebackType, SimpleNamespace
-from typing import TYPE_CHECKING, Self, Unpack, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Self, Unpack, TypedDict, cast
 import asyncio
 from datetime import UTC, datetime, timedelta
 
@@ -15,9 +15,7 @@ from discordbot import cli
 from discordbot.cogs import games, video, economy, template, auto_unmute, parse_threads
 from discordbot.cogs.games import GamesCogs
 from discordbot.cogs.video import VideoCogs
-from discordbot.cogs._games import dealer as dealer_module
 from discordbot.cogs.economy import EconomyCogs
-from discordbot.cogs._economy import database
 from discordbot.cogs.template import TemplateCogs
 from discordbot.typings.games import BlackjackDealerDecision
 from discordbot.utils.threads import ThreadsOutput
@@ -25,6 +23,16 @@ from discordbot.typings.models import ModelSettings
 from discordbot.cogs.auto_unmute import AutoUnmuteCogs
 from discordbot.cogs._games.dealer import DealerAI
 from discordbot.cogs.parse_threads import ThreadsCogs
+from discordbot.cogs._economy.database import (
+    VIP_PURCHASE_COST,
+    RepayResult,
+    BorrowResult,
+    CreditResult,
+    CheckinResult,
+    TransferResult,
+    VipPurchaseResult,
+    BalanceAdjustmentResult,
+)
 from discordbot.cogs._games.blackjack_views import BlackjackLobbyView
 from discordbot.cogs._games.dragon_gate_views import DragonGateLobbyView
 
@@ -172,12 +180,12 @@ class FakeDiscordMessage:
 class HangingResponses:
     """Fake Responses API resource that sleeps longer than dealer timeout."""
 
-    async def create(self, **_kwargs: object) -> SimpleNamespace:
+    async def create(self, **_kwargs: Any) -> SimpleNamespace:  # noqa: ANN401 -- test double accepts heterogeneous kwargs
         """Sleeps before returning a late response."""
         await asyncio.sleep(delay=10)
         return SimpleNamespace(output_text="late")
 
-    async def parse(self, **_kwargs: object) -> SimpleNamespace:
+    async def parse(self, **_kwargs: Any) -> SimpleNamespace:  # noqa: ANN401 -- test double accepts heterogeneous kwargs
         """Sleeps before returning a late parsed response."""
         await asyncio.sleep(delay=10)
         return SimpleNamespace(output_parsed=None)
@@ -197,9 +205,9 @@ class ParsedDecisionResponses:
     def __init__(self, output_parsed: BlackjackDealerDecision | None) -> None:
         """Stores the parsed output to return."""
         self.output_parsed = output_parsed
-        self.calls: list[dict[str, object]] = []
+        self.calls: list[dict[str, Any]] = []
 
-    async def parse(self, **kwargs: object) -> SimpleNamespace:
+    async def parse(self, **kwargs: Any) -> SimpleNamespace:  # noqa: ANN401 -- test double accepts heterogeneous kwargs
         """Records parse arguments and returns the configured parsed output."""
         self.calls.append(kwargs)
         return SimpleNamespace(output_parsed=self.output_parsed)
@@ -624,11 +632,11 @@ async def test_economy_admin_rejects_non_admin(monkeypatch: pytest.MonkeyPatch) 
         """Returns a non-admin status."""
         return False
 
-    async def fake_adjust_balance_guard(**_kwargs: object) -> database.BalanceAdjustmentResult:
+    async def fake_adjust_balance_guard(**_kwargs: Any) -> BalanceAdjustmentResult:  # noqa: ANN401 -- test double accepts heterogeneous kwargs
         """Fails the test if a non-admin reaches the mutation path."""
         nonlocal called
         called = True
-        return database.BalanceAdjustmentResult(new_balance=0, applied_delta=0)
+        return BalanceAdjustmentResult(new_balance=0, applied_delta=0)
 
     monkeypatch.setattr(economy, "get_admin", fake_get_admin_false)
     monkeypatch.setattr(economy, "adjust_balance", fake_adjust_balance_guard)
@@ -682,53 +690,51 @@ async def fake_get_account(user_id: int) -> tuple[str, int, int, int]:
     return ("Bot", -50, 100, 150)
 
 
-async def fake_transfer(  # noqa: PLR0913 -- mirrors database.transfer signature
+async def fake_transfer(  # noqa: PLR0913 -- mirrors transfer signature
     sender_id: int,
     sender_name: str,
-    sender_avatar_url: str,
     receiver_id: int,
     receiver_name: str,
-    receiver_avatar_url: str,
     amount: int,
-) -> database.TransferResult:
+    sender_avatar_url: str = "",
+    receiver_avatar_url: str = "",
+) -> TransferResult | None:
     """Returns a successful fake transfer result."""
-    return database.TransferResult(sender_balance=50, receiver_balance=100)
+    return TransferResult(sender_balance=50, receiver_balance=100)
 
 
-async def fake_adjust_balance(  # noqa: PLR0913 -- mirrors database.adjust_balance signature
+async def fake_adjust_balance(  # noqa: PLR0913 -- mirrors adjust_balance signature
     user_id: int,
     name: str,
     delta: int,
     allow_negative: bool = False,
     avatar_url: str = "",
     note: str | None = None,
-) -> database.BalanceAdjustmentResult:
+) -> BalanceAdjustmentResult:
     """Returns a successful fake manual adjustment result."""
-    return database.BalanceAdjustmentResult(new_balance=150 + delta, applied_delta=delta)
+    return BalanceAdjustmentResult(new_balance=150 + delta, applied_delta=delta)
 
 
 async def fake_borrow(
     user_id: int, name: str, amount: int, credit_limit_value: int, avatar_url: str = ""
-) -> database.BorrowResult:
+) -> BorrowResult:
     """Returns a successful fake borrow result."""
-    return database.BorrowResult(new_balance=250, principal=amount, borrowed_amount=amount)
+    return BorrowResult(new_balance=250, principal=amount, borrowed_amount=amount)
 
 
-async def fake_repay(
-    user_id: int, name: str, amount: int, avatar_url: str = ""
-) -> database.RepayResult:
+async def fake_repay(user_id: int, name: str, amount: int, avatar_url: str = "") -> RepayResult:
     """Returns a successful fake repay result."""
-    return database.RepayResult(new_balance=100, principal_repaid=amount, remaining_debt=0)
+    return RepayResult(new_balance=100, principal_repaid=amount, remaining_debt=0)
 
 
-async def fake_checkin(user_id: int, name: str, avatar_url: str) -> database.CheckinResult:
+async def fake_checkin(user_id: int, name: str, avatar_url: str) -> CheckinResult:
     """Returns a successful fake daily check-in result."""
-    return database.CheckinResult(new_balance=600_000, amount=150_000, streak=2, is_vip=False)
+    return CheckinResult(new_balance=600_000, amount=150_000, streak=2, is_vip=False)
 
 
-async def fake_buy_vip(user_id: int, name: str, avatar_url: str) -> database.VipPurchaseResult:
+async def fake_buy_vip(user_id: int, name: str, avatar_url: str) -> VipPurchaseResult:
     """Returns a successful fake VIP purchase result."""
-    return database.VipPurchaseResult(new_balance=500_000, cost=database.VIP_PURCHASE_COST)
+    return VipPurchaseResult(new_balance=500_000, cost=VIP_PURCHASE_COST)
 
 
 def ignore_scheduled_game_message(message: FakeDiscordMessage) -> None:
@@ -889,7 +895,7 @@ async def test_dragon_gate_lobby_start_is_owner_only(monkeypatch: pytest.MonkeyP
 
 async def test_dealer_ai_times_out_to_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     """Verifies DealerAI returns fallback banter when the LLM call times out."""
-    monkeypatch.setattr(dealer_module, "DEALER_AI_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr("discordbot.cogs._games.dealer.DEALER_AI_TIMEOUT_SECONDS", 0.01)
     dealer = DealerAI(
         client=cast("AsyncOpenAI", HangingClient()),
         model=ModelSettings(name="gemini-flash-latest", effort="none"),
@@ -941,7 +947,9 @@ async def test_dealer_ai_blackjack_decision_times_out_to_basic_rule(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Verifies slow Blackjack decisions use the dedicated decision timeout."""
-    monkeypatch.setattr(dealer_module, "DEALER_BLACKJACK_DECISION_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(
+        "discordbot.cogs._games.dealer.DEALER_BLACKJACK_DECISION_TIMEOUT_SECONDS", 0.01
+    )
     dealer = DealerAI(
         client=cast("AsyncOpenAI", HangingClient()),
         model=ModelSettings(name="gemini-flash-latest", effort="medium"),
@@ -1022,16 +1030,16 @@ def test_cli_loads_cogs_and_handles_command_errors(tmp_path: Path) -> None:
 async def test_cli_message_and_command_error_branches(monkeypatch: pytest.MonkeyPatch) -> None:
     """Verifies base message rewards and common command error embeds."""
     processed: list[SimpleNamespace] = []
-    rewards: list[dict[str, object]] = []
+    rewards: list[dict[str, Any]] = []
 
     async def record_processed(message: SimpleNamespace) -> None:
         """Records messages passed to process_commands."""
         processed.append(message)
 
-    async def record_reward(**kwargs: object) -> database.CreditResult:
+    async def record_reward(**kwargs: Any) -> CreditResult:  # noqa: ANN401 -- test double accepts heterogeneous kwargs
         """Records base reward arguments and returns a fake credit result."""
         rewards.append(kwargs)
-        return database.CreditResult(
+        return CreditResult(
             new_balance=5_000, credited_amount=5_000, principal_repaid=0, remaining_debt=0
         )
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,25 +1,25 @@
 """Tests for the yt-dlp downloader facade."""
 
-from typing import Self
+from types import TracebackType
+from typing import Any, Self
 from pathlib import Path
 
 import pytest
 
-from discordbot.utils import downloader as downloader_module
 from discordbot.utils.downloader import VideoDownloader
 
 
 def _install_youtube_dl_stub(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Installs a yt-dlp stub and returns captured params and calls."""
-    captured_params: list[dict[str, object]] = []
-    captured_calls: list[dict[str, object]] = []
+    captured_params: list[dict[str, Any]] = []
+    captured_calls: list[dict[str, Any]] = []
 
     class _YoutubeDLStub:
         """Small context-manager stub for yt-dlp."""
 
-        def __init__(self, params: dict[str, object]) -> None:
+        def __init__(self, params: dict[str, Any]) -> None:
             """Records the yt-dlp params passed by the downloader."""
             self.params = params
             captured_params.append(params)
@@ -32,7 +32,7 @@ def _install_youtube_dl_stub(
             self,
             exc_type: type[BaseException] | None,
             exc_val: BaseException | None,
-            exc_tb: object,
+            exc_tb: TracebackType | None,
         ) -> None:
             """Matches yt-dlp's context-manager shape."""
 
@@ -45,7 +45,7 @@ def _install_youtube_dl_stub(
             """Returns the filename yt-dlp would prepare for the result."""
             return (tmp_path / f"{info['id']}.{info['ext']}").as_posix()
 
-    monkeypatch.setattr(target=downloader_module, name="YoutubeDL", value=_YoutubeDLStub)
+    monkeypatch.setattr("discordbot.utils.downloader.YoutubeDL", _YoutubeDLStub)
     return captured_params, captured_calls
 
 

--- a/tests/test_dragon_gate.py
+++ b/tests/test_dragon_gate.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from random import Random
-from typing import TYPE_CHECKING, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 # ruff: noqa: S311 -- seeded Random() in tests is for determinism, not cryptography
 import pytest
 from nextcord import Embed
 
-from discordbot.cogs._games import lobby, dragon_gate_views
 from discordbot.typings.games import Card, GameParticipant, DragonGatePlayerResult
 from discordbot.typings.economy import (
     JackpotSettlementResult,
@@ -48,9 +47,9 @@ class MessageStub:
 
     def __init__(self) -> None:
         """Initializes the recorded edit payloads."""
-        self.edits: list[dict[str, object]] = []
+        self.edits: list[dict[str, Any]] = []
 
-    async def edit(self, **kwargs: object) -> None:
+    async def edit(self, **kwargs: Any) -> None:  # noqa: ANN401 -- test double accepts heterogeneous kwargs
         """Records a message edit payload."""
         self.edits.append(kwargs)
 
@@ -61,14 +60,14 @@ class ResponseStub:
     def __init__(self) -> None:
         """Initializes interaction response state records."""
         self.deferred = False
-        self.sent: list[dict[str, object]] = []
-        self.modals: list[object] = []
+        self.sent: list[dict[str, Any]] = []
+        self.modals: list[DragonGateBetModal] = []
 
     async def defer(self) -> None:
         """Records that the interaction was deferred."""
         self.deferred = True
 
-    async def send_message(self, **kwargs: object) -> None:
+    async def send_message(self, **kwargs: Any) -> None:  # noqa: ANN401 -- test double accepts heterogeneous kwargs
         """Records an ephemeral or public interaction message."""
         self.sent.append(kwargs)
 
@@ -76,7 +75,7 @@ class ResponseStub:
         """Returns whether the interaction response has already been used."""
         return self.deferred or bool(self.sent) or bool(self.modals)
 
-    async def send_modal(self, modal: object) -> None:
+    async def send_modal(self, modal: DragonGateBetModal) -> None:
         """Records a modal launch."""
         self.modals.append(modal)
 
@@ -86,9 +85,9 @@ class FollowupStub:
 
     def __init__(self) -> None:
         """Initializes recorded followup sends."""
-        self.sent: list[dict[str, object]] = []
+        self.sent: list[dict[str, Any]] = []
 
-    async def send(self, **kwargs: object) -> MessageStub:
+    async def send(self, **kwargs: Any) -> MessageStub:  # noqa: ANN401 -- test double accepts heterogeneous kwargs
         """Records followup sends and returns a fake message."""
         self.sent.append(kwargs)
         return MessageStub()
@@ -110,7 +109,7 @@ class InteractionStub:
         self.message = message
         self.response = ResponseStub()
         self.followup = FollowupStub()
-        self.data: dict[str, object] = {"custom_id": custom_id}
+        self.data: dict[str, Any] = {"custom_id": custom_id}
 
 
 class DealerStub:
@@ -118,15 +117,15 @@ class DealerStub:
 
     def __init__(self) -> None:
         """Initializes dealer call records."""
-        self.table_settle_calls: list[dict[str, object]] = []
-        self.taunt_calls: list[dict[str, object]] = []
+        self.table_settle_calls: list[dict[str, Any]] = []
+        self.taunt_calls: list[dict[str, Any]] = []
 
-    async def taunt_bet(self, **kwargs: object) -> str:
+    async def taunt_bet(self, **kwargs: Any) -> str:  # noqa: ANN401 -- test double accepts heterogeneous kwargs
         """Returns a deterministic opening line."""
         self.taunt_calls.append(kwargs)
         return "taunt"
 
-    async def table_settle(self, **kwargs: object) -> str:
+    async def table_settle(self, **kwargs: Any) -> str:  # noqa: ANN401 -- test double accepts heterogeneous kwargs
         """Returns a deterministic settlement line and records the call."""
         self.table_settle_calls.append(kwargs)
         return "settled"
@@ -174,7 +173,7 @@ class JackpotState:
         self.balances: dict[int, int] = {}
         self._initial_balance = initial_balance
         self._replenish_seed = replenish_seed
-        self.calls: list[dict[str, object]] = []
+        self.calls: list[dict[str, Any]] = []
 
     async def settle(  # noqa: PLR0913 -- mirrors apply_jackpot_settlement for monkeypatching
         self,
@@ -262,22 +261,23 @@ def _participant(user_id: int, display_name: str, balance: int = 1_000_000) -> G
 def _install_jackpot_mock(monkeypatch: pytest.MonkeyPatch, state: JackpotState) -> None:
     """Patches jackpot database calls to use an in-memory state model."""
     monkeypatch.setattr(
-        target=dragon_gate_views, name="apply_jackpot_settlement", value=state.settle
+        "discordbot.cogs._games.dragon_gate_views.apply_jackpot_settlement", state.settle
     )
     monkeypatch.setattr(
-        target=lobby, name="apply_jackpot_settlement_batch", value=state.settle_batch
+        "discordbot.cogs._games.lobby.apply_jackpot_settlement_batch", state.settle_batch
     )
 
     async def fake_get_balance(user_id: int) -> int:
         """Returns the simulated final balance for a player."""
         return state.balances.get(user_id, 0)
 
-    monkeypatch.setattr(target=dragon_gate_views, name="get_balance", value=fake_get_balance)
+    monkeypatch.setattr("discordbot.cogs._games.dragon_gate_views.get_balance", fake_get_balance)
     monkeypatch.setattr(
-        target=dragon_gate_views, name="schedule_game_message_delete", value=lambda message: None
+        "discordbot.cogs._games.dragon_gate_views.schedule_game_message_delete",
+        lambda message: None,
     )
     monkeypatch.setattr(
-        target=lobby, name="schedule_game_message_delete", value=lambda message: None
+        "discordbot.cogs._games.lobby.schedule_game_message_delete", lambda message: None
     )
 
 
@@ -575,10 +575,10 @@ async def test_dragon_gate_lobby_ante_rejection_keeps_lobby_open(
         )
 
     monkeypatch.setattr(
-        target=lobby, name="apply_jackpot_settlement_batch", value=rejected_ante_batch
+        "discordbot.cogs._games.lobby.apply_jackpot_settlement_batch", rejected_ante_batch
     )
     monkeypatch.setattr(
-        target=lobby, name="schedule_game_message_delete", value=lambda message: None
+        "discordbot.cogs._games.lobby.schedule_game_message_delete", lambda message: None
     )
 
     view = DragonGateLobbyView(
@@ -702,7 +702,7 @@ async def test_dragon_gate_view_uses_capped_jackpot_settlement_delta(
         rng=RiggedRandom(choices=("3", "♠", "9", "♥", "7", "♣")), participants=[owner]
     )
 
-    async def capped_settlement(**kwargs: object) -> JackpotSettlementResult:
+    async def capped_settlement(**kwargs: Any) -> JackpotSettlementResult:  # noqa: ANN401 -- test double accepts heterogeneous kwargs
         """Returns a lower applied delta than the rules snapshot requested."""
         assert kwargs["expected_jackpot_generation"] == 2
         return JackpotSettlementResult(
@@ -714,10 +714,11 @@ async def test_dragon_gate_view_uses_capped_jackpot_settlement_delta(
         )
 
     monkeypatch.setattr(
-        target=dragon_gate_views, name="apply_jackpot_settlement", value=capped_settlement
+        "discordbot.cogs._games.dragon_gate_views.apply_jackpot_settlement", capped_settlement
     )
     monkeypatch.setattr(
-        target=dragon_gate_views, name="schedule_game_message_delete", value=lambda message: None
+        "discordbot.cogs._games.dragon_gate_views.schedule_game_message_delete",
+        lambda message: None,
     )
 
     message = MessageStub()

--- a/tests/test_economy.py
+++ b/tests/test_economy.py
@@ -1,7 +1,7 @@
 """Tests for the economy persistence layer."""
 
-from random import SystemRandom
-from typing import cast
+from random import Random, SystemRandom
+from typing import Any, cast
 import asyncio
 from pathlib import Path
 from datetime import datetime, timedelta
@@ -10,9 +10,6 @@ import pytest
 from sqlalchemy import func, text, select, update
 from sqlalchemy.ext.asyncio import create_async_engine
 
-from discordbot.cogs._games import blackjack as blackjack_rules
-from discordbot.cogs._games import blackjack_views as views
-from discordbot.cogs._economy import database
 from discordbot.typings.games import (
     GameParticipant,
     BlackjackPlayerResult,
@@ -20,13 +17,56 @@ from discordbot.typings.games import (
     BlackjackHandSettlement,
     BlackjackPlayerSettlement,
 )
-from discordbot.cogs._games.blackjack import Card, BlackjackHand, BlackjackRound
+from discordbot.cogs._games.blackjack import (
+    Card,
+    BlackjackHand,
+    BlackjackRound,
+    BlackjackHandState,
+)
+from discordbot.cogs._economy.database import (
+    TAIWAN_TIMEZONE,
+    VIP_PURCHASE_COST,
+    CHECKIN_STREAK_CYCLE,
+    BASE_CHECKIN_REWARD_AMOUNT,
+    JackpotPool,
+    UserAccount,
+    TransferResult,
+    JackpotSnapshot,
+    TransactionKind,
+    PointTransaction,
+    BalanceAdjustmentResult,
+    JackpotSettlementRequest,
+    top_n,
+    buy_vip,
+    checkin,
+    get_vip,
+    transfer,
+    get_admin,
+    set_admin,
+    top_losers,
+    get_account,
+    get_balance,
+    list_admins,
+    open_session,
+    _database_now,
+    _ensure_schema,
+    adjust_balance,
+    checkin_reward,
+    get_jackpot_pool,
+    _build_credit_upsert,
+    get_jackpot_snapshot,
+    credit_with_repayment,
+    apply_round_settlement,
+    apply_jackpot_settlement,
+    apply_jackpot_settlement_batch,
+    _apply_jackpot_delta_in_session,
+)
 from discordbot.cogs._games.settlement import (
     settle_wager,
     settle_blackjack_round,
     settle_blackjack_player,
 )
-from discordbot.cogs._games.blackjack_views import BlackjackView
+from discordbot.cogs._games.blackjack_views import BlackjackView, build_final_embed
 
 pytestmark = pytest.mark.usefixtures("economy_isolated_db")
 
@@ -40,22 +80,22 @@ class _DealerStub:
         self.hint_calls = 0
         self.decision_calls = 0
         self.decisions: list[BlackjackDealerDecision] = []
-        self.hints: list[dict[str, object]] = []
+        self.hints: list[dict[str, Any]] = []
 
-    async def settle(self, **_kwargs: object) -> str:
+    async def settle(self, **_kwargs: Any) -> str:  # noqa: ANN401 -- test double accepts heterogeneous kwargs
         """Returns deterministic banter and tracks settlement calls."""
         self.settle_calls += 1
         await asyncio.sleep(delay=0)
         return "settled"
 
-    async def hint(self, **_kwargs: object) -> str:
+    async def hint(self, **_kwargs: Any) -> str:  # noqa: ANN401 -- test double accepts heterogeneous kwargs
         """Returns deterministic in-progress banter and tracks hint calls."""
         self.hint_calls += 1
         self.hints.append(_kwargs)
         await asyncio.sleep(delay=0)
         return "hint"
 
-    async def decide_blackjack_action(self, **_kwargs: object) -> BlackjackDealerDecision:
+    async def decide_blackjack_action(self, **_kwargs: Any) -> BlackjackDealerDecision:  # noqa: ANN401 -- test double accepts heterogeneous kwargs
         """Returns deterministic dealer decisions and tracks calls."""
         self.decision_calls += 1
         await asyncio.sleep(delay=0)
@@ -70,9 +110,9 @@ class _MessageStub:
     def __init__(self) -> None:
         """Initializes the message edit counter."""
         self.edit_calls = 0
-        self.edits: list[dict[str, object]] = []
+        self.edits: list[dict[str, Any]] = []
 
-    async def edit(self, **_kwargs: object) -> None:
+    async def edit(self, **_kwargs: Any) -> None:  # noqa: ANN401 -- test double accepts heterogeneous kwargs
         """Records a Discord message edit."""
         self.edit_calls += 1
         self.edits.append(_kwargs)
@@ -99,9 +139,9 @@ class _FollowupStub:
 
     def __init__(self) -> None:
         """Initializes recorded followup sends."""
-        self.sent: list[dict[str, object]] = []
+        self.sent: list[dict[str, Any]] = []
 
-    async def send(self, **kwargs: object) -> None:
+    async def send(self, **kwargs: Any) -> None:  # noqa: ANN401 -- test double accepts heterogeneous kwargs
         """Records a followup send payload."""
         self.sent.append(kwargs)
 
@@ -156,24 +196,22 @@ def _round_from_hand(hand: BlackjackHand, participant: GameParticipant) -> Black
 
 async def _stored_avatar_url(user_id: int) -> str:
     """Reads the cached avatar URL for one account."""
-    async with database.open_session() as session:
+    async with open_session() as session:
         result = await session.execute(
-            statement=select(database.UserAccount.avatar_url).where(
-                database.UserAccount.user_id == user_id
-            )
+            statement=select(UserAccount.avatar_url).where(UserAccount.user_id == user_id)
         )
         return result.scalar_one()
 
 
 async def _add_balance(user_id: int, name: str, amount: int, avatar_url: str = "") -> int:
     """Seeds a positive balance without writing audit rows."""
-    await database._ensure_schema()
+    await _ensure_schema()
     if amount <= 0:
-        return await database.get_balance(user_id=user_id)
-    now = database._database_now()
-    async with database.open_session() as session:
+        return await get_balance(user_id=user_id)
+    now = _database_now()
+    async with open_session() as session:
         result = await session.execute(
-            statement=database._build_credit_upsert(
+            statement=_build_credit_upsert(
                 user_id=user_id, name=name, amount=amount, avatar_url=avatar_url, now=now
             )
         )
@@ -183,28 +221,28 @@ async def _add_balance(user_id: int, name: str, amount: int, avatar_url: str = "
 
 async def test_adjust_balance_creates_user() -> None:
     """First manual adjustment upserts the row and returns the new balance."""
-    result = await database.adjust_balance(user_id=42, name="alice", delta=100)
-    assert result == database.BalanceAdjustmentResult(new_balance=100, applied_delta=100)
-    assert await database.get_balance(user_id=42) == 100
+    result = await adjust_balance(user_id=42, name="alice", delta=100)
+    assert result == BalanceAdjustmentResult(new_balance=100, applied_delta=100)
+    assert await get_balance(user_id=42) == 100
 
 
 async def test_adjust_balance_accumulates() -> None:
     """Repeated manual adjustments increment the running balance."""
-    await database.adjust_balance(user_id=42, name="alice", delta=100)
-    result = await database.adjust_balance(user_id=42, name="alice", delta=50)
-    assert result == database.BalanceAdjustmentResult(new_balance=150, applied_delta=50)
+    await adjust_balance(user_id=42, name="alice", delta=100)
+    result = await adjust_balance(user_id=42, name="alice", delta=50)
+    assert result == BalanceAdjustmentResult(new_balance=150, applied_delta=50)
 
 
 async def test_adjust_balance_zero_is_noop() -> None:
     """Zero deltas do not change the balance or write an audit row."""
     await _add_balance(user_id=42, name="alice", amount=100)
-    result = await database.adjust_balance(user_id=42, name="alice", delta=0)
-    assert result == database.BalanceAdjustmentResult(new_balance=100, applied_delta=0)
-    async with database.open_session() as session:
+    result = await adjust_balance(user_id=42, name="alice", delta=0)
+    assert result == BalanceAdjustmentResult(new_balance=100, applied_delta=0)
+    async with open_session() as session:
         count = await session.scalar(
             statement=select(func.count()).where(
-                database.PointTransaction.user_id == 42,
-                database.PointTransaction.kind == database.TransactionKind.MANUAL_ADJUSTMENT.value,
+                PointTransaction.user_id == 42,
+                PointTransaction.kind == TransactionKind.MANUAL_ADJUSTMENT.value,
             )
         )
     assert count == 0
@@ -212,29 +250,25 @@ async def test_adjust_balance_zero_is_noop() -> None:
 
 async def test_adjust_balance_logs_manual_adjustment() -> None:
     """Manual adjustments write explicit MANUAL_ADJUSTMENT audit rows."""
-    result = await database.adjust_balance(user_id=42, name="alice", delta=100)
-    assert result == database.BalanceAdjustmentResult(new_balance=100, applied_delta=100)
-    async with database.open_session() as session:
+    result = await adjust_balance(user_id=42, name="alice", delta=100)
+    assert result == BalanceAdjustmentResult(new_balance=100, applied_delta=100)
+    async with open_session() as session:
         rows = (
             await session.execute(
                 statement=select(
-                    database.PointTransaction.kind,
-                    database.PointTransaction.delta,
-                    database.PointTransaction.balance_after,
-                ).where(database.PointTransaction.user_id == 42)
+                    PointTransaction.kind, PointTransaction.delta, PointTransaction.balance_after
+                ).where(PointTransaction.user_id == 42)
             )
         ).all()
-    assert rows == [(database.TransactionKind.MANUAL_ADJUSTMENT.value, 100, 100)]
+    assert rows == [(TransactionKind.MANUAL_ADJUSTMENT.value, 100, 100)]
 
 
 async def test_adjust_balance_logs_note() -> None:
     """Manual adjustments can annotate the audit row."""
-    await database.adjust_balance(user_id=42, name="alice", delta=100, note="refund_tax by 1")
-    async with database.open_session() as session:
+    await adjust_balance(user_id=42, name="alice", delta=100, note="refund_tax by 1")
+    async with open_session() as session:
         note = await session.scalar(
-            statement=select(database.PointTransaction.note).where(
-                database.PointTransaction.user_id == 42
-            )
+            statement=select(PointTransaction.note).where(PointTransaction.user_id == 42)
         )
     assert note == "refund_tax by 1"
 
@@ -242,32 +276,30 @@ async def test_adjust_balance_logs_note() -> None:
 async def test_adjust_balance_clamps_at_zero() -> None:
     """Negative manual adjustment clamps at zero by default."""
     await _add_balance(user_id=42, name="alice", amount=10)
-    result = await database.adjust_balance(user_id=42, name="alice", delta=-1_000)
-    assert result == database.BalanceAdjustmentResult(new_balance=0, applied_delta=-10)
+    result = await adjust_balance(user_id=42, name="alice", delta=-1_000)
+    assert result == BalanceAdjustmentResult(new_balance=0, applied_delta=-10)
 
 
 async def test_adjust_balance_negative_missing_user_does_not_create_row() -> None:
     """Clamped negative adjustments to absent users stay no-op reads."""
-    result = await database.adjust_balance(user_id=42, name="alice", delta=-1_000)
+    result = await adjust_balance(user_id=42, name="alice", delta=-1_000)
 
-    assert result == database.BalanceAdjustmentResult(new_balance=0, applied_delta=0)
-    assert await database.get_account(user_id=42) is None
+    assert result == BalanceAdjustmentResult(new_balance=0, applied_delta=0)
+    assert await get_account(user_id=42) is None
 
 
 async def test_adjust_balance_allows_negative_when_requested() -> None:
     """Manual tooling can explicitly allow a negative resulting balance."""
     await _add_balance(user_id=42, name="alice", amount=10)
-    result = await database.adjust_balance(
-        user_id=42, name="alice", delta=-500, allow_negative=True
-    )
-    assert result == database.BalanceAdjustmentResult(new_balance=-490, applied_delta=-500)
+    result = await adjust_balance(user_id=42, name="alice", delta=-500, allow_negative=True)
+    assert result == BalanceAdjustmentResult(new_balance=-490, applied_delta=-500)
 
 
 async def test_adjust_balance_refreshes_name() -> None:
     """Subsequent writes refresh the cached display name."""
     await _add_balance(user_id=42, name="alice", amount=10)
     await _add_balance(user_id=42, name="alice_renamed", amount=10)
-    rows = await database.top_n(limit=1)
+    rows = await top_n(limit=1)
     assert rows[0][1] == "alice_renamed"
     assert rows[0][3] == ""
 
@@ -283,61 +315,56 @@ async def test_adjust_balance_stores_and_refreshes_avatar_url() -> None:
 
 async def test_admin_flag_defaults_to_false() -> None:
     """Unknown users and normal accounts are not economy admins."""
-    assert await database.get_admin(user_id=42) is False
+    assert await get_admin(user_id=42) is False
     await _add_balance(user_id=42, name="alice", amount=10)
-    assert await database.get_admin(user_id=42) is False
+    assert await get_admin(user_id=42) is False
 
 
 async def test_set_admin_creates_user() -> None:
     """Granting admin creates a zero-balance account row."""
-    applied = await database.set_admin(user_id=42, name="alice", is_admin=True)
+    applied = await set_admin(user_id=42, name="alice", is_admin=True)
     assert applied is True
-    assert await database.get_admin(user_id=42) is True
-    assert await database.get_balance(user_id=42) == 0
+    assert await get_admin(user_id=42) is True
+    assert await get_balance(user_id=42) == 0
 
 
 async def test_set_admin_revokes_existing_user() -> None:
     """Revoking admin clears the flag on an existing account."""
-    await database.set_admin(user_id=42, name="alice", is_admin=True)
-    applied = await database.set_admin(user_id=42, name="alice", is_admin=False)
+    await set_admin(user_id=42, name="alice", is_admin=True)
+    applied = await set_admin(user_id=42, name="alice", is_admin=False)
     assert applied is True
-    assert await database.get_admin(user_id=42) is False
+    assert await get_admin(user_id=42) is False
 
 
 async def test_set_admin_revoke_missing_user_noops() -> None:
     """Revoking a missing user does not create an account row."""
-    applied = await database.set_admin(user_id=42, name="alice", is_admin=False)
+    applied = await set_admin(user_id=42, name="alice", is_admin=False)
     assert applied is False
-    assert await database.get_account(user_id=42) is None
+    assert await get_account(user_id=42) is None
 
 
 async def test_list_admins_returns_only_admin_accounts() -> None:
     """Admin listing filters out normal economy users."""
-    await database.set_admin(user_id=42, name="alice", is_admin=True)
-    await database.set_admin(user_id=43, name="bob", is_admin=True)
+    await set_admin(user_id=42, name="alice", is_admin=True)
+    await set_admin(user_id=43, name="bob", is_admin=True)
     await _add_balance(user_id=44, name="carol", amount=10)
-    await database.set_admin(user_id=43, name="bob", is_admin=False)
-    assert await database.list_admins() == [(42, "alice")]
+    await set_admin(user_id=43, name="bob", is_admin=False)
+    assert await list_admins() == [(42, "alice")]
 
 
 async def test_write_timestamps_use_taiwan_local_time() -> None:
     """Account and audit timestamps are persisted as Taiwan-local wall time."""
-    before = datetime.now(tz=database.TAIWAN_TIMEZONE).replace(tzinfo=None)
-    await database.credit_with_repayment(
-        user_id=42, name="alice", amount=10, kind=database.TransactionKind.CHAT_REWARD
+    before = datetime.now(tz=TAIWAN_TIMEZONE).replace(tzinfo=None)
+    await credit_with_repayment(
+        user_id=42, name="alice", amount=10, kind=TransactionKind.CHAT_REWARD
     )
-    after = datetime.now(tz=database.TAIWAN_TIMEZONE).replace(tzinfo=None)
+    after = datetime.now(tz=TAIWAN_TIMEZONE).replace(tzinfo=None)
 
-    async with database.open_session() as session:
+    async with open_session() as session:
         result = await session.execute(
-            statement=select(
-                database.UserAccount.updated_at, database.PointTransaction.occurred_at
-            )
-            .join(
-                database.PointTransaction,
-                database.PointTransaction.user_id == database.UserAccount.user_id,
-            )
-            .where(database.UserAccount.user_id == 42)
+            statement=select(UserAccount.updated_at, PointTransaction.occurred_at)
+            .join(PointTransaction, PointTransaction.user_id == UserAccount.user_id)
+            .where(UserAccount.user_id == 42)
         )
         updated_at, occurred_at = result.one()
 
@@ -384,14 +411,14 @@ async def test_existing_economy_db_gets_schema_migrations(
                 """
             )
         )
-    monkeypatch.setattr(target=database, name="_engine", value=engine)
+    monkeypatch.setattr("discordbot.cogs._economy.database._engine", engine)
 
     await _add_balance(
         user_id=42, name="alice", amount=5, avatar_url="https://cdn.example/avatar.png"
     )
 
     assert await _stored_avatar_url(user_id=42) == "https://cdn.example/avatar.png"
-    async with database.open_session() as session:
+    async with open_session() as session:
         result = await session.execute(statement=text(text="PRAGMA table_info(user_account)"))
         columns = {row[1] for row in result.all()}
     assert {"is_vip", "last_checkin_at", "checkin_streak", "is_admin"} <= columns
@@ -401,62 +428,60 @@ async def test_existing_economy_db_gets_schema_migrations(
     # A brand-new user must be insertable after the migration even when the
     # legacy schema had NOT NULL columns without DEFAULT.
     await _add_balance(user_id=43, name="bob", amount=7)
-    assert await database.get_balance(user_id=43) == 7
+    assert await get_balance(user_id=43) == 7
     await engine.dispose()
 
 
 async def test_get_balance_unknown_user_returns_zero() -> None:
     """Reading a never-seen user returns zero, not an error."""
-    assert await database.get_balance(user_id=999) == 0
+    assert await get_balance(user_id=999) == 0
 
 
 async def test_transfer_moves_currency_between_users() -> None:
     """Successful transfer debits sender and credits receiver atomically."""
     await _add_balance(user_id=1, name="alice", amount=200)
-    result = await database.transfer(
+    result = await transfer(
         sender_id=1, sender_name="alice", receiver_id=2, receiver_name="bob", amount=80
     )
-    assert result == database.TransferResult(sender_balance=120, receiver_balance=80)
-    assert await database.get_balance(user_id=1) == 120
-    assert await database.get_balance(user_id=2) == 80
+    assert result == TransferResult(sender_balance=120, receiver_balance=80)
+    assert await get_balance(user_id=1) == 120
+    assert await get_balance(user_id=2) == 80
 
 
 async def test_transfer_rejects_self() -> None:
     """Transfers to oneself must be rejected."""
     await _add_balance(user_id=1, name="alice", amount=100)
-    result = await database.transfer(
+    result = await transfer(
         sender_id=1, sender_name="alice", receiver_id=1, receiver_name="alice", amount=10
     )
     assert result is None
-    assert await database.get_balance(user_id=1) == 100
+    assert await get_balance(user_id=1) == 100
 
 
 async def test_transfer_rejects_insufficient_balance() -> None:
     """Transfers exceeding the sender's balance must be rejected."""
     await _add_balance(user_id=1, name="alice", amount=10)
-    result = await database.transfer(
+    result = await transfer(
         sender_id=1, sender_name="alice", receiver_id=2, receiver_name="bob", amount=100
     )
     assert result is None
-    assert await database.get_balance(user_id=1) == 10
-    assert await database.get_balance(user_id=2) == 0
+    assert await get_balance(user_id=1) == 10
+    assert await get_balance(user_id=2) == 0
 
 
 async def test_transfer_prevents_concurrent_double_spend() -> None:
     """Concurrent transfers from one sender cannot reuse the same points."""
     await _add_balance(user_id=1, name="alice", amount=100)
     results = await asyncio.gather(
-        database.transfer(
-            sender_id=1, sender_name="alice", receiver_id=2, receiver_name="bob", amount=80
-        ),
-        database.transfer(
+        transfer(sender_id=1, sender_name="alice", receiver_id=2, receiver_name="bob", amount=80),
+        transfer(
             sender_id=1, sender_name="alice", receiver_id=3, receiver_name="carol", amount=80
         ),
     )
     assert sum(result is not None for result in results) == 1
     assert results.count(None) == 1
-    assert await database.get_balance(user_id=1) == 20
-    assert await database.get_balance(user_id=2) + await database.get_balance(user_id=3) == 80
+    assert await get_balance(user_id=1) == 20
+    assert await get_balance(user_id=2) + await get_balance(user_id=3) == 80
 
 
 async def test_transfer_concurrent_credits_accumulate() -> None:
@@ -464,24 +489,22 @@ async def test_transfer_concurrent_credits_accumulate() -> None:
     await _add_balance(user_id=1, name="alice", amount=100)
     await _add_balance(user_id=2, name="bob", amount=100)
     results = await asyncio.gather(
-        database.transfer(
+        transfer(
             sender_id=1, sender_name="alice", receiver_id=3, receiver_name="carol", amount=80
         ),
-        database.transfer(
-            sender_id=2, sender_name="bob", receiver_id=3, receiver_name="carol", amount=70
-        ),
+        transfer(sender_id=2, sender_name="bob", receiver_id=3, receiver_name="carol", amount=70),
     )
     assert all(result is not None for result in results)
     assert {result.sender_balance for result in results if result is not None} == {20, 30}
     assert max(result.receiver_balance for result in results if result is not None) == 150
-    assert await database.get_balance(user_id=3) == 150
+    assert await get_balance(user_id=3) == 150
 
 
 @pytest.mark.parametrize(argnames="amount", argvalues=[0, -1, -1000])
 async def test_transfer_rejects_non_positive(amount: int) -> None:
     """Transfers with non-positive amounts must be rejected."""
     await _add_balance(user_id=1, name="alice", amount=100)
-    result = await database.transfer(
+    result = await transfer(
         sender_id=1, sender_name="alice", receiver_id=2, receiver_name="bob", amount=amount
     )
     assert result is None
@@ -492,7 +515,7 @@ async def test_top_n_orders_by_balance_descending() -> None:
     await _add_balance(user_id=1, name="alice", amount=100, avatar_url="https://cdn/a.png")
     await _add_balance(user_id=2, name="bob", amount=300, avatar_url="https://cdn/b.png")
     await _add_balance(user_id=3, name="carol", amount=50)
-    rows = await database.top_n(limit=2)
+    rows = await top_n(limit=2)
     assert rows == [(2, "bob", 300, "https://cdn/b.png"), (1, "alice", 100, "https://cdn/a.png")]
 
 
@@ -501,14 +524,14 @@ async def test_top_n_excludes_specified_users() -> None:
     await _add_balance(user_id=1, name="alice", amount=100)
     await _add_balance(user_id=2, name="bob", amount=300)
     await _add_balance(user_id=99, name="house", amount=999)
-    rows = await database.top_n(limit=10, exclude_user_ids=(99,))
+    rows = await top_n(limit=10, exclude_user_ids=(99,))
     assert all(row[0] != 99 for row in rows)
     assert rows[0][:3] == (2, "bob", 300)
 
 
 async def test_apply_round_settlement_allows_negative_house_balance() -> None:
     """House ledger keeps a true running net even when the dealer is down."""
-    await database.apply_round_settlement(
+    await apply_round_settlement(
         player_id=1,
         player_account_name="alice",
         player_delta=500,
@@ -516,12 +539,12 @@ async def test_apply_round_settlement_allows_negative_house_balance() -> None:
         dealer_name="house",
         dealer_delta=-500,
     )
-    assert await database.get_balance(user_id=99) == -500
+    assert await get_balance(user_id=99) == -500
 
 
 async def test_apply_round_settlement_house_accumulates_gross_flows() -> None:
     """Wins and losses both accumulate gross totals, not just the net balance."""
-    await database.apply_round_settlement(
+    await apply_round_settlement(
         player_id=1,
         player_account_name="alice",
         player_delta=-200,
@@ -529,7 +552,7 @@ async def test_apply_round_settlement_house_accumulates_gross_flows() -> None:
         dealer_name="house",
         dealer_delta=200,
     )
-    await database.apply_round_settlement(
+    await apply_round_settlement(
         player_id=2,
         player_account_name="bob",
         player_delta=300,
@@ -537,7 +560,7 @@ async def test_apply_round_settlement_house_accumulates_gross_flows() -> None:
         dealer_name="house",
         dealer_delta=-300,
     )
-    account = await database.get_account(user_id=99)
+    account = await get_account(user_id=99)
     assert account is not None
     name, balance, total_earned, total_spent = account
     assert name == "house"
@@ -560,7 +583,7 @@ async def test_settle_wager_updates_player_and_house() -> None:
 
 async def test_get_account_returns_none_for_unseen_user() -> None:
     """Unknown users return None instead of a synthetic zero row."""
-    assert await database.get_account(user_id=12345) is None
+    assert await get_account(user_id=12345) is None
 
 
 async def test_settle_blackjack_round_updates_player_and_house() -> None:
@@ -579,21 +602,22 @@ async def test_settle_blackjack_round_updates_player_and_house() -> None:
     assert settlement.payout == 50
     assert settlement.new_balance == 150
     assert settlement.house_balance == -50
-    assert await database.get_balance(user_id=99) == -50
+    assert await get_balance(user_id=99) == -50
 
 
 async def test_blackjack_view_finalizes_once_when_called_concurrently(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Concurrent finalization attempts must not pay out one Blackjack hand twice."""
-    cleanup_messages: list[object] = []
+    cleanup_messages: list[_MessageStub] = []
 
-    def fake_schedule_game_message_delete(message: object, delay: float = 180) -> None:
+    def fake_schedule_game_message_delete(message: _MessageStub, delay: float = 180) -> None:
         """Records the final message scheduled for cleanup."""
         cleanup_messages.append(message)
 
     monkeypatch.setattr(
-        target=views, name="schedule_game_message_delete", value=fake_schedule_game_message_delete
+        "discordbot.cogs._games.blackjack_views.schedule_game_message_delete",
+        fake_schedule_game_message_delete,
     )
     await _add_balance(user_id=1, name="alice", amount=100)
 
@@ -616,11 +640,11 @@ async def test_blackjack_view_finalizes_once_when_called_concurrently(
 
     await asyncio.gather(view.finalize(message=message), view.finalize(message=message))
 
-    assert await database.get_balance(user_id=1) == 150
-    assert await database.get_balance(user_id=99) == -50
+    assert await get_balance(user_id=1) == 150
+    assert await get_balance(user_id=99) == -50
     assert dealer.settle_calls == 1
     assert message.edit_calls == 2
-    thinking_embeds = cast("list[object]", message.edits[0]["embeds"])
+    thinking_embeds = cast("list[Any]", message.edits[0]["embeds"])
     thinking_line = cast("str", thinking_embeds[0].description)
     assert "莊家正在思考 hit / stand" in thinking_line
     assert cleanup_messages == [message]
@@ -630,14 +654,15 @@ async def test_blackjack_view_timeout_auto_stands_and_settles(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A player who walks away is treated as standing and the wager resolves."""
-    cleanup_messages: list[object] = []
+    cleanup_messages: list[_MessageStub] = []
 
-    def fake_schedule_game_message_delete(message: object, delay: float = 180) -> None:
+    def fake_schedule_game_message_delete(message: _MessageStub, delay: float = 180) -> None:
         """Records the final message scheduled for cleanup."""
         cleanup_messages.append(message)
 
     monkeypatch.setattr(
-        target=views, name="schedule_game_message_delete", value=fake_schedule_game_message_delete
+        "discordbot.cogs._games.blackjack_views.schedule_game_message_delete",
+        fake_schedule_game_message_delete,
     )
     await _add_balance(user_id=1, name="alice", amount=100)
 
@@ -661,11 +686,11 @@ async def test_blackjack_view_timeout_auto_stands_and_settles(
     await view.on_timeout()
 
     assert view.round_state.finished is True
-    assert await database.get_balance(user_id=1) == 50
-    assert await database.get_balance(user_id=99) == 50
+    assert await get_balance(user_id=1) == 50
+    assert await get_balance(user_id=99) == 50
     assert dealer.settle_calls == 1
     assert message.edit_calls == 2
-    thinking_embeds = cast("list[object]", message.edits[0]["embeds"])
+    thinking_embeds = cast("list[Any]", message.edits[0]["embeds"])
     thinking_line = cast("str", thinking_embeds[0].description)
     assert "莊家正在思考 hit / stand" in thinking_line
     assert cleanup_messages == [message]
@@ -673,20 +698,21 @@ async def test_blackjack_view_timeout_auto_stands_and_settles(
 
 async def test_blackjack_view_uses_ai_dealer_decisions(monkeypatch: pytest.MonkeyPatch) -> None:
     """Dealer AI can hit once, stand, and settle with the updated dealer hand."""
-    cleanup_messages: list[object] = []
+    cleanup_messages: list[_MessageStub] = []
 
-    def fake_schedule_game_message_delete(message: object, delay: float = 180) -> None:
+    def fake_schedule_game_message_delete(message: _MessageStub, delay: float = 180) -> None:
         """Records the final message scheduled for cleanup."""
         cleanup_messages.append(message)
 
-    def draw_fixed_card(rng: object) -> Card:
+    def draw_fixed_card(rng: Random) -> Card:
         """Returns a deterministic dealer draw."""
         return Card(rank="5", suit="♣")
 
     monkeypatch.setattr(
-        target=views, name="schedule_game_message_delete", value=fake_schedule_game_message_delete
+        "discordbot.cogs._games.blackjack_views.schedule_game_message_delete",
+        fake_schedule_game_message_delete,
     )
-    monkeypatch.setattr(target=blackjack_rules, name="draw_card", value=draw_fixed_card)
+    monkeypatch.setattr("discordbot.cogs._games.blackjack.draw_card", draw_fixed_card)
     await _add_balance(user_id=1, name="alice", amount=100)
 
     participant = _participant()
@@ -717,12 +743,12 @@ async def test_blackjack_view_uses_ai_dealer_decisions(monkeypatch: pytest.Monke
     assert [str(card) for card in view.round_state.dealer] == ["10♣", "3♦", "5♣"]
     assert view.round_state.dealer_played is True
     assert dealer.decision_calls == 2
-    assert await database.get_balance(user_id=1) == 50
-    assert await database.get_balance(user_id=99) == 50
-    thinking_embeds = cast("list[object]", message.edits[0]["embeds"])
+    assert await get_balance(user_id=1) == 50
+    assert await get_balance(user_id=99) == 50
+    thinking_embeds = cast("list[Any]", message.edits[0]["embeds"])
     thinking_line = cast("str", thinking_embeds[0].description)
     assert "莊家正在思考 hit / stand" in thinking_line
-    final_embeds = cast("list[object]", message.edits[1]["embeds"])
+    final_embeds = cast("list[Any]", message.edits[1]["embeds"])
     description = cast("str", final_embeds[1].description)
     assert "AI決策: 13 hit 抽 5♣ → 18；18 stand" in description
     assert cleanup_messages == [message]
@@ -768,21 +794,22 @@ async def test_blackjack_view_basic_rule_fallback_finishes_dealer_phase(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A DealerAI fallback decision switches the rest of the dealer phase to basic rule."""
-    cleanup_messages: list[object] = []
+    cleanup_messages: list[_MessageStub] = []
     draws = [Card(rank="5", suit="♣")]
 
-    def fake_schedule_game_message_delete(message: object, delay: float = 180) -> None:
+    def fake_schedule_game_message_delete(message: _MessageStub, delay: float = 180) -> None:
         """Records the final message scheduled for cleanup."""
         cleanup_messages.append(message)
 
-    def draw_fixed_card(rng: object) -> Card:
+    def draw_fixed_card(rng: Random) -> Card:
         """Returns deterministic dealer draws."""
         return draws.pop(0)
 
     monkeypatch.setattr(
-        target=views, name="schedule_game_message_delete", value=fake_schedule_game_message_delete
+        "discordbot.cogs._games.blackjack_views.schedule_game_message_delete",
+        fake_schedule_game_message_delete,
     )
-    monkeypatch.setattr(target=blackjack_rules, name="draw_card", value=draw_fixed_card)
+    monkeypatch.setattr("discordbot.cogs._games.blackjack.draw_card", draw_fixed_card)
     await _add_balance(user_id=1, name="alice", amount=100)
 
     participant = _participant()
@@ -810,10 +837,10 @@ async def test_blackjack_view_basic_rule_fallback_finishes_dealer_phase(
     assert dealer.decision_calls == 1
     assert view.round_state.dealer_total() == 18
     assert len(view.round_state.dealer) == 3
-    thinking_embeds = cast("list[object]", message.edits[0]["embeds"])
+    thinking_embeds = cast("list[Any]", message.edits[0]["embeds"])
     thinking_line = cast("str", thinking_embeds[0].description)
     assert "莊家正在思考 hit / stand" in thinking_line
-    final_embeds = cast("list[object]", message.edits[1]["embeds"])
+    final_embeds = cast("list[Any]", message.edits[1]["embeds"])
     description = cast("str", final_embeds[1].description)
     assert "fallback basic rule" in description
     assert cleanup_messages == [message]
@@ -823,15 +850,15 @@ async def test_blackjack_view_locks_actions_while_finalizing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A late Hit cannot mutate a hand that is already finalizing from Stand."""
-    cleanup_messages: list[object] = []
+    cleanup_messages: list[_MessageStub] = []
     settlement_started = asyncio.Event()
     continue_settlement = asyncio.Event()
 
-    def fake_schedule_game_message_delete(message: object, delay: float = 180) -> None:
+    def fake_schedule_game_message_delete(message: _MessageStub, delay: float = 180) -> None:
         """Records the final message scheduled for cleanup."""
         cleanup_messages.append(message)
 
-    async def delayed_settle_blackjack_player(**_kwargs: object) -> BlackjackPlayerSettlement:
+    async def delayed_settle_blackjack_player(**_kwargs: Any) -> BlackjackPlayerSettlement:  # noqa: ANN401 -- test double accepts heterogeneous kwargs
         """Blocks settlement until the test releases the finalization lock."""
         settlement_started.set()
         await continue_settlement.wait()
@@ -853,10 +880,12 @@ async def test_blackjack_view_locks_actions_while_finalizing(
         )
 
     monkeypatch.setattr(
-        target=views, name="schedule_game_message_delete", value=fake_schedule_game_message_delete
+        "discordbot.cogs._games.blackjack_views.schedule_game_message_delete",
+        fake_schedule_game_message_delete,
     )
     monkeypatch.setattr(
-        target=views, name="settle_blackjack_player", value=delayed_settle_blackjack_player
+        "discordbot.cogs._games.blackjack_views.settle_blackjack_player",
+        delayed_settle_blackjack_player,
     )
 
     hand = BlackjackHand(rng=SystemRandom(), bet=50)
@@ -891,7 +920,7 @@ async def test_blackjack_view_locks_actions_while_finalizing(
     assert dealer.settle_calls == 1
     assert dealer.hint_calls == 0
     assert message.edit_calls == 2
-    thinking_embeds = cast("list[object]", message.edits[0]["embeds"])
+    thinking_embeds = cast("list[Any]", message.edits[0]["embeds"])
     thinking_line = cast("str", thinking_embeds[0].description)
     assert "莊家正在思考 hit / stand" in thinking_line
     assert cleanup_messages == [message]
@@ -943,11 +972,11 @@ async def test_blackjack_view_rejects_stale_hit_without_drawing_for_next_player(
 ) -> None:
     """A stale Hit interaction cannot draw a card for the next active player."""
 
-    def fail_draw(rng: object) -> Card:
+    def fail_draw(rng: Random) -> Card:
         """Fails the test if stale Hit reaches card draw."""
         raise AssertionError("stale hit should not draw")
 
-    monkeypatch.setattr(target=blackjack_rules, name="draw_card", value=fail_draw)
+    monkeypatch.setattr("discordbot.cogs._games.blackjack.draw_card", fail_draw)
     round_state = BlackjackRound.from_participants(
         rng=SystemRandom(),
         participants=[
@@ -988,25 +1017,25 @@ async def test_blackjack_view_hit_hint_uses_active_split_hand_total(
 ) -> None:
     """Hit hint should describe the active split hand, not the first hand."""
 
-    def draw_five(rng: object) -> Card:
+    def draw_five(rng: Random) -> Card:
         """Returns a deterministic card for the active split hand."""
         return Card(rank="5", suit="♣")
 
-    monkeypatch.setattr(target=blackjack_rules, name="draw_card", value=draw_five)
+    monkeypatch.setattr("discordbot.cogs._games.blackjack.draw_card", draw_five)
     participant = _participant(user_id=1, account_name="alice", display_name="Alice")
     round_state = BlackjackRound.from_participants(
         rng=SystemRandom(), participants=[participant], auto_play_dealer=False
     )
     player = round_state.players[0]
     player.hands = [
-        blackjack_rules.BlackjackHandState(
+        BlackjackHandState(
             cards=[Card(rank="10", suit="♠"), Card(rank="2", suit="♥")],
             bet=50,
             base_bet=50,
             is_split_hand=True,
             finished=True,
         ),
-        blackjack_rules.BlackjackHandState(
+        BlackjackHandState(
             cards=[Card(rank="9", suit="♣"), Card(rank="2", suit="♦")],
             bet=50,
             base_bet=50,
@@ -1040,7 +1069,7 @@ async def test_add_balance_concurrent_credits_accumulate() -> None:
     """Verifies that concurrent credits on the same user do not lose updates."""
     await _add_balance(user_id=42, name="alice", amount=100)
     await asyncio.gather(*[_add_balance(user_id=42, name="alice", amount=10) for _ in range(20)])
-    assert await database.get_balance(user_id=42) == 300
+    assert await get_balance(user_id=42) == 300
 
 
 async def test_add_balance_concurrent_first_sight_does_not_raise() -> None:
@@ -1049,14 +1078,14 @@ async def test_add_balance_concurrent_first_sight_does_not_raise() -> None:
         _add_balance(user_id=42, name="alice", amount=10) for _ in range(8)
     ])
     assert all(isinstance(value, int) for value in results)
-    assert await database.get_balance(user_id=42) == 80
+    assert await get_balance(user_id=42) == 80
 
 
 async def test_apply_round_settlement_concurrent_credits_accumulate() -> None:
     """Concurrent positive settlements on the same user must not lose updates."""
     await _add_balance(user_id=42, name="alice", amount=100)
     await asyncio.gather(*[
-        database.apply_round_settlement(
+        apply_round_settlement(
             player_id=42,
             player_account_name="alice",
             player_delta=10,
@@ -1066,13 +1095,13 @@ async def test_apply_round_settlement_concurrent_credits_accumulate() -> None:
         )
         for _ in range(10)
     ])
-    assert await database.get_balance(user_id=42) == 200
+    assert await get_balance(user_id=42) == 200
 
 
 async def test_apply_round_settlement_concurrent_house_updates_accumulate() -> None:
     """Verifies that concurrent dealer ledger settlements accumulate."""
     await asyncio.gather(*[
-        database.apply_round_settlement(
+        apply_round_settlement(
             player_id=user_id,
             player_account_name=f"player{user_id}",
             player_delta=-10,
@@ -1082,7 +1111,7 @@ async def test_apply_round_settlement_concurrent_house_updates_accumulate() -> N
         )
         for user_id in range(10)
     ])
-    account = await database.get_account(user_id=99)
+    account = await get_account(user_id=99)
     assert account is not None
     _, balance, total_earned, total_spent = account
     assert balance == 100
@@ -1094,7 +1123,7 @@ async def test_apply_round_settlement_is_atomic() -> None:
     """Player delta and house mirror share one transaction and one return."""
     await _add_balance(user_id=1, name="alice", amount=100)
 
-    player_balance, house_balance = await database.apply_round_settlement(
+    player_balance, house_balance = await apply_round_settlement(
         player_id=1,
         player_account_name="alice",
         player_delta=40,
@@ -1104,15 +1133,15 @@ async def test_apply_round_settlement_is_atomic() -> None:
     )
     assert player_balance == 140
     assert house_balance == -40
-    assert await database.get_balance(user_id=1) == 140
-    assert await database.get_balance(user_id=99) == -40
+    assert await get_balance(user_id=1) == 140
+    assert await get_balance(user_id=99) == -40
 
 
 async def test_apply_round_settlement_loss_debits_player_and_house() -> None:
     """A loss debits the player and credits the house."""
     await _add_balance(user_id=1, name="alice", amount=100)
 
-    player_balance, house_balance = await database.apply_round_settlement(
+    player_balance, house_balance = await apply_round_settlement(
         player_id=1,
         player_account_name="alice",
         player_delta=-40,
@@ -1122,7 +1151,7 @@ async def test_apply_round_settlement_loss_debits_player_and_house() -> None:
     )
     assert player_balance == 60
     assert house_balance == 40
-    account = await database.get_account(user_id=1)
+    account = await get_account(user_id=1)
     assert account is not None
     _, _, total_earned, total_spent = account
     assert total_earned == 100
@@ -1133,7 +1162,7 @@ async def test_apply_round_settlement_loss_can_make_player_negative() -> None:
     """Deferred settlement still collects a loss after the balance was spent elsewhere."""
     await _add_balance(user_id=1, name="alice", amount=25)
 
-    player_balance, house_balance = await database.apply_round_settlement(
+    player_balance, house_balance = await apply_round_settlement(
         player_id=1,
         player_account_name="alice",
         player_delta=-40,
@@ -1151,38 +1180,37 @@ async def test_apply_round_settlement_loss_can_make_player_negative() -> None:
 
 async def test_checkin_first_time_credits_base_reward() -> None:
     """A first check-in pays the base reward and persists a streak of 1."""
-    result = await database.checkin(user_id=1, name="alice")
+    result = await checkin(user_id=1, name="alice")
     assert result is not None
-    assert result.amount == database.BASE_CHECKIN_REWARD_AMOUNT
+    assert result.amount == BASE_CHECKIN_REWARD_AMOUNT
     assert result.streak == 1
     assert result.is_vip is False
-    assert result.new_balance == database.BASE_CHECKIN_REWARD_AMOUNT
+    assert result.new_balance == BASE_CHECKIN_REWARD_AMOUNT
 
 
 async def test_checkin_same_day_is_rejected() -> None:
     """A second check-in within the same Taipei day must return None."""
-    first = await database.checkin(user_id=1, name="alice")
+    first = await checkin(user_id=1, name="alice")
     assert first is not None
-    second = await database.checkin(user_id=1, name="alice")
+    second = await checkin(user_id=1, name="alice")
     assert second is None
-    assert await database.get_balance(user_id=1) == first.new_balance
+    assert await get_balance(user_id=1) == first.new_balance
 
 
 async def test_checkin_consecutive_day_advances_streak() -> None:
     """A check-in on the next calendar day bumps the streak by 1."""
-    first = await database.checkin(user_id=1, name="alice")
+    first = await checkin(user_id=1, name="alice")
     assert first is not None
     # Backdate the previous check-in to yesterday Taipei
-    yesterday = datetime.now(tz=database.TAIWAN_TIMEZONE) - timedelta(days=1)
-    async with database.open_session() as session:
+    yesterday = datetime.now(tz=TAIWAN_TIMEZONE) - timedelta(days=1)
+    async with open_session() as session:
         await session.execute(
-            statement=database
-            .update(database.UserAccount)
-            .where(database.UserAccount.user_id == 1)
+            statement=update(UserAccount)
+            .where(UserAccount.user_id == 1)
             .values(last_checkin_at=yesterday)
         )
         await session.commit()
-    second = await database.checkin(user_id=1, name="alice")
+    second = await checkin(user_id=1, name="alice")
     assert second is not None
     assert second.streak == 2
     assert second.amount > first.amount
@@ -1190,51 +1218,49 @@ async def test_checkin_consecutive_day_advances_streak() -> None:
 
 async def test_checkin_streak_cycles_back_to_one_after_seven() -> None:
     """Day 8 in a row resets back to streak 1."""
-    await database.checkin(user_id=1, name="alice")
-    async with database.open_session() as session:
+    await checkin(user_id=1, name="alice")
+    async with open_session() as session:
         await session.execute(
-            statement=database
-            .update(database.UserAccount)
-            .where(database.UserAccount.user_id == 1)
+            statement=update(UserAccount)
+            .where(UserAccount.user_id == 1)
             .values(
-                last_checkin_at=datetime.now(tz=database.TAIWAN_TIMEZONE) - timedelta(days=1),
-                checkin_streak=database.CHECKIN_STREAK_CYCLE,
+                last_checkin_at=datetime.now(tz=TAIWAN_TIMEZONE) - timedelta(days=1),
+                checkin_streak=CHECKIN_STREAK_CYCLE,
             )
         )
         await session.commit()
-    result = await database.checkin(user_id=1, name="alice")
+    result = await checkin(user_id=1, name="alice")
     assert result is not None
     assert result.streak == 1
 
 
 async def test_checkin_missed_day_resets_streak_to_one() -> None:
     """Skipping a day resets the streak back to 1."""
-    await database.checkin(user_id=1, name="alice")
-    async with database.open_session() as session:
+    await checkin(user_id=1, name="alice")
+    async with open_session() as session:
         await session.execute(
-            statement=database
-            .update(database.UserAccount)
-            .where(database.UserAccount.user_id == 1)
+            statement=update(UserAccount)
+            .where(UserAccount.user_id == 1)
             .values(
-                last_checkin_at=datetime.now(tz=database.TAIWAN_TIMEZONE) - timedelta(days=3),
+                last_checkin_at=datetime.now(tz=TAIWAN_TIMEZONE) - timedelta(days=3),
                 checkin_streak=4,
             )
         )
         await session.commit()
-    result = await database.checkin(user_id=1, name="alice")
+    result = await checkin(user_id=1, name="alice")
     assert result is not None
     assert result.streak == 1
 
 
 async def test_checkin_vip_gets_double_base() -> None:
     """A VIP account starts at 2x base before the streak multiplier."""
-    await _add_balance(user_id=1, name="alice", amount=database.VIP_PURCHASE_COST)
-    purchase = await database.buy_vip(user_id=1, name="alice")
+    await _add_balance(user_id=1, name="alice", amount=VIP_PURCHASE_COST)
+    purchase = await buy_vip(user_id=1, name="alice")
     assert purchase is not None
-    result = await database.checkin(user_id=1, name="alice")
+    result = await checkin(user_id=1, name="alice")
     assert result is not None
     assert result.is_vip is True
-    assert result.amount == 2 * database.BASE_CHECKIN_REWARD_AMOUNT
+    assert result.amount == 2 * BASE_CHECKIN_REWARD_AMOUNT
 
 
 @pytest.mark.parametrize(
@@ -1249,24 +1275,22 @@ async def test_checkin_vip_gets_double_base() -> None:
 )
 def test_checkin_reward_formula(streak: int, is_vip: bool, expected: int) -> None:
     """Streak + VIP combinations compute to the expected reward."""
-    assert database.checkin_reward(streak=streak, is_vip=is_vip) == expected
+    assert checkin_reward(streak=streak, is_vip=is_vip) == expected
 
 
 async def test_checkin_logs_audit_row() -> None:
     """A successful check-in writes one CHECKIN_REWARD row tagged with the streak."""
-    result = await database.checkin(user_id=1, name="alice")
+    result = await checkin(user_id=1, name="alice")
     assert result is not None
-    async with database.open_session() as session:
+    async with open_session() as session:
         rows = (
             await session.execute(
                 statement=select(
-                    database.PointTransaction.kind,
-                    database.PointTransaction.delta,
-                    database.PointTransaction.note,
-                ).where(database.PointTransaction.user_id == 1)
+                    PointTransaction.kind, PointTransaction.delta, PointTransaction.note
+                ).where(PointTransaction.user_id == 1)
             )
         ).all()
-    assert rows == [(database.TransactionKind.CHECKIN_REWARD.value, result.amount, "streak 1")]
+    assert rows == [(TransactionKind.CHECKIN_REWARD.value, result.amount, "streak 1")]
 
 
 # VIP purchase --------------------------------------------------------------
@@ -1274,55 +1298,55 @@ async def test_checkin_logs_audit_row() -> None:
 
 async def test_buy_vip_sets_flag_and_debits_balance() -> None:
     """A successful purchase costs ``VIP_PURCHASE_COST`` and flips ``is_vip``."""
-    await _add_balance(user_id=1, name="alice", amount=database.VIP_PURCHASE_COST + 100)
-    result = await database.buy_vip(user_id=1, name="alice")
+    await _add_balance(user_id=1, name="alice", amount=VIP_PURCHASE_COST + 100)
+    result = await buy_vip(user_id=1, name="alice")
     assert result is not None
     assert result.new_balance == 100
-    assert result.cost == database.VIP_PURCHASE_COST
-    assert await database.get_vip(user_id=1) is True
+    assert result.cost == VIP_PURCHASE_COST
+    assert await get_vip(user_id=1) is True
 
 
 async def test_buy_vip_rejects_insufficient_balance() -> None:
     """Users without enough points cannot purchase VIP."""
     await _add_balance(user_id=1, name="alice", amount=100)
-    result = await database.buy_vip(user_id=1, name="alice")
+    result = await buy_vip(user_id=1, name="alice")
     assert result is None
-    assert await database.get_vip(user_id=1) is False
+    assert await get_vip(user_id=1) is False
 
 
 async def test_buy_vip_rejects_existing_vip() -> None:
     """A second purchase by an existing VIP returns None and does not re-debit."""
-    await _add_balance(user_id=1, name="alice", amount=database.VIP_PURCHASE_COST * 2)
-    first = await database.buy_vip(user_id=1, name="alice")
+    await _add_balance(user_id=1, name="alice", amount=VIP_PURCHASE_COST * 2)
+    first = await buy_vip(user_id=1, name="alice")
     assert first is not None
-    second = await database.buy_vip(user_id=1, name="alice")
+    second = await buy_vip(user_id=1, name="alice")
     assert second is None
-    assert await database.get_balance(user_id=1) == database.VIP_PURCHASE_COST
+    assert await get_balance(user_id=1) == VIP_PURCHASE_COST
 
 
 async def test_buy_vip_rejects_unseen_user() -> None:
     """A user without a row cannot purchase (no balance to debit)."""
-    assert await database.buy_vip(user_id=999, name="ghost") is None
+    assert await buy_vip(user_id=999, name="ghost") is None
 
 
 async def test_buy_vip_logs_audit_row() -> None:
     """A successful purchase records one VIP_PURCHASE audit row."""
-    await _add_balance(user_id=1, name="alice", amount=database.VIP_PURCHASE_COST)
-    await database.buy_vip(user_id=1, name="alice")
-    async with database.open_session() as session:
+    await _add_balance(user_id=1, name="alice", amount=VIP_PURCHASE_COST)
+    await buy_vip(user_id=1, name="alice")
+    async with open_session() as session:
         rows = (
             await session.execute(
-                statement=select(
-                    database.PointTransaction.kind, database.PointTransaction.delta
-                ).where(database.PointTransaction.user_id == 1)
+                statement=select(PointTransaction.kind, PointTransaction.delta).where(
+                    PointTransaction.user_id == 1
+                )
             )
         ).all()
-    assert rows == [(database.TransactionKind.VIP_PURCHASE.value, -database.VIP_PURCHASE_COST)]
+    assert rows == [(TransactionKind.VIP_PURCHASE.value, -VIP_PURCHASE_COST)]
 
 
 async def test_get_vip_unknown_user_returns_false() -> None:
     """Unknown users report no VIP perk rather than raising."""
-    assert await database.get_vip(user_id=12345) is False
+    assert await get_vip(user_id=12345) is False
 
 
 # Loss leaderboard ----------------------------------------------------------
@@ -1332,7 +1356,7 @@ async def test_top_losers_only_lists_net_negative_players() -> None:
     """A player with a positive casino net does not appear on the loss board."""
     await _add_balance(user_id=1, name="alice", amount=1_000)
     await _add_balance(user_id=2, name="bob", amount=1_000)
-    await database.apply_round_settlement(
+    await apply_round_settlement(
         player_id=1,
         player_account_name="alice",
         player_delta=-300,
@@ -1340,7 +1364,7 @@ async def test_top_losers_only_lists_net_negative_players() -> None:
         dealer_name="house",
         dealer_delta=300,
     )
-    await database.apply_round_settlement(
+    await apply_round_settlement(
         player_id=2,
         player_account_name="bob",
         player_delta=200,
@@ -1348,7 +1372,7 @@ async def test_top_losers_only_lists_net_negative_players() -> None:
         dealer_name="house",
         dealer_delta=-200,
     )
-    rows = await database.top_losers(limit=10, exclude_user_ids=(99,))
+    rows = await top_losers(limit=10, exclude_user_ids=(99,))
     assert [(row[0], row[1], row[2]) for row in rows] == [(1, "alice", 300)]
 
 
@@ -1356,7 +1380,7 @@ async def test_top_losers_orders_by_loss_magnitude() -> None:
     """The leaderboard sorts from biggest loss to smallest."""
     for user_id, name, loss in [(1, "alice", 100), (2, "bob", 500), (3, "carol", 250)]:
         await _add_balance(user_id=user_id, name=name, amount=loss)
-        await database.apply_round_settlement(
+        await apply_round_settlement(
             player_id=user_id,
             player_account_name=name,
             player_delta=-loss,
@@ -1364,14 +1388,14 @@ async def test_top_losers_orders_by_loss_magnitude() -> None:
             dealer_name="house",
             dealer_delta=loss,
         )
-    rows = await database.top_losers(limit=10, exclude_user_ids=(99,))
+    rows = await top_losers(limit=10, exclude_user_ids=(99,))
     assert [(row[0], row[2]) for row in rows] == [(2, 500), (3, 250), (1, 100)]
 
 
 async def test_top_losers_excludes_specified_users() -> None:
     """``exclude_user_ids`` filters the house ledger out of the report."""
     await _add_balance(user_id=1, name="alice", amount=500)
-    await database.apply_round_settlement(
+    await apply_round_settlement(
         player_id=1,
         player_account_name="alice",
         player_delta=-500,
@@ -1379,14 +1403,14 @@ async def test_top_losers_excludes_specified_users() -> None:
         dealer_name="house",
         dealer_delta=500,
     )
-    rows = await database.top_losers(limit=10, exclude_user_ids=(99,))
+    rows = await top_losers(limit=10, exclude_user_ids=(99,))
     assert all(row[0] != 99 for row in rows)
 
 
 async def test_top_losers_ignores_events_before_today() -> None:
     """Audit rows older than today's Taipei midnight do not count."""
     await _add_balance(user_id=1, name="alice", amount=500)
-    await database.apply_round_settlement(
+    await apply_round_settlement(
         player_id=1,
         player_account_name="alice",
         player_delta=-500,
@@ -1394,25 +1418,23 @@ async def test_top_losers_ignores_events_before_today() -> None:
         dealer_name="house",
         dealer_delta=500,
     )
-    past = datetime.now(tz=database.TAIWAN_TIMEZONE) - timedelta(days=2)
-    async with database.open_session() as session:
-        await session.execute(
-            statement=database.update(database.PointTransaction).values(occurred_at=past)
-        )
+    past = datetime.now(tz=TAIWAN_TIMEZONE) - timedelta(days=2)
+    async with open_session() as session:
+        await session.execute(statement=update(PointTransaction).values(occurred_at=past))
         await session.commit()
-    assert await database.top_losers(limit=10, exclude_user_ids=(99,)) == []
+    assert await top_losers(limit=10, exclude_user_ids=(99,)) == []
 
 
 async def test_top_losers_empty_when_no_casino_activity() -> None:
     """Without any CASINO_BET / CASINO_PAYOUT rows the leaderboard is empty."""
     await _add_balance(user_id=1, name="alice", amount=100)
-    assert await database.top_losers(limit=10, exclude_user_ids=(99,)) == []
+    assert await top_losers(limit=10, exclude_user_ids=(99,)) == []
 
 
 async def test_top_losers_ignores_manual_adjustments() -> None:
     """Manual admin debits do not count as casino losses."""
-    await database.adjust_balance(user_id=1, name="alice", delta=-100, allow_negative=True)
-    assert await database.top_losers(limit=10, exclude_user_ids=(99,)) == []
+    await adjust_balance(user_id=1, name="alice", delta=-100, allow_negative=True)
+    assert await top_losers(limit=10, exclude_user_ids=(99,)) == []
 
 
 # VIP blackjack settlement -------------------------------------------------
@@ -1420,8 +1442,8 @@ async def test_top_losers_ignores_manual_adjustments() -> None:
 
 async def test_settle_wager_applies_vip_bonus_on_win() -> None:
     """A VIP player wins 1.5x of the base delta; house mirrors the boosted amount."""
-    await _add_balance(user_id=1, name="alice", amount=database.VIP_PURCHASE_COST)
-    purchase = await database.buy_vip(user_id=1, name="alice")
+    await _add_balance(user_id=1, name="alice", amount=VIP_PURCHASE_COST)
+    purchase = await buy_vip(user_id=1, name="alice")
     assert purchase is not None
     settlement = await settle_wager(
         player_id=1, player_account_name="alice", dealer_id=99, dealer_name="house", delta=100
@@ -1435,8 +1457,8 @@ async def test_settle_wager_applies_vip_bonus_on_win() -> None:
 
 async def test_settle_wager_keeps_loss_unchanged_for_vip() -> None:
     """The VIP perk does not soften losses."""
-    await _add_balance(user_id=1, name="alice", amount=database.VIP_PURCHASE_COST + 1_000)
-    purchase = await database.buy_vip(user_id=1, name="alice")
+    await _add_balance(user_id=1, name="alice", amount=VIP_PURCHASE_COST + 1_000)
+    purchase = await buy_vip(user_id=1, name="alice")
     assert purchase is not None
     settlement = await settle_wager(
         player_id=1, player_account_name="alice", dealer_id=99, dealer_name="house", delta=-100
@@ -1515,14 +1537,14 @@ async def test_settle_blackjack_player_split_both_wins_aggregates_delta() -> Non
     )
     player = round_state.players[0]
     player.hands = [
-        blackjack_rules.BlackjackHandState(
+        BlackjackHandState(
             cards=[Card(rank="8", suit="♠"), Card(rank="K", suit="♥")],
             bet=50,
             base_bet=50,
             is_split_hand=True,
             finished=True,
         ),
-        blackjack_rules.BlackjackHandState(
+        BlackjackHandState(
             cards=[Card(rank="8", suit="♣"), Card(rank="9", suit="♦")],
             bet=50,
             base_bet=50,
@@ -1545,22 +1567,22 @@ async def test_settle_blackjack_player_split_both_wins_aggregates_delta() -> Non
 
 async def test_settle_blackjack_player_split_offset_skips_vip_bonus() -> None:
     """A split that nets to zero does not trigger the VIP bonus."""
-    await _add_balance(user_id=1, name="alice", amount=database.VIP_PURCHASE_COST + 200)
-    purchase = await database.buy_vip(user_id=1, name="alice")
+    await _add_balance(user_id=1, name="alice", amount=VIP_PURCHASE_COST + 200)
+    purchase = await buy_vip(user_id=1, name="alice")
     assert purchase is not None
     round_state = BlackjackRound.from_participants(
         rng=SystemRandom(), participants=[_participant(bet=50)]
     )
     player = round_state.players[0]
     player.hands = [
-        blackjack_rules.BlackjackHandState(
+        BlackjackHandState(
             cards=[Card(rank="8", suit="♠"), Card(rank="K", suit="♥")],
             bet=50,
             base_bet=50,
             is_split_hand=True,
             finished=True,
         ),
-        blackjack_rules.BlackjackHandState(
+        BlackjackHandState(
             cards=[Card(rank="8", suit="♣"), Card(rank="2", suit="♦")],
             bet=50,
             base_bet=50,
@@ -1625,7 +1647,7 @@ async def test_blackjack_final_embed_uses_aggregate_insurance_push_title() -> No
     round_state.phase = "settled"
 
     settlement = await _settle_player(round_state=round_state)
-    embed = views.build_final_embed(
+    embed = build_final_embed(
         dealer_name="house",
         round_state=round_state,
         results=[BlackjackPlayerResult(participant=player.participant, settlement=settlement)],
@@ -1674,9 +1696,9 @@ async def test_apply_jackpot_settlement_credits_player_and_drains_pool() -> None
     """Player wins pull points out of the jackpot row in one atomic step."""
     await _add_balance(user_id=1, name="alice", amount=10_000)
     # _ensure_schema already seeded the dragon_gate pool at 100_000.
-    assert await database.get_jackpot_pool(game_id="dragon_gate") == 100_000
+    assert await get_jackpot_pool(game_id="dragon_gate") == 100_000
 
-    settlement = await database.apply_jackpot_settlement(
+    settlement = await apply_jackpot_settlement(
         player_id=1, player_account_name="alice", player_delta=20_000, game_id="dragon_gate"
     )
 
@@ -1684,12 +1706,12 @@ async def test_apply_jackpot_settlement_credits_player_and_drains_pool() -> None
     assert settlement.jackpot_balance == 80_000
     assert settlement.applied_player_delta == 20_000
     assert settlement.jackpot_depleted is False
-    assert await database.get_jackpot_pool(game_id="dragon_gate") == 80_000
+    assert await get_jackpot_pool(game_id="dragon_gate") == 80_000
 
 
 async def test_apply_jackpot_settlement_replenishes_drained_seed_pool() -> None:
     """A seeded jackpot restores itself after a player wins the whole pool."""
-    settlement = await database.apply_jackpot_settlement(
+    settlement = await apply_jackpot_settlement(
         player_id=1, player_account_name="alice", player_delta=100_000, game_id="dragon_gate"
     )
 
@@ -1697,12 +1719,12 @@ async def test_apply_jackpot_settlement_replenishes_drained_seed_pool() -> None:
     assert settlement.jackpot_balance == 100_000
     assert settlement.applied_player_delta == 100_000
     assert settlement.jackpot_depleted is True
-    assert await database.get_jackpot_pool(game_id="dragon_gate") == 100_000
-    async with database.open_session() as session:
+    assert await get_jackpot_pool(game_id="dragon_gate") == 100_000
+    async with open_session() as session:
         result = await session.execute(
-            statement=select(
-                database.JackpotPool.seeded_amount, database.JackpotPool.total_claimed
-            ).where(database.JackpotPool.game_id == "dragon_gate")
+            statement=select(JackpotPool.seeded_amount, JackpotPool.total_claimed).where(
+                JackpotPool.game_id == "dragon_gate"
+            )
         )
         seeded_amount, total_claimed = result.one()
     assert seeded_amount == 200_000
@@ -1713,23 +1735,21 @@ async def test_apply_jackpot_settlement_clamps_loss_and_grows_pool_by_actual_deb
     """Player losses stop at zero and feed the jackpot with the actual debit."""
     await _add_balance(user_id=1, name="alice", amount=15_000)
 
-    settlement = await database.apply_jackpot_settlement(
+    settlement = await apply_jackpot_settlement(
         player_id=1, player_account_name="alice", player_delta=-25_000, game_id="dragon_gate"
     )
 
     assert settlement.player_balance == 0
     assert settlement.jackpot_balance == 115_000
     assert settlement.applied_player_delta == -15_000
-    async with database.open_session() as session:
+    async with open_session() as session:
         result = await session.execute(
             statement=select(
-                database.PointTransaction.kind,
-                database.PointTransaction.delta,
-                database.PointTransaction.balance_after,
-            ).where(database.PointTransaction.user_id == 1)
+                PointTransaction.kind, PointTransaction.delta, PointTransaction.balance_after
+            ).where(PointTransaction.user_id == 1)
         )
         kind, delta, balance_after = result.one()
-    assert kind == database.TransactionKind.CASINO_BET.value
+    assert kind == TransactionKind.CASINO_BET.value
     assert delta == -15_000
     assert balance_after == 0
 
@@ -1739,23 +1759,23 @@ async def test_apply_jackpot_settlement_concurrent_clamped_losses_log_actual_deb
     await _add_balance(user_id=1, name="alice", amount=100)
 
     first, second = await asyncio.gather(
-        database.apply_jackpot_settlement(
+        apply_jackpot_settlement(
             player_id=1, player_account_name="alice", player_delta=-80, game_id="dragon_gate"
         ),
-        database.apply_jackpot_settlement(
+        apply_jackpot_settlement(
             player_id=1, player_account_name="alice", player_delta=-80, game_id="dragon_gate"
         ),
     )
 
     applied_total = first.applied_player_delta + second.applied_player_delta
     assert applied_total == -100
-    assert await database.get_balance(user_id=1) == 0
-    assert await database.get_jackpot_pool(game_id="dragon_gate") == 100_100
-    async with database.open_session() as session:
+    assert await get_balance(user_id=1) == 0
+    assert await get_jackpot_pool(game_id="dragon_gate") == 100_100
+    async with open_session() as session:
         result = await session.execute(
-            statement=select(func.sum(database.PointTransaction.delta)).where(
-                database.PointTransaction.user_id == 1,
-                database.PointTransaction.kind == database.TransactionKind.CASINO_BET.value,
+            statement=select(func.sum(PointTransaction.delta)).where(
+                PointTransaction.user_id == 1,
+                PointTransaction.kind == TransactionKind.CASINO_BET.value,
             )
         )
         assert result.scalar_one() == -100
@@ -1763,7 +1783,7 @@ async def test_apply_jackpot_settlement_concurrent_clamped_losses_log_actual_deb
 
 async def test_apply_jackpot_settlement_caps_win_to_live_pool() -> None:
     """A stale oversized jackpot win only pays the live pool amount."""
-    settlement = await database.apply_jackpot_settlement(
+    settlement = await apply_jackpot_settlement(
         player_id=1, player_account_name="alice", player_delta=150_000, game_id="dragon_gate"
     )
 
@@ -1775,16 +1795,16 @@ async def test_apply_jackpot_settlement_caps_win_to_live_pool() -> None:
 
 async def test_apply_jackpot_settlement_concurrent_wins_do_not_double_claim_pool() -> None:
     """Concurrent whole-pool wins cannot both claim the same jackpot generation."""
-    snapshot = await database.get_jackpot_snapshot(game_id="dragon_gate")
+    snapshot = await get_jackpot_snapshot(game_id="dragon_gate")
     first, second = await asyncio.gather(
-        database.apply_jackpot_settlement(
+        apply_jackpot_settlement(
             player_id=1,
             player_account_name="alice",
             player_delta=100_000,
             game_id="dragon_gate",
             expected_jackpot_generation=snapshot.generation,
         ),
-        database.apply_jackpot_settlement(
+        apply_jackpot_settlement(
             player_id=2,
             player_account_name="bob",
             player_delta=100_000,
@@ -1795,7 +1815,7 @@ async def test_apply_jackpot_settlement_concurrent_wins_do_not_double_claim_pool
 
     applied_total = first.applied_player_delta + second.applied_player_delta
     assert applied_total == 100_000
-    assert await database.get_jackpot_pool(game_id="dragon_gate") == 100_000
+    assert await get_jackpot_pool(game_id="dragon_gate") == 100_000
 
 
 async def test_apply_jackpot_settlement_batch_charges_multiple_players_atomically() -> None:
@@ -1803,22 +1823,20 @@ async def test_apply_jackpot_settlement_batch_charges_multiple_players_atomicall
     await _add_balance(user_id=1, name="alice", amount=10_000)
     await _add_balance(user_id=2, name="bob", amount=10_000)
 
-    result = await database.apply_jackpot_settlement_batch(
+    result = await apply_jackpot_settlement_batch(
         game_id="dragon_gate",
         settlements=(
-            database.JackpotSettlementRequest(
+            JackpotSettlementRequest(
                 player_id=1, player_account_name="alice", player_delta=-5_000
             ),
-            database.JackpotSettlementRequest(
-                player_id=2, player_account_name="bob", player_delta=-7_000
-            ),
+            JackpotSettlementRequest(player_id=2, player_account_name="bob", player_delta=-7_000),
         ),
     )
 
     assert result.player_balances == {1: 5_000, 2: 3_000}
     assert result.applied_player_deltas == {1: -5_000, 2: -7_000}
     assert result.jackpot_balance == 112_000
-    assert await database.get_jackpot_pool(game_id="dragon_gate") == 112_000
+    assert await get_jackpot_pool(game_id="dragon_gate") == 112_000
 
 
 async def test_apply_jackpot_settlement_batch_rejects_required_full_debit() -> None:
@@ -1826,16 +1844,16 @@ async def test_apply_jackpot_settlement_batch_rejects_required_full_debit() -> N
     await _add_balance(user_id=1, name="alice", amount=10_000)
     await _add_balance(user_id=2, name="bob", amount=3_000)
 
-    result = await database.apply_jackpot_settlement_batch(
+    result = await apply_jackpot_settlement_batch(
         game_id="dragon_gate",
         settlements=(
-            database.JackpotSettlementRequest(
+            JackpotSettlementRequest(
                 player_id=1,
                 player_account_name="alice",
                 player_delta=-5_000,
                 require_full_debit=True,
             ),
-            database.JackpotSettlementRequest(
+            JackpotSettlementRequest(
                 player_id=2,
                 player_account_name="bob",
                 player_delta=-5_000,
@@ -1847,9 +1865,9 @@ async def test_apply_jackpot_settlement_batch_rejects_required_full_debit() -> N
     assert result.rejected_player_ids == (2,)
     assert result.player_balances == {}
     assert result.applied_player_deltas == {}
-    assert await database.get_balance(user_id=1) == 10_000
-    assert await database.get_balance(user_id=2) == 3_000
-    assert await database.get_jackpot_pool(game_id="dragon_gate") == 100_000
+    assert await get_balance(user_id=1) == 10_000
+    assert await get_balance(user_id=2) == 3_000
+    assert await get_jackpot_pool(game_id="dragon_gate") == 100_000
 
 
 async def test_apply_jackpot_settlement_batch_rolls_back_on_failure(
@@ -1858,14 +1876,14 @@ async def test_apply_jackpot_settlement_batch_rolls_back_on_failure(
     """A failed batch ante settlement cannot partially charge players."""
     await _add_balance(user_id=1, name="alice", amount=10_000)
     await _add_balance(user_id=2, name="bob", amount=10_000)
-    assert await database.get_jackpot_pool(game_id="dragon_gate") == 100_000
+    assert await get_jackpot_pool(game_id="dragon_gate") == 100_000
 
     calls = 0
-    original_apply = database._apply_jackpot_delta_in_session
+    original_apply = _apply_jackpot_delta_in_session
 
     async def flaky_apply_jackpot_delta_in_session(
-        **kwargs: object,
-    ) -> tuple[database.JackpotSnapshot, bool]:
+        **kwargs: Any,  # noqa: ANN401 -- test double accepts heterogeneous kwargs
+    ) -> tuple[JackpotSnapshot, bool]:
         """Fails on the second jackpot write to test batch rollback."""
         nonlocal calls
         calls += 1
@@ -1874,38 +1892,37 @@ async def test_apply_jackpot_settlement_batch_rolls_back_on_failure(
         return await original_apply(**kwargs)
 
     monkeypatch.setattr(
-        target=database,
-        name="_apply_jackpot_delta_in_session",
-        value=flaky_apply_jackpot_delta_in_session,
+        "discordbot.cogs._economy.database._apply_jackpot_delta_in_session",
+        flaky_apply_jackpot_delta_in_session,
     )
 
     with pytest.raises(expected_exception=RuntimeError, match="forced batch failure"):
-        await database.apply_jackpot_settlement_batch(
+        await apply_jackpot_settlement_batch(
             game_id="dragon_gate",
             settlements=(
-                database.JackpotSettlementRequest(
+                JackpotSettlementRequest(
                     player_id=1, player_account_name="alice", player_delta=-5_000
                 ),
-                database.JackpotSettlementRequest(
+                JackpotSettlementRequest(
                     player_id=2, player_account_name="bob", player_delta=-7_000
                 ),
             ),
         )
 
-    assert await database.get_balance(user_id=1) == 10_000
-    assert await database.get_balance(user_id=2) == 10_000
-    assert await database.get_jackpot_pool(game_id="dragon_gate") == 100_000
+    assert await get_balance(user_id=1) == 10_000
+    assert await get_balance(user_id=2) == 10_000
+    assert await get_jackpot_pool(game_id="dragon_gate") == 100_000
 
 
 async def test_apply_jackpot_settlement_skips_vip_blackjack_bonus() -> None:
     """射龍門 winnings stay at face value even for VIP accounts."""
-    await _add_balance(user_id=1, name="alice", amount=database.VIP_PURCHASE_COST)
-    purchase = await database.buy_vip(user_id=1, name="alice")
+    await _add_balance(user_id=1, name="alice", amount=VIP_PURCHASE_COST)
+    purchase = await buy_vip(user_id=1, name="alice")
     assert purchase is not None
 
-    player_balance_before = await database.get_balance(user_id=1)
-    pool_before = await database.get_jackpot_pool(game_id="dragon_gate")
-    settlement = await database.apply_jackpot_settlement(
+    player_balance_before = await get_balance(user_id=1)
+    pool_before = await get_jackpot_pool(game_id="dragon_gate")
+    settlement = await apply_jackpot_settlement(
         player_id=1, player_account_name="alice", player_delta=100, game_id="dragon_gate"
     )
 
@@ -1916,22 +1933,22 @@ async def test_apply_jackpot_settlement_skips_vip_blackjack_bonus() -> None:
 
 async def test_get_jackpot_pool_returns_zero_for_missing_game() -> None:
     """Unseeded game ids surface as 0 instead of raising."""
-    assert await database.get_jackpot_pool(game_id="never_registered") == 0
+    assert await get_jackpot_pool(game_id="never_registered") == 0
 
 
 async def test_get_jackpot_pool_replenishes_legacy_drained_seed_pool() -> None:
     """Reading a seeded jackpot repairs an older zero-balance row."""
-    await database._ensure_schema()
-    async with database.open_session() as session:
+    await _ensure_schema()
+    async with open_session() as session:
         await session.execute(
-            statement=update(database.JackpotPool)
-            .where(database.JackpotPool.game_id == "dragon_gate")
+            statement=update(JackpotPool)
+            .where(JackpotPool.game_id == "dragon_gate")
             .values(pool_balance=0)
         )
         await session.commit()
 
-    assert await database.get_jackpot_pool(game_id="dragon_gate") == 100_000
-    snapshot = await database.get_jackpot_snapshot(game_id="dragon_gate")
+    assert await get_jackpot_pool(game_id="dragon_gate") == 100_000
+    snapshot = await get_jackpot_snapshot(game_id="dragon_gate")
     assert snapshot.generation == 1
 
 
@@ -1941,16 +1958,16 @@ async def test_ensure_schema_seeds_dragon_gate_jackpot_once(
     """_ensure_schema seeds the dragon_gate pool exactly once across calls."""
     db_path = tmp_path / "seed-economy.db"
     engine = create_async_engine(url=f"sqlite+aiosqlite:///{db_path}")
-    monkeypatch.setattr(target=database, name="_engine", value=engine)
-    monkeypatch.setattr(target=database, name="_schema_ready_for", value=None)
+    monkeypatch.setattr("discordbot.cogs._economy.database._engine", engine)
+    monkeypatch.setattr("discordbot.cogs._economy.database._schema_ready_for", None)
 
-    await database._ensure_schema()
-    first_balance = await database.get_jackpot_pool(game_id="dragon_gate")
+    await _ensure_schema()
+    first_balance = await get_jackpot_pool(game_id="dragon_gate")
     assert first_balance == 100_000
 
     # Calling again is idempotent: the seed must not pile on top of itself.
-    monkeypatch.setattr(target=database, name="_schema_ready_for", value=None)
-    await database._ensure_schema()
-    assert await database.get_jackpot_pool(game_id="dragon_gate") == 100_000
+    monkeypatch.setattr("discordbot.cogs._economy.database._schema_ready_for", None)
+    await _ensure_schema()
+    assert await get_jackpot_pool(game_id="dragon_gate") == 100_000
 
     await engine.dispose()

--- a/tests/test_game_cleanup.py
+++ b/tests/test_game_cleanup.py
@@ -9,7 +9,15 @@ import nextcord
 from nextcord import Message, Interaction
 
 from discordbot.cogs import economy
-from discordbot.cogs._games import cleanup
+from discordbot.cogs._games.cleanup import (
+    GAME_RESPONSE_TTL_SECONDS,
+    PendingGameMessage,
+    track_game_message,
+    delete_game_message_after,
+    list_pending_game_messages,
+    delete_tracked_game_messages,
+    schedule_game_message_delete,
+)
 
 if TYPE_CHECKING:
     from nextcord.ext import commands
@@ -86,16 +94,26 @@ class _FetchMessageChannelStub:
         )
 
 
+class _NonMessageableChannelStub:
+    """Channel shape without ``fetch_message`` used to exercise fallback paths."""
+
+    pass
+
+
 class _BotStub:
     """Minimal bot shape for startup cleanup."""
 
-    def __init__(self, cached_channel: object | None = None) -> None:
+    def __init__(
+        self, cached_channel: _FetchMessageChannelStub | _NonMessageableChannelStub | None = None
+    ) -> None:
         """Initializes cached-channel behavior and cleanup call records."""
         self.deleted: list[tuple[int, int]] = []
         self.cached_channel = cached_channel
         self.fetch_calls: list[int] = []
 
-    def get_channel(self, channel_id: int, /) -> object | None:
+    def get_channel(
+        self, channel_id: int, /
+    ) -> _FetchMessageChannelStub | _NonMessageableChannelStub | None:
         """Returns the configured cached channel."""
         return self.cached_channel
 
@@ -112,9 +130,15 @@ class _UnfetchableBotStub:
         """Returns no cached channel."""
         return
 
-    async def fetch_channel(self, channel_id: int, /) -> object:
+    async def fetch_channel(self, channel_id: int, /) -> _NonMessageableChannelStub:
         """Returns a non-messageable channel shape."""
-        return object()
+        return _NonMessageableChannelStub()
+
+
+class _SentFollowupMessageStub:
+    """Message shape returned by fake followup sends."""
+
+    pass
 
 
 class _FollowupStub:
@@ -122,14 +146,14 @@ class _FollowupStub:
 
     def __init__(self) -> None:
         """Initializes followup send records."""
-        self.message = object()
+        self.message = _SentFollowupMessageStub()
         self.sent_wait: bool | None = None
         self.sent_ephemeral: bool | None = None
         self.sent_embed: nextcord.Embed | None = None
 
     async def send(
         self, embed: nextcord.Embed, wait: bool = False, ephemeral: bool = False
-    ) -> object:
+    ) -> _SentFollowupMessageStub:
         """Records the embed send and returns the message object."""
         self.sent_embed = embed
         self.sent_wait = wait
@@ -149,7 +173,8 @@ class _InteractionStub:
 def isolated_cleanup_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Keeps cleanup DB writes out of the real data directory."""
     monkeypatch.setattr(
-        target=cleanup, name="_PENDING_GAME_MESSAGE_DB_PATH", value=tmp_path / "game_cleanup.db"
+        "discordbot.cogs._games.cleanup._PENDING_GAME_MESSAGE_DB_PATH",
+        tmp_path / "game_cleanup.db",
     )
 
 
@@ -157,7 +182,7 @@ async def test_delete_game_message_after_waits_then_deletes() -> None:
     """Game response cleanup deletes the message after the configured delay."""
     message = _DeletableMessageStub()
 
-    await cleanup.delete_game_message_after(message=cast("Message", message), delay=0)
+    await delete_game_message_after(message=cast("Message", message), delay=0)
 
     assert message.delete_calls == 1
 
@@ -166,70 +191,68 @@ async def test_track_game_message_persists_message_identity() -> None:
     """Game response tracking stores the channel/message pair needed for restart cleanup."""
     message = _DeletableMessageStub(message_id=10, channel_id=20)
 
-    record = await cleanup.track_game_message(message=cast("Message", message))
+    record = await track_game_message(message=cast("Message", message))
 
-    assert record == cleanup.PendingGameMessage(channel_id=20, message_id=10)
-    assert await cleanup.list_pending_game_messages() == [
-        cleanup.PendingGameMessage(channel_id=20, message_id=10)
-    ]
+    assert record == PendingGameMessage(channel_id=20, message_id=10)
+    assert await list_pending_game_messages() == [PendingGameMessage(channel_id=20, message_id=10)]
 
 
 async def test_delete_game_message_after_forgets_successful_cleanup() -> None:
     """Successful TTL cleanup removes the persisted restart record."""
     message = _DeletableMessageStub(message_id=10, channel_id=20)
-    await cleanup.track_game_message(message=cast("Message", message))
+    await track_game_message(message=cast("Message", message))
 
-    await cleanup.delete_game_message_after(message=cast("Message", message), delay=0)
+    await delete_game_message_after(message=cast("Message", message), delay=0)
 
     assert message.delete_calls == 1
-    assert await cleanup.list_pending_game_messages() == []
+    assert await list_pending_game_messages() == []
 
 
 async def test_delete_tracked_game_messages_deletes_stale_restart_records() -> None:
     """Startup cleanup deletes persisted Discord messages and clears the records."""
     message = _DeletableMessageStub(message_id=10, channel_id=20)
-    await cleanup.track_game_message(message=cast("Message", message))
+    await track_game_message(message=cast("Message", message))
     bot = _BotStub()
 
-    await cleanup.delete_tracked_game_messages(bot=cast("commands.Bot", bot))
+    await delete_tracked_game_messages(bot=cast("commands.Bot", bot))
 
     assert bot.deleted == [(20, 10)]
     assert bot.fetch_calls == [20]
-    assert await cleanup.list_pending_game_messages() == []
+    assert await list_pending_game_messages() == []
 
 
 async def test_delete_tracked_game_messages_skips_non_messageable_cached_channel() -> None:
     """Cached PartialMessageable-like channels should be resolved via fetch_channel first."""
     message = _DeletableMessageStub(message_id=10, channel_id=20)
-    await cleanup.track_game_message(message=cast("Message", message))
-    bot = _BotStub(cached_channel=object())
+    await track_game_message(message=cast("Message", message))
+    bot = _BotStub(cached_channel=_NonMessageableChannelStub())
 
-    await cleanup.delete_tracked_game_messages(bot=cast("commands.Bot", bot))
+    await delete_tracked_game_messages(bot=cast("commands.Bot", bot))
 
     assert bot.deleted == [(20, 10)]
     assert bot.fetch_calls == [20]
-    assert await cleanup.list_pending_game_messages() == []
+    assert await list_pending_game_messages() == []
 
 
 async def test_delete_tracked_game_messages_keeps_unresolved_channel_records() -> None:
     """Startup cleanup keeps records when it cannot resolve a message-fetchable channel."""
     message = _DeletableMessageStub(message_id=10, channel_id=20)
-    await cleanup.track_game_message(message=cast("Message", message))
+    await track_game_message(message=cast("Message", message))
 
-    await cleanup.delete_tracked_game_messages(bot=cast("commands.Bot", _UnfetchableBotStub()))
+    await delete_tracked_game_messages(bot=cast("commands.Bot", _UnfetchableBotStub()))
 
-    assert await cleanup.list_pending_game_messages() == [
-        cleanup.PendingGameMessage(channel_id=20, message_id=10)
-    ]
+    assert await list_pending_game_messages() == [PendingGameMessage(channel_id=20, message_id=10)]
 
 
 async def test_send_expiring_followup_waits_for_message_and_schedules_cleanup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Game-related economy embeds must retrieve their message before cleanup."""
-    scheduled_messages: list[object] = []
+    scheduled_messages: list[_SentFollowupMessageStub] = []
 
-    def fake_schedule_game_message_delete(message: object, delay: float = 180) -> None:
+    def fake_schedule_game_message_delete(
+        message: _SentFollowupMessageStub, delay: float = 180
+    ) -> None:
         """Records the message scheduled for later deletion."""
         scheduled_messages.append(message)
 
@@ -254,9 +277,11 @@ async def test_send_private_followup_is_ephemeral_and_not_scheduled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Personal economy embeds should not enter the game cleanup scheduler."""
-    scheduled_messages: list[object] = []
+    scheduled_messages: list[_SentFollowupMessageStub] = []
 
-    def fake_schedule_game_message_delete(message: object, delay: float = 180) -> None:
+    def fake_schedule_game_message_delete(
+        message: _SentFollowupMessageStub, delay: float = 180
+    ) -> None:
         """Records any unexpected scheduler calls."""
         scheduled_messages.append(message)
 
@@ -277,9 +302,7 @@ async def test_send_private_followup_is_ephemeral_and_not_scheduled(
 
 async def test_delete_game_message_after_ignores_already_deleted_message() -> None:
     """Manual deletion before cleanup should not surface as a task failure."""
-    await cleanup.delete_game_message_after(
-        message=cast("Message", _AlreadyDeletedMessageStub()), delay=0
-    )
+    await delete_game_message_after(message=cast("Message", _AlreadyDeletedMessageStub()), delay=0)
 
 
 async def test_schedule_game_message_delete_uses_default_ttl(
@@ -288,16 +311,16 @@ async def test_schedule_game_message_delete_uses_default_ttl(
     """Scheduling uses the shared three-minute TTL by default."""
     scheduled_delay: float | None = None
 
-    async def fake_delete_game_message_after(message: object, delay: float) -> None:
+    async def fake_delete_game_message_after(message: Message, delay: float) -> None:
         """Records the delay requested by the scheduler."""
         nonlocal scheduled_delay
         scheduled_delay = delay
 
     monkeypatch.setattr(
-        target=cleanup, name="delete_game_message_after", value=fake_delete_game_message_after
+        "discordbot.cogs._games.cleanup.delete_game_message_after", fake_delete_game_message_after
     )
 
-    cleanup.schedule_game_message_delete(message=cast("Message", _DeletableMessageStub()))
+    schedule_game_message_delete(message=cast("Message", _DeletableMessageStub()))
     await asyncio.sleep(delay=0)
 
-    assert scheduled_delay == cleanup.GAME_RESPONSE_TTL_SECONDS
+    assert scheduled_delay == GAME_RESPONSE_TTL_SECONDS

--- a/tests/test_loan.py
+++ b/tests/test_loan.py
@@ -9,8 +9,27 @@ from datetime import UTC, datetime, timedelta
 import pytest
 from sqlalchemy import select, update
 
-from discordbot.cogs._economy import database
 from discordbot.typings.economy import TransactionKind
+from discordbot.cogs._economy.database import (
+    TAIWAN_TIMEZONE,
+    UserAccount,
+    PointTransaction,
+    repay,
+    borrow,
+    transfer,
+    get_account,
+    get_balance,
+    credit_limit,
+    open_session,
+    _database_now,
+    get_loan_view,
+    _ensure_schema,
+    adjust_balance,
+    _build_credit_upsert,
+    credit_with_repayment,
+    apply_round_settlement,
+    apply_vip_blackjack_bonus,
+)
 
 pytestmark = pytest.mark.usefixtures("economy_isolated_db")
 
@@ -22,28 +41,26 @@ def _user_with_age(days_old: int) -> SimpleNamespace:
 
 async def _list_transactions(user_id: int) -> list[tuple[str, int, int]]:
     """Returns ``(kind, delta, debt_after)`` rows for a user, oldest first."""
-    async with database.open_session() as session:
+    async with open_session() as session:
         result = await session.execute(
             statement=select(
-                database.PointTransaction.kind,
-                database.PointTransaction.delta,
-                database.PointTransaction.debt_after,
+                PointTransaction.kind, PointTransaction.delta, PointTransaction.debt_after
             )
-            .where(database.PointTransaction.user_id == user_id)
-            .order_by(database.PointTransaction.id)
+            .where(PointTransaction.user_id == user_id)
+            .order_by(PointTransaction.id)
         )
         return [(row[0], row[1], row[2]) for row in result.all()]
 
 
 async def _add_balance(user_id: int, name: str, amount: int, avatar_url: str = "") -> int:
     """Seeds a positive balance without writing audit rows."""
-    await database._ensure_schema()
+    await _ensure_schema()
     if amount <= 0:
-        return await database.get_balance(user_id=user_id)
-    now = database._database_now()
-    async with database.open_session() as session:
+        return await get_balance(user_id=user_id)
+    now = _database_now()
+    async with open_session() as session:
         result = await session.execute(
-            statement=database._build_credit_upsert(
+            statement=_build_credit_upsert(
                 user_id=user_id, name=name, amount=amount, avatar_url=avatar_url, now=now
             )
         )
@@ -53,11 +70,11 @@ async def _add_balance(user_id: int, name: str, amount: int, avatar_url: str = "
 
 async def _backdate_loan_opened_at(user_id: int, days_ago: int) -> None:
     """Test helper: simulates time passing by pushing loan_opened_at back."""
-    past = datetime.now(tz=database.TAIWAN_TIMEZONE) - timedelta(days=days_ago)
-    async with database.open_session() as session:
+    past = datetime.now(tz=TAIWAN_TIMEZONE) - timedelta(days=days_ago)
+    async with open_session() as session:
         await session.execute(
-            statement=update(database.UserAccount)
-            .where(database.UserAccount.user_id == user_id)
+            statement=update(UserAccount)
+            .where(UserAccount.user_id == user_id)
             .values(loan_opened_at=past)
         )
         await session.commit()
@@ -84,14 +101,14 @@ async def _backdate_loan_opened_at(user_id: int, days_ago: int) -> None:
 def test_credit_limit_tier_boundaries(days: int, expected: int) -> None:
     """Each tier boundary returns the expected cap (non-VIP)."""
     user = _user_with_age(days_old=days)
-    assert database.credit_limit(user=user) == expected
+    assert credit_limit(user=user) == expected
 
 
 def test_credit_limit_doubles_for_vip() -> None:
     """VIP perk doubles the credit limit regardless of account-age tier."""
     user = _user_with_age(days_old=365 * 5)
-    assert database.credit_limit(user=user, is_vip=False) == 500_000
-    assert database.credit_limit(user=user, is_vip=True) == 1_000_000
+    assert credit_limit(user=user, is_vip=False) == 500_000
+    assert credit_limit(user=user, is_vip=True) == 1_000_000
 
 
 # VIP blackjack bonus -------------------------------------------------------
@@ -110,7 +127,7 @@ def test_credit_limit_doubles_for_vip() -> None:
 )
 def test_apply_vip_blackjack_bonus(delta: int, is_vip: bool, expected: int) -> None:
     """VIP 1.5x multiplier only fires for positive deltas."""
-    assert database.apply_vip_blackjack_bonus(delta=delta, is_vip=is_vip) == expected
+    assert apply_vip_blackjack_bonus(delta=delta, is_vip=is_vip) == expected
 
 
 # Borrow --------------------------------------------------------------------
@@ -118,13 +135,13 @@ def test_apply_vip_blackjack_bonus(delta: int, is_vip: bool, expected: int) -> N
 
 async def test_borrow_first_time_creates_row_and_disburses() -> None:
     """A first-time borrow creates the row, sets opened_at, and credits balance."""
-    result = await database.borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
+    result = await borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
     assert result is not None
     assert result.new_balance == 500
     assert result.principal == 500
     assert result.borrowed_amount == 500
 
-    view = await database.get_loan_view(user_id=1)
+    view = await get_loan_view(user_id=1)
     assert view is not None
     assert view.principal == 500
     assert view.total_borrowed == 500
@@ -133,18 +150,18 @@ async def test_borrow_first_time_creates_row_and_disburses() -> None:
 
 async def test_borrow_accumulates_principal_on_existing_loan() -> None:
     """A second borrow adds to existing principal without resetting opened_at."""
-    first = await database.borrow(user_id=1, name="alice", amount=300, credit_limit_value=1_000)
+    first = await borrow(user_id=1, name="alice", amount=300, credit_limit_value=1_000)
     assert first is not None
-    first_view = await database.get_loan_view(user_id=1)
+    first_view = await get_loan_view(user_id=1)
     assert first_view is not None
     first_opened_at = first_view.opened_at
 
-    result = await database.borrow(user_id=1, name="alice", amount=400, credit_limit_value=1_000)
+    result = await borrow(user_id=1, name="alice", amount=400, credit_limit_value=1_000)
     assert result is not None
     assert result.new_balance == 700
     assert result.principal == 700
     assert result.borrowed_amount == 400
-    view = await database.get_loan_view(user_id=1)
+    view = await get_loan_view(user_id=1)
     assert view is not None
     assert view.opened_at == first_opened_at
     assert view.total_borrowed == 700
@@ -152,20 +169,20 @@ async def test_borrow_accumulates_principal_on_existing_loan() -> None:
 
 async def test_borrow_over_limit_clamps_to_remaining_credit() -> None:
     """A borrow that would exceed the cap disburses the remaining daily credit."""
-    await database.borrow(user_id=1, name="alice", amount=800, credit_limit_value=1_000)
-    result = await database.borrow(user_id=1, name="alice", amount=300, credit_limit_value=1_000)
+    await borrow(user_id=1, name="alice", amount=800, credit_limit_value=1_000)
+    result = await borrow(user_id=1, name="alice", amount=300, credit_limit_value=1_000)
     assert result is not None
     assert result.new_balance == 1_000
     assert result.principal == 1_000
     assert result.borrowed_amount == 200
-    view = await database.get_loan_view(user_id=1)
+    view = await get_loan_view(user_id=1)
     assert view is not None
     assert view.principal == 1_000
 
 
 async def test_borrow_first_request_over_limit_clamps_to_limit() -> None:
     """A first borrow request above the cap borrows the full cap."""
-    result = await database.borrow(user_id=1, name="alice", amount=1_500, credit_limit_value=1_000)
+    result = await borrow(user_id=1, name="alice", amount=1_500, credit_limit_value=1_000)
     assert result is not None
     assert result.new_balance == 1_000
     assert result.principal == 1_000
@@ -174,29 +191,29 @@ async def test_borrow_first_request_over_limit_clamps_to_limit() -> None:
 
 async def test_borrow_rejects_when_remaining_credit_is_zero() -> None:
     """Once principal reaches the cap, additional borrow requests are rejected."""
-    await database.borrow(user_id=1, name="alice", amount=1_500, credit_limit_value=1_000)
-    result = await database.borrow(user_id=1, name="alice", amount=1, credit_limit_value=1_000)
+    await borrow(user_id=1, name="alice", amount=1_500, credit_limit_value=1_000)
+    result = await borrow(user_id=1, name="alice", amount=1, credit_limit_value=1_000)
     assert result is None
 
 
 async def test_borrow_concurrent_requests_cannot_exceed_limit() -> None:
     """Concurrent borrows must not both pass against the same observed principal."""
     results = await asyncio.gather(
-        database.borrow(user_id=1, name="alice", amount=800, credit_limit_value=1_000),
-        database.borrow(user_id=1, name="alice", amount=800, credit_limit_value=1_000),
+        borrow(user_id=1, name="alice", amount=800, credit_limit_value=1_000),
+        borrow(user_id=1, name="alice", amount=800, credit_limit_value=1_000),
     )
     assert all(result is not None for result in results)
-    view = await database.get_loan_view(user_id=1)
+    view = await get_loan_view(user_id=1)
     assert view is not None
     assert view.principal == 1_000
-    assert await database.get_balance(user_id=1) == 1_000
+    assert await get_balance(user_id=1) == 1_000
     assert sum(result.borrowed_amount for result in results if result is not None) == 1_000
 
 
 async def test_borrow_treats_borrowed_money_as_debt_not_earnings() -> None:
     """Borrowed money goes into balance but does not bump total_earned."""
-    await database.borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
-    account = await database.get_account(user_id=1)
+    await borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
+    account = await get_account(user_id=1)
     assert account is not None
     _, balance, total_earned, _ = account
     assert balance == 500
@@ -206,10 +223,10 @@ async def test_borrow_treats_borrowed_money_as_debt_not_earnings() -> None:
 async def test_borrow_on_existing_account_preserves_total_earned() -> None:
     """Borrowing on top of an existing balance doesn't disturb earnings history."""
     await _add_balance(user_id=1, name="alice", amount=100)
-    result = await database.borrow(user_id=1, name="alice", amount=400, credit_limit_value=1_000)
+    result = await borrow(user_id=1, name="alice", amount=400, credit_limit_value=1_000)
     assert result is not None
     assert result.new_balance == 500
-    account = await database.get_account(user_id=1)
+    account = await get_account(user_id=1)
     assert account is not None
     _, balance, total_earned, _ = account
     assert balance == 500
@@ -219,9 +236,7 @@ async def test_borrow_on_existing_account_preserves_total_earned() -> None:
 @pytest.mark.parametrize(argnames="amount", argvalues=[0, -1, -1000])
 async def test_borrow_rejects_non_positive_amount(amount: int) -> None:
     """Non-positive borrow amounts are rejected."""
-    result = await database.borrow(
-        user_id=1, name="alice", amount=amount, credit_limit_value=1_000
-    )
+    result = await borrow(user_id=1, name="alice", amount=amount, credit_limit_value=1_000)
     assert result is None
 
 
@@ -230,8 +245,8 @@ async def test_borrow_rejects_non_positive_amount(amount: int) -> None:
 
 async def test_repay_pays_principal_only() -> None:
     """Repayment debits the requested amount from principal in one shot."""
-    await database.borrow(user_id=1, name="alice", amount=1_000, credit_limit_value=10_000)
-    result = await database.repay(user_id=1, name="alice", amount=300)
+    await borrow(user_id=1, name="alice", amount=1_000, credit_limit_value=10_000)
+    result = await repay(user_id=1, name="alice", amount=300)
     assert result is not None
     assert result.principal_repaid == 300
     assert result.remaining_debt == 700
@@ -240,8 +255,8 @@ async def test_repay_pays_principal_only() -> None:
 
 async def test_repay_clamps_to_debt_total() -> None:
     """Over-request only repays up to the user's debt."""
-    await database.borrow(user_id=1, name="alice", amount=500, credit_limit_value=10_000)
-    result = await database.repay(user_id=1, name="alice", amount=10_000)
+    await borrow(user_id=1, name="alice", amount=500, credit_limit_value=10_000)
+    result = await repay(user_id=1, name="alice", amount=10_000)
     assert result is not None
     assert result.principal_repaid == 500
     assert result.remaining_debt == 0
@@ -250,8 +265,8 @@ async def test_repay_clamps_to_debt_total() -> None:
 
 async def test_repay_clamps_to_balance_when_balance_smaller() -> None:
     """When balance < debt, repayment caps at balance."""
-    await database.borrow(user_id=1, name="alice", amount=1_000, credit_limit_value=10_000)
-    await database.apply_round_settlement(
+    await borrow(user_id=1, name="alice", amount=1_000, credit_limit_value=10_000)
+    await apply_round_settlement(
         player_id=1,
         player_account_name="alice",
         player_delta=-600,
@@ -259,7 +274,7 @@ async def test_repay_clamps_to_balance_when_balance_smaller() -> None:
         dealer_name="house",
         dealer_delta=600,
     )
-    result = await database.repay(user_id=1, name="alice", amount=10_000)
+    result = await repay(user_id=1, name="alice", amount=10_000)
     assert result is not None
     assert result.principal_repaid == 400
     assert result.new_balance == 0
@@ -269,13 +284,13 @@ async def test_repay_clamps_to_balance_when_balance_smaller() -> None:
 async def test_repay_no_debt_returns_none() -> None:
     """No outstanding debt → repayment rejected."""
     await _add_balance(user_id=1, name="alice", amount=100)
-    assert await database.repay(user_id=1, name="alice", amount=50) is None
+    assert await repay(user_id=1, name="alice", amount=50) is None
 
 
 async def test_repay_zero_balance_returns_none() -> None:
     """Zero balance → no funds to repay with, even when debt remains."""
-    await database.borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
-    await database.apply_round_settlement(
+    await borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
+    await apply_round_settlement(
         player_id=1,
         player_account_name="alice",
         player_delta=-500,
@@ -283,13 +298,13 @@ async def test_repay_zero_balance_returns_none() -> None:
         dealer_name="house",
         dealer_delta=500,
     )
-    assert await database.repay(user_id=1, name="alice", amount=100) is None
+    assert await repay(user_id=1, name="alice", amount=100) is None
 
 
 async def test_repay_negative_balance_returns_none() -> None:
     """Negative casino balance is not repayable cash."""
-    await database.borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
-    await database.apply_round_settlement(
+    await borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
+    await apply_round_settlement(
         player_id=1,
         player_account_name="alice",
         player_delta=-600,
@@ -297,14 +312,14 @@ async def test_repay_negative_balance_returns_none() -> None:
         dealer_name="house",
         dealer_delta=600,
     )
-    assert await database.repay(user_id=1, name="alice", amount=100) is None
+    assert await repay(user_id=1, name="alice", amount=100) is None
 
 
 async def test_repay_does_not_bump_total_spent() -> None:
     """Repaying a loan must not pollute the gameplay-spent counter."""
-    await database.borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
-    await database.repay(user_id=1, name="alice", amount=200)
-    account = await database.get_account(user_id=1)
+    await borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
+    await repay(user_id=1, name="alice", amount=200)
+    account = await get_account(user_id=1)
     assert account is not None
     _, _, _, total_spent = account
     assert total_spent == 0
@@ -313,8 +328,8 @@ async def test_repay_does_not_bump_total_spent() -> None:
 @pytest.mark.parametrize(argnames="amount", argvalues=[0, -1])
 async def test_repay_rejects_non_positive_amount(amount: int) -> None:
     """Non-positive repay amounts are rejected."""
-    await database.borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
-    assert await database.repay(user_id=1, name="alice", amount=amount) is None
+    await borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
+    assert await repay(user_id=1, name="alice", amount=amount) is None
 
 
 # credit_with_repayment ----------------------------------------------------
@@ -322,7 +337,7 @@ async def test_repay_rejects_non_positive_amount(amount: int) -> None:
 
 async def test_credit_with_repayment_full_credit_when_no_debt() -> None:
     """Without debt, the full amount lands in balance."""
-    result = await database.credit_with_repayment(
+    result = await credit_with_repayment(
         user_id=1, name="alice", amount=100, kind=TransactionKind.CHAT_REWARD
     )
     assert result.new_balance == 100
@@ -333,8 +348,8 @@ async def test_credit_with_repayment_full_credit_when_no_debt() -> None:
 
 async def test_credit_with_repayment_diverts_50_percent_to_principal() -> None:
     """With debt, 50% of income pays down principal."""
-    await database.borrow(user_id=1, name="alice", amount=1_000, credit_limit_value=10_000)
-    result = await database.credit_with_repayment(
+    await borrow(user_id=1, name="alice", amount=1_000, credit_limit_value=10_000)
+    result = await credit_with_repayment(
         user_id=1, name="alice", amount=200, kind=TransactionKind.CHAT_REWARD
     )
     assert result.principal_repaid == 100
@@ -344,8 +359,8 @@ async def test_credit_with_repayment_diverts_50_percent_to_principal() -> None:
 
 async def test_credit_with_repayment_caps_at_principal_total() -> None:
     """Repayment clamps to total debt when 50% exceeds outstanding."""
-    await database.borrow(user_id=1, name="alice", amount=50, credit_limit_value=1_000)
-    await database.apply_round_settlement(
+    await borrow(user_id=1, name="alice", amount=50, credit_limit_value=1_000)
+    await apply_round_settlement(
         player_id=1,
         player_account_name="alice",
         player_delta=-50,
@@ -353,7 +368,7 @@ async def test_credit_with_repayment_caps_at_principal_total() -> None:
         dealer_name="house",
         dealer_delta=50,
     )
-    result = await database.credit_with_repayment(
+    result = await credit_with_repayment(
         user_id=1, name="alice", amount=1_000, kind=TransactionKind.CHAT_REWARD
     )
     assert result.principal_repaid == 50
@@ -364,8 +379,8 @@ async def test_credit_with_repayment_caps_at_principal_total() -> None:
 
 async def test_credit_with_repayment_floors_odd_amount() -> None:
     """Floor-division of odd amount: 11 // 2 = 5 to repayment, 6 to balance."""
-    await database.borrow(user_id=1, name="alice", amount=100, credit_limit_value=1_000)
-    result = await database.credit_with_repayment(
+    await borrow(user_id=1, name="alice", amount=100, credit_limit_value=1_000)
+    result = await credit_with_repayment(
         user_id=1, name="alice", amount=11, kind=TransactionKind.CHAT_REWARD
     )
     assert result.principal_repaid == 5
@@ -375,7 +390,7 @@ async def test_credit_with_repayment_floors_odd_amount() -> None:
 async def test_credit_with_repayment_zero_amount_is_noop() -> None:
     """Zero amount returns current balance without writing or logging."""
     await _add_balance(user_id=1, name="alice", amount=100)
-    result = await database.credit_with_repayment(
+    result = await credit_with_repayment(
         user_id=1, name="alice", amount=0, kind=TransactionKind.CHAT_REWARD
     )
     assert result.new_balance == 100
@@ -386,24 +401,22 @@ async def test_credit_with_repayment_zero_amount_is_noop() -> None:
 
 async def test_credit_with_repayment_first_sight_creates_row() -> None:
     """An unknown user receiving credit gets a fresh row."""
-    result = await database.credit_with_repayment(
+    result = await credit_with_repayment(
         user_id=42, name="newcomer", amount=200, kind=TransactionKind.CHAT_REWARD
     )
     assert result.new_balance == 200
     assert result.credited_amount == 200
-    assert await database.get_balance(user_id=42) == 200
+    assert await get_balance(user_id=42) == 200
 
 
 async def test_credit_with_repayment_concurrent_credits_accumulate() -> None:
     """Concurrent credits on the same user must not lose updates."""
     await _add_balance(user_id=1, name="alice", amount=0)
     await asyncio.gather(*[
-        database.credit_with_repayment(
-            user_id=1, name="alice", amount=10, kind=TransactionKind.CHAT_REWARD
-        )
+        credit_with_repayment(user_id=1, name="alice", amount=10, kind=TransactionKind.CHAT_REWARD)
         for _ in range(10)
     ])
-    assert await database.get_balance(user_id=1) == 100
+    assert await get_balance(user_id=1) == 100
 
 
 # Daily loan reset ---------------------------------------------------------
@@ -411,9 +424,9 @@ async def test_credit_with_repayment_concurrent_credits_accumulate() -> None:
 
 async def test_loan_expires_at_next_taipei_midnight() -> None:
     """A loan opened before today's Taipei midnight is wiped on next access."""
-    await database.borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
+    await borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
     await _backdate_loan_opened_at(user_id=1, days_ago=2)
-    view = await database.get_loan_view(user_id=1)
+    view = await get_loan_view(user_id=1)
     assert view is not None
     assert view.principal == 0
     assert view.opened_at is None
@@ -421,8 +434,8 @@ async def test_loan_expires_at_next_taipei_midnight() -> None:
 
 async def test_loan_stays_active_within_the_same_taipei_day() -> None:
     """A loan opened earlier the same Taipei day is still outstanding."""
-    await database.borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
-    view = await database.get_loan_view(user_id=1)
+    await borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
+    view = await get_loan_view(user_id=1)
     assert view is not None
     assert view.principal == 500
     assert view.opened_at is not None
@@ -430,29 +443,29 @@ async def test_loan_stays_active_within_the_same_taipei_day() -> None:
 
 async def test_borrow_after_expiry_re_arms_daily_window() -> None:
     """A new borrow after expiry creates a fresh daily window."""
-    await database.borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
+    await borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
     await _backdate_loan_opened_at(user_id=1, days_ago=3)
 
-    second = await database.borrow(user_id=1, name="alice", amount=400, credit_limit_value=1_000)
+    second = await borrow(user_id=1, name="alice", amount=400, credit_limit_value=1_000)
     assert second is not None
     assert second.principal == 400
-    view = await database.get_loan_view(user_id=1)
+    view = await get_loan_view(user_id=1)
     assert view is not None
     assert view.opened_at is not None
 
 
 async def test_expired_loan_does_not_reduce_balance() -> None:
     """The daily reset wipes principal but does not claw back borrowed funds."""
-    await database.borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
+    await borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
     await _backdate_loan_opened_at(user_id=1, days_ago=2)
-    assert await database.get_balance(user_id=1) == 500
+    assert await get_balance(user_id=1) == 500
 
 
 async def test_credit_with_repayment_after_expiry_credits_full_amount() -> None:
     """After the daily reset the 50% auto-repay no longer applies."""
-    await database.borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
+    await borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
     await _backdate_loan_opened_at(user_id=1, days_ago=2)
-    result = await database.credit_with_repayment(
+    result = await credit_with_repayment(
         user_id=1, name="alice", amount=200, kind=TransactionKind.CHAT_REWARD
     )
     assert result.credited_amount == 200
@@ -465,13 +478,13 @@ async def test_credit_with_repayment_after_expiry_credits_full_amount() -> None:
 
 async def test_get_loan_view_unknown_user_returns_none() -> None:
     """An unknown user has no row to project."""
-    assert await database.get_loan_view(user_id=999) is None
+    assert await get_loan_view(user_id=999) is None
 
 
 async def test_get_loan_view_account_without_loan_returns_zero_state() -> None:
     """A user with a balance row but no loan returns a fresh-zero snapshot."""
     await _add_balance(user_id=1, name="alice", amount=100)
-    view = await database.get_loan_view(user_id=1)
+    view = await get_loan_view(user_id=1)
     assert view is not None
     assert view.principal == 0
     assert view.opened_at is None
@@ -481,9 +494,9 @@ async def test_get_loan_view_account_without_loan_returns_zero_state() -> None:
 
 async def test_get_loan_view_after_borrow_and_repay_tracks_totals() -> None:
     """Gross flows persist in total_borrowed / total_repaid across operations."""
-    await database.borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
-    await database.repay(user_id=1, name="alice", amount=200)
-    view = await database.get_loan_view(user_id=1)
+    await borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
+    await repay(user_id=1, name="alice", amount=200)
+    view = await get_loan_view(user_id=1)
     assert view is not None
     assert view.principal == 300
     assert view.total_borrowed == 500
@@ -495,15 +508,15 @@ async def test_get_loan_view_after_borrow_and_repay_tracks_totals() -> None:
 
 async def test_borrow_logs_audit_row() -> None:
     """Borrow writes one BORROW row with positive delta and post-state debt."""
-    await database.borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
+    await borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
     rows = await _list_transactions(user_id=1)
     assert rows == [(TransactionKind.BORROW.value, 500, 500)]
 
 
 async def test_repay_logs_audit_row() -> None:
     """Repay writes one REPAY row with negative delta and reduced debt."""
-    await database.borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
-    await database.repay(user_id=1, name="alice", amount=200)
+    await borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
+    await repay(user_id=1, name="alice", amount=200)
     rows = await _list_transactions(user_id=1)
     assert rows == [
         (TransactionKind.BORROW.value, 500, 500),
@@ -513,8 +526,8 @@ async def test_repay_logs_audit_row() -> None:
 
 async def test_chat_reward_logs_credited_slice_with_debt_context() -> None:
     """credit_with_repayment logs delta=credited and debt_after=post-repay debt."""
-    await database.borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
-    await database.credit_with_repayment(
+    await borrow(user_id=1, name="alice", amount=500, credit_limit_value=1_000)
+    await credit_with_repayment(
         user_id=1, name="alice", amount=100, kind=TransactionKind.CHAT_REWARD
     )
     rows = await _list_transactions(user_id=1)
@@ -527,9 +540,7 @@ async def test_chat_reward_logs_credited_slice_with_debt_context() -> None:
 async def test_transfer_logs_both_sides() -> None:
     """Transfer writes TRANSFER_OUT for sender and TRANSFER_IN for receiver."""
     await _add_balance(user_id=1, name="alice", amount=100)
-    await database.transfer(
-        sender_id=1, sender_name="alice", receiver_id=2, receiver_name="bob", amount=40
-    )
+    await transfer(sender_id=1, sender_name="alice", receiver_id=2, receiver_name="bob", amount=40)
     assert await _list_transactions(user_id=1) == [(TransactionKind.TRANSFER_OUT.value, -40, 0)]
     assert await _list_transactions(user_id=2) == [(TransactionKind.TRANSFER_IN.value, 40, 0)]
 
@@ -537,14 +548,12 @@ async def test_transfer_logs_both_sides() -> None:
 async def test_transfer_log_note_captures_counterparty() -> None:
     """Transfer audit rows carry the counterparty identity in ``note``."""
     await _add_balance(user_id=1, name="alice", amount=100)
-    await database.transfer(
-        sender_id=1, sender_name="alice", receiver_id=2, receiver_name="bob", amount=40
-    )
-    async with database.open_session() as session:
+    await transfer(sender_id=1, sender_name="alice", receiver_id=2, receiver_name="bob", amount=40)
+    async with open_session() as session:
         result = await session.execute(
-            statement=select(
-                database.PointTransaction.user_id, database.PointTransaction.note
-            ).order_by(database.PointTransaction.id)
+            statement=select(PointTransaction.user_id, PointTransaction.note).order_by(
+                PointTransaction.id
+            )
         )
         notes = result.all()
     assert (1, "to bob (2)") in notes
@@ -554,7 +563,7 @@ async def test_transfer_log_note_captures_counterparty() -> None:
 async def test_apply_round_settlement_logs_casino_bet() -> None:
     """A negative player settlement writes a CASINO_BET row."""
     await _add_balance(user_id=1, name="alice", amount=100)
-    await database.apply_round_settlement(
+    await apply_round_settlement(
         player_id=1,
         player_account_name="alice",
         player_delta=-40,
@@ -568,7 +577,7 @@ async def test_apply_round_settlement_logs_casino_bet() -> None:
 async def test_apply_round_settlement_logs_payout_and_house_settle() -> None:
     """Player and dealer sides of a round each produce one audit row."""
     await _add_balance(user_id=1, name="alice", amount=100)
-    await database.apply_round_settlement(
+    await apply_round_settlement(
         player_id=1,
         player_account_name="alice",
         player_delta=40,
@@ -583,7 +592,7 @@ async def test_apply_round_settlement_logs_payout_and_house_settle() -> None:
 async def test_apply_round_settlement_skips_zero_delta_house_log() -> None:
     """A push (dealer_delta=0) does not produce a house audit row."""
     await _add_balance(user_id=1, name="alice", amount=100)
-    await database.apply_round_settlement(
+    await apply_round_settlement(
         player_id=1,
         player_account_name="alice",
         player_delta=0,
@@ -597,6 +606,6 @@ async def test_apply_round_settlement_skips_zero_delta_house_log() -> None:
 async def test_adjust_balance_logs_applied_delta_not_requested_delta() -> None:
     """A clamped manual adjustment logs only the applied balance delta."""
     await _add_balance(user_id=1, name="alice", amount=10)
-    await database.adjust_balance(user_id=1, name="alice", delta=-1000)
+    await adjust_balance(user_id=1, name="alice", delta=-1000)
     rows = await _list_transactions(user_id=1)
     assert rows == [(TransactionKind.MANUAL_ADJUSTMENT.value, -10, 0)]

--- a/tests/test_manage_admin.py
+++ b/tests/test_manage_admin.py
@@ -3,7 +3,7 @@
 import pytest
 from scripts import manage_admin as manage_admin_script
 
-from discordbot.cogs._economy import database
+from discordbot.cogs._economy.database import get_admin, get_account, get_balance, adjust_balance
 
 pytestmark = pytest.mark.usefixtures("economy_isolated_db")
 
@@ -30,8 +30,8 @@ async def test_grant_admin_creates_admin_row() -> None:
 
     assert result.applied is True
     assert result.is_admin is True
-    assert await database.get_admin(user_id=42) is True
-    assert await database.get_balance(user_id=42) == 0
+    assert await get_admin(user_id=42) is True
+    assert await get_balance(user_id=42) == 0
 
 
 async def test_revoke_admin_clears_existing_flag() -> None:
@@ -42,7 +42,7 @@ async def test_revoke_admin_clears_existing_flag() -> None:
 
     assert result.applied is True
     assert result.is_admin is False
-    assert await database.get_admin(user_id=42) is False
+    assert await get_admin(user_id=42) is False
 
 
 async def test_revoke_admin_missing_user_noops() -> None:
@@ -51,12 +51,12 @@ async def test_revoke_admin_missing_user_noops() -> None:
 
     assert result.applied is False
     assert result.is_admin is False
-    assert await database.get_account(user_id=42) is None
+    assert await get_account(user_id=42) is None
 
 
 async def test_list_admin_accounts_filters_non_admins() -> None:
     """The script lists only current admins."""
     await manage_admin_script.grant_admin(user_id=42, name="alice")
-    await database.adjust_balance(user_id=43, name="bob", delta=100)
+    await adjust_balance(user_id=43, name="bob", delta=100)
 
     assert await manage_admin_script.list_admin_accounts() == [(42, "alice")]

--- a/tests/test_maplestory.py
+++ b/tests/test_maplestory.py
@@ -11,8 +11,7 @@ from nextcord import Embed, SelectOption
 
 from discordbot.cogs import maplestory
 from discordbot.cogs.maplestory import MapleStoryCogs
-from discordbot.cogs._maplestory import views
-from discordbot.cogs._maplestory.views import MapleDropSearchView
+from discordbot.cogs._maplestory.views import _RESOLVERS, MapleDropSearchView
 from discordbot.cogs._maplestory.embeds import (
     _truncate,
     create_map_embed,
@@ -477,7 +476,7 @@ async def test_maplestory_view_resolvers_and_selection(service: MapleStoryServic
         ("quest", "Helping Hand"),
         ("map", "Henesys > Hunting Ground"),
     ]:
-        resolver = views._RESOLVERS[search_type]
+        resolver = _RESOLVERS[search_type]
         embed = resolver(service=service, name=name, tr=service.translate)
         assert isinstance(embed, Embed)
 

--- a/tests/test_modify_balance.py
+++ b/tests/test_modify_balance.py
@@ -3,14 +3,14 @@
 import pytest
 from scripts import modify_balance as modify_balance_script
 
-from discordbot.cogs._economy import database
+from discordbot.cogs._economy.database import BalanceAdjustmentResult, get_account, adjust_balance
 
 pytestmark = pytest.mark.usefixtures("economy_isolated_db")
 
 
 async def _add_balance(user_id: int, name: str, amount: int) -> int:
     """Seeds a balance through the manual adjustment API."""
-    result = await database.adjust_balance(user_id=user_id, name=name, delta=amount)
+    result = await adjust_balance(user_id=user_id, name=name, delta=amount)
     return result.new_balance
 
 
@@ -32,10 +32,10 @@ async def test_modify_all_balances_updates_existing_accounts_only() -> None:
     assert len(result.changes) == 2
     assert result.applied_delta == 100_000
     assert all(not change.created for change in result.changes)
-    assert await database.get_account(user_id=3) is None
+    assert await get_account(user_id=3) is None
 
-    alice = await database.get_account(user_id=1)
-    bob = await database.get_account(user_id=2)
+    alice = await get_account(user_id=1)
+    bob = await get_account(user_id=2)
     assert alice is not None
     assert bob is not None
     assert alice[1] == 50_100
@@ -46,7 +46,7 @@ async def test_modify_balance_reports_actual_adjustment_after_stale_read(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The CLI summary uses the adjustment result, not the pre-read projection."""
-    call: dict[str, object] = {}
+    call: dict[str, int | str | bool] = {}
 
     async def fake_get_account(user_id: int) -> tuple[str, int, int, int]:
         """Returns a stale pre-adjustment account snapshot."""
@@ -55,7 +55,7 @@ async def test_modify_balance_reports_actual_adjustment_after_stale_read(
 
     async def fake_adjust_balance(
         user_id: int, name: str, delta: int, allow_negative: bool
-    ) -> database.BalanceAdjustmentResult:
+    ) -> BalanceAdjustmentResult:
         """Records the requested adjustment and returns the true DB result."""
         call.update({
             "user_id": user_id,
@@ -63,13 +63,11 @@ async def test_modify_balance_reports_actual_adjustment_after_stale_read(
             "delta": delta,
             "allow_negative": allow_negative,
         })
-        return database.BalanceAdjustmentResult(new_balance=0, applied_delta=-25)
+        return BalanceAdjustmentResult(new_balance=0, applied_delta=-25)
 
+    monkeypatch.setattr(target=modify_balance_script, name="get_account", value=fake_get_account)
     monkeypatch.setattr(
-        target=modify_balance_script.database, name="get_account", value=fake_get_account
-    )
-    monkeypatch.setattr(
-        target=modify_balance_script.database, name="adjust_balance", value=fake_adjust_balance
+        target=modify_balance_script, name="adjust_balance", value=fake_adjust_balance
     )
 
     result = await modify_balance_script.modify_balance(user_id=1, name="", delta=-80)
@@ -89,14 +87,14 @@ async def test_modify_balance_missing_user_negative_noops_without_creating() -> 
     assert result.applied_delta == 0
     assert result.after == 0
     assert result.created is False
-    assert await database.get_account(user_id=3) is None
+    assert await get_account(user_id=3) is None
 
 
 async def test_modify_balance_missing_user_negative_delegates_to_database(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Missing-user negative writes still go through the transactional API."""
-    call: dict[str, object] = {}
+    call: dict[str, int | str | bool] = {}
 
     async def fake_get_account(user_id: int) -> None:
         """Returns no account for the requested user."""
@@ -104,7 +102,7 @@ async def test_modify_balance_missing_user_negative_delegates_to_database(
 
     async def fake_adjust_balance(
         user_id: int, name: str, delta: int, allow_negative: bool
-    ) -> database.BalanceAdjustmentResult:
+    ) -> BalanceAdjustmentResult:
         """Records that the missing-user write still reaches the DB facade."""
         call.update({
             "user_id": user_id,
@@ -112,13 +110,11 @@ async def test_modify_balance_missing_user_negative_delegates_to_database(
             "delta": delta,
             "allow_negative": allow_negative,
         })
-        return database.BalanceAdjustmentResult(new_balance=20, applied_delta=-80)
+        return BalanceAdjustmentResult(new_balance=20, applied_delta=-80)
 
+    monkeypatch.setattr(target=modify_balance_script, name="get_account", value=fake_get_account)
     monkeypatch.setattr(
-        target=modify_balance_script.database, name="get_account", value=fake_get_account
-    )
-    monkeypatch.setattr(
-        target=modify_balance_script.database, name="adjust_balance", value=fake_adjust_balance
+        target=modify_balance_script, name="adjust_balance", value=fake_adjust_balance
     )
 
     result = await modify_balance_script.modify_balance(user_id=3, name="", delta=-100)


### PR DESCRIPTION
## Summary
- Replace bare `object` annotations with JSON aliases, concrete UI item types, or justified heterogeneous test payload types.
- Import economy, cleanup, game, and MapleStory symbols directly instead of accessing them through local module namespace prefixes.
- Move module-global test patches to dotted `monkeypatch` targets so tests no longer need local module namespace imports.

## Root Cause
Issue #180 came from broad local module imports such as `from discordbot.cogs._economy import database`, which hid the actual symbols each file used. Several test doubles also used `object` as a catch-all annotation, reducing type-checker value.

## Validation
- `uv run pre-commit run -a`
- `uv run pytest`

Closes #180