### PR TITLE
refactor: normalize nextcord UI imports

### DIFF
--- a/src/discordbot/cogs/_games/blackjack_views.py
+++ b/src/discordbot/cogs/_games/blackjack_views.py
@@ -7,7 +7,9 @@ import asyncio
 import contextlib
 
 import logfire
-from nextcord import Embed, Message, ButtonStyle, Interaction, ui
+import nextcord
+from nextcord import Embed, Message, ButtonStyle, Interaction
+from nextcord.ui import View, Button
 
 from discordbot.typings.games import (
     Card,
@@ -501,7 +503,7 @@ class BlackjackLobbyView(BaseGameLobbyView):
         return True
 
 
-class BlackjackView(ui.View):
+class BlackjackView(View):
     """Hit / Stand / Double / Split / Surrender / Insurance controls."""
 
     def __init__(  # noqa: PLR0913 -- view needs table, dealer, and ledger identity
@@ -530,9 +532,9 @@ class BlackjackView(ui.View):
         self._dealer_line = dealer_line
         self.round_state.auto_play_dealer = False
         self._dealer_steps: list[BlackjackDealerStep] = []
-        self._insurance_buttons: tuple[ui.Button, ui.Button] = (
-            cast("ui.Button", self.insure_yes),
-            cast("ui.Button", self.insure_no),
+        self._insurance_buttons: tuple[Button, Button] = (
+            cast("Button", self.insure_yes),
+            cast("Button", self.insure_no),
         )
 
     async def interaction_check(self, interaction: Interaction) -> bool:  # noqa: PLR0911 -- phase + identity gating naturally fans out into early returns
@@ -583,8 +585,10 @@ class BlackjackView(ui.View):
             self.round_state.stand_all_remaining()
             await self._finalize_locked(message=self.message)
 
-    @ui.button(label="再要一張", emoji="🃏", style=ButtonStyle.primary, custom_id="bj:hit", row=0)
-    async def hit(self, _button: ui.Button, interaction: Interaction) -> None:
+    @nextcord.ui.button(
+        label="再要一張", emoji="🃏", style=ButtonStyle.primary, custom_id="bj:hit", row=0
+    )
+    async def hit(self, _button: Button, interaction: Interaction) -> None:
         """Handles the active player's Hit button."""
         await interaction.response.defer()
         if interaction.message is None or interaction.user is None:
@@ -621,8 +625,10 @@ class BlackjackView(ui.View):
                 )
             await self._edit_in_progress_locked(message=interaction.message)
 
-    @ui.button(label="停手", emoji="✋", style=ButtonStyle.secondary, custom_id="bj:stand", row=0)
-    async def stand(self, _button: ui.Button, interaction: Interaction) -> None:
+    @nextcord.ui.button(
+        label="停手", emoji="✋", style=ButtonStyle.secondary, custom_id="bj:stand", row=0
+    )
+    async def stand(self, _button: Button, interaction: Interaction) -> None:
         """Handles the active player's Stand button."""
         await interaction.response.defer()
         if interaction.message is None or interaction.user is None:
@@ -646,8 +652,10 @@ class BlackjackView(ui.View):
                 return
             await self._edit_in_progress_locked(message=interaction.message)
 
-    @ui.button(label="加倍", emoji="💰", style=ButtonStyle.success, custom_id="bj:double", row=0)
-    async def double(self, _button: ui.Button, interaction: Interaction) -> None:
+    @nextcord.ui.button(
+        label="加倍", emoji="💰", style=ButtonStyle.success, custom_id="bj:double", row=0
+    )
+    async def double(self, _button: Button, interaction: Interaction) -> None:
         """Doubles the active hand's bet and finishes it after one draw."""
         await interaction.response.defer()
         if interaction.message is None or interaction.user is None:
@@ -671,8 +679,10 @@ class BlackjackView(ui.View):
                 return
             await self._edit_in_progress_locked(message=interaction.message)
 
-    @ui.button(label="分牌", emoji="🪓", style=ButtonStyle.success, custom_id="bj:split", row=0)
-    async def split(self, _button: ui.Button, interaction: Interaction) -> None:
+    @nextcord.ui.button(
+        label="分牌", emoji="🪓", style=ButtonStyle.success, custom_id="bj:split", row=0
+    )
+    async def split(self, _button: Button, interaction: Interaction) -> None:
         """Splits the active pair into two sibling sub-hands."""
         await interaction.response.defer()
         if interaction.message is None or interaction.user is None:
@@ -696,8 +706,10 @@ class BlackjackView(ui.View):
                 return
             await self._edit_in_progress_locked(message=interaction.message)
 
-    @ui.button(label="投降", emoji="🏳️", style=ButtonStyle.danger, custom_id="bj:surrender", row=0)
-    async def surrender(self, _button: ui.Button, interaction: Interaction) -> None:
+    @nextcord.ui.button(
+        label="投降", emoji="🏳️", style=ButtonStyle.danger, custom_id="bj:surrender", row=0
+    )
+    async def surrender(self, _button: Button, interaction: Interaction) -> None:
         """Surrenders the active hand for a half-bet refund."""
         await interaction.response.defer()
         if interaction.message is None or interaction.user is None:
@@ -721,10 +733,10 @@ class BlackjackView(ui.View):
                 return
             await self._edit_in_progress_locked(message=interaction.message)
 
-    @ui.button(
+    @nextcord.ui.button(
         label="保險 ½", emoji="🛡️", style=ButtonStyle.success, custom_id="bj:insure_yes", row=1
     )
-    async def insure_yes(self, _button: ui.Button, interaction: Interaction) -> None:
+    async def insure_yes(self, _button: Button, interaction: Interaction) -> None:
         """Takes insurance for the calling player."""
         await interaction.response.defer()
         if interaction.message is None:
@@ -766,10 +778,10 @@ class BlackjackView(ui.View):
                 return
             await self._edit_in_progress_locked(message=interaction.message)
 
-    @ui.button(
+    @nextcord.ui.button(
         label="不保險", emoji="❌", style=ButtonStyle.secondary, custom_id="bj:insure_no", row=1
     )
-    async def insure_no(self, _button: ui.Button, interaction: Interaction) -> None:
+    async def insure_no(self, _button: Button, interaction: Interaction) -> None:
         """Declines insurance for the calling player."""
         await interaction.response.defer()
         if interaction.message is None:
@@ -807,7 +819,7 @@ class BlackjackView(ui.View):
                 player=active_player
             )
         for child in self.children:
-            if not isinstance(child, ui.Button):
+            if not isinstance(child, Button):
                 continue
             cid = child.custom_id or ""
             if cid in ("bj:insure_yes", "bj:insure_no"):
@@ -1043,7 +1055,7 @@ class BlackjackView(ui.View):
     def _disable_buttons(self) -> None:
         """Disables every action / insurance control after settlement."""
         self._sync_insurance_button_visibility(in_insurance=self.round_state.phase == "insurance")
-        disable_view_components(children=self.children, component_types=(ui.Button,))
+        disable_view_components(children=self.children, component_types=(Button,))
 
 
 __all__: list[str] = [

--- a/src/discordbot/cogs/_games/dragon_gate_views.py
+++ b/src/discordbot/cogs/_games/dragon_gate_views.py
@@ -8,7 +8,8 @@ import contextlib
 
 import logfire
 import nextcord
-from nextcord import Embed, Message, ButtonStyle, Interaction, ui
+from nextcord import Embed, Message, ButtonStyle, Interaction
+from nextcord.ui import Item, View, Modal, Button, TextInput, StringSelect
 
 from discordbot.typings.games import GameParticipant, DragonGatePlayerResult
 from discordbot.cogs._games.lobby import (
@@ -395,7 +396,7 @@ class DragonGateLobbyView(BaseJackpotLobbyView):
         await edit_message_with_retry(message=message, embeds=view.in_progress_embeds(), view=view)
 
 
-class DragonGateView(ui.View):
+class DragonGateView(View):
     """High / low buttons, bet select, and leave button for an active 射龍門 table."""
 
     def __init__(  # noqa: PLR0913 -- view needs round, dealer, jackpot, and initial balances
@@ -463,21 +464,21 @@ class DragonGateView(ui.View):
             await self._refund_remaining_winners_locked()
             await self._finalize_locked(message=self.message, reason="逾時未操作")
 
-    @ui.button(
+    @nextcord.ui.button(
         label="同點猜大", emoji="⬆️", style=ButtonStyle.secondary, custom_id="dg:higher", row=0
     )
-    async def choose_higher(self, _button: ui.Button, interaction: Interaction) -> None:
+    async def choose_higher(self, _button: Button, interaction: Interaction) -> None:
         """Chooses higher for a same-point gate."""
         await self._choose_direction(interaction=interaction, direction="higher")
 
-    @ui.button(
+    @nextcord.ui.button(
         label="同點猜小", emoji="⬇️", style=ButtonStyle.secondary, custom_id="dg:lower", row=0
     )
-    async def choose_lower(self, _button: ui.Button, interaction: Interaction) -> None:
+    async def choose_lower(self, _button: Button, interaction: Interaction) -> None:
         """Chooses lower for a same-point gate."""
         await self._choose_direction(interaction=interaction, direction="lower")
 
-    @ui.string_select(
+    @nextcord.ui.string_select(
         placeholder="🪙 選擇下注金額",
         custom_id="dg:bet",
         min_values=1,
@@ -489,12 +490,14 @@ class DragonGateView(ui.View):
         ],
         row=1,
     )
-    async def bet_select(self, select: ui.StringSelect, interaction: Interaction) -> None:
+    async def bet_select(self, select: StringSelect, interaction: Interaction) -> None:
         """Routes the bet select choice to a fixed amount or a custom modal."""
         await self._handle_bet_choice(choice=select.values[0], interaction=interaction)
 
-    @ui.button(label="離桌", emoji="🚪", style=ButtonStyle.danger, custom_id="dg:leave", row=2)
-    async def leave_table(self, _button: ui.Button, interaction: Interaction) -> None:
+    @nextcord.ui.button(
+        label="離桌", emoji="🚪", style=ButtonStyle.danger, custom_id="dg:leave", row=2
+    )
+    async def leave_table(self, _button: Button, interaction: Interaction) -> None:
         """Lets any seated player withdraw mid-table without ending the round."""
         await self._handle_leave(interaction=interaction)
 
@@ -807,17 +810,17 @@ class DragonGateView(ui.View):
                 return participant
         return None
 
-    def _button(self, custom_id: str) -> ui.Button:
+    def _button(self, custom_id: str) -> Button:
         """Returns a button component by custom ID."""
         for child in self.children:
-            if isinstance(child, ui.Button) and child.custom_id == custom_id:
+            if isinstance(child, Button) and child.custom_id == custom_id:
                 return child
         raise RuntimeError(f"Missing button: {custom_id}")
 
-    def _select(self, custom_id: str) -> ui.StringSelect:
+    def _select(self, custom_id: str) -> StringSelect:
         """Returns a string select component by custom ID."""
         for child in self.children:
-            if isinstance(child, ui.StringSelect) and child.custom_id == custom_id:
+            if isinstance(child, StringSelect) and child.custom_id == custom_id:
                 return child
         raise RuntimeError(f"Missing select: {custom_id}")
 
@@ -858,7 +861,7 @@ class DragonGateView(ui.View):
             log_message="Failed to send Dragon Gate action notice",
         )
 
-    async def on_error(self, error: Exception, item: ui.Item, interaction: Interaction) -> None:
+    async def on_error(self, error: Exception, item: Item, interaction: Interaction) -> None:
         """Logs active-table component failures instead of only printing to stderr."""
         logfire.error(
             "Dragon Gate action interaction failed",
@@ -869,19 +872,17 @@ class DragonGateView(ui.View):
 
     def _disable_controls(self) -> None:
         """Disables every active-table button and select control."""
-        disable_view_components(
-            children=self.children, component_types=(ui.Button, ui.StringSelect)
-        )
+        disable_view_components(children=self.children, component_types=(Button, StringSelect))
 
 
-class DragonGateBetModal(ui.Modal):
+class DragonGateBetModal(Modal):
     """Modal for entering an exact 射龍門 bet amount."""
 
     def __init__(self, view: DragonGateView, minimum: int, maximum: int) -> None:
         """Initializes the modal with a range-aware amount input."""
         super().__init__(title="自訂下注")
         self.view = view
-        self.amount: ui.TextInput = ui.TextInput(
+        self.amount: TextInput = TextInput(
             label="下注金額",
             placeholder=f"{minimum:,} 到 {maximum:,}",
             min_length=1,

--- a/src/discordbot/cogs/_games/interactions.py
+++ b/src/discordbot/cogs/_games/interactions.py
@@ -5,7 +5,8 @@ import asyncio
 from collections.abc import Iterable
 
 import logfire
-from nextcord import Message, Interaction, ui
+from nextcord import Message, Interaction
+from nextcord.ui import Item
 from nextcord.errors import DiscordServerError
 
 
@@ -21,7 +22,7 @@ async def send_ephemeral_notice(interaction: Interaction, content: str, log_mess
 
 
 def disable_view_components(
-    children: Iterable[ui.Item], component_types: tuple[type[ui.Item], ...]
+    children: Iterable[Item], component_types: tuple[type[Item], ...]
 ) -> None:
     """Disables view children matching any supplied component type."""
     for child in children:

--- a/src/discordbot/cogs/_games/lobby.py
+++ b/src/discordbot/cogs/_games/lobby.py
@@ -7,7 +7,9 @@ import asyncio
 import contextlib
 
 import logfire
-from nextcord import Embed, Message, ButtonStyle, Interaction, ui
+import nextcord
+from nextcord import Embed, Message, ButtonStyle, Interaction
+from nextcord.ui import Item, View, Button
 
 from discordbot.typings.economy import JackpotSettlementRequest, JackpotSettlementBatchResult
 from discordbot.cogs._games.cleanup import schedule_game_message_delete
@@ -43,7 +45,7 @@ class RefreshParticipants(Protocol):
         """Returns refreshed participants and display names removed from the table."""
 
 
-class BaseGameLobbyView(ui.View):
+class BaseGameLobbyView(View):
     """Join / leave / start scaffold shared by multiplayer game lobbies.
 
     Subclasses must override:
@@ -97,8 +99,8 @@ class BaseGameLobbyView(ui.View):
             await self.message.edit(embed=embed, view=self)
         schedule_game_message_delete(message=self.message)
 
-    @ui.button(label="加入", emoji="✅", style=ButtonStyle.success)
-    async def join(self, _button: ui.Button, interaction: Interaction) -> None:
+    @nextcord.ui.button(label="加入", emoji="✅", style=ButtonStyle.success)
+    async def join(self, _button: Button, interaction: Interaction) -> None:
         """Adds the interacting user to the lobby."""
         if interaction.user is None:
             return
@@ -121,8 +123,8 @@ class BaseGameLobbyView(ui.View):
                 message=interaction.message, status=f"{participant.display_name} 已加入"
             )
 
-    @ui.button(label="離開", emoji="🚪", style=ButtonStyle.secondary)
-    async def leave(self, _button: ui.Button, interaction: Interaction) -> None:
+    @nextcord.ui.button(label="離開", emoji="🚪", style=ButtonStyle.secondary)
+    async def leave(self, _button: Button, interaction: Interaction) -> None:
         """Removes the interacting user from the lobby."""
         if interaction.user is None:
             return
@@ -142,8 +144,8 @@ class BaseGameLobbyView(ui.View):
                 message=interaction.message, status=f"{participant.display_name} 已離開"
             )
 
-    @ui.button(label="開始", emoji="▶️", style=ButtonStyle.primary)
-    async def start(self, _button: ui.Button, interaction: Interaction) -> None:
+    @nextcord.ui.button(label="開始", emoji="▶️", style=ButtonStyle.primary)
+    async def start(self, _button: Button, interaction: Interaction) -> None:
         """Starts the game if the lobby owner pressed the button."""
         if interaction.user is None:
             return
@@ -184,7 +186,7 @@ class BaseGameLobbyView(ui.View):
             interaction=interaction, content=content, log_message="Failed to send lobby notice"
         )
 
-    async def on_error(self, error: Exception, item: ui.Item, interaction: Interaction) -> None:
+    async def on_error(self, error: Exception, item: Item, interaction: Interaction) -> None:
         """Logs lobby component failures instead of only printing to stderr."""
         logfire.error(
             "Lobby interaction failed",
@@ -195,7 +197,7 @@ class BaseGameLobbyView(ui.View):
 
     def _disable_buttons(self) -> None:
         """Disables all button components on the lobby view."""
-        disable_view_components(children=self.children, component_types=(ui.Button,))
+        disable_view_components(children=self.children, component_types=(Button,))
 
     def _build_lobby_embed(self, status: str = "等待玩家加入") -> Embed:
         """Builds the lobby embed for a concrete game type."""

--- a/src/discordbot/cogs/_gen_reply/views.py
+++ b/src/discordbot/cogs/_gen_reply/views.py
@@ -3,13 +3,15 @@
 from typing import TYPE_CHECKING
 import contextlib
 
-from nextcord import Message, ButtonStyle, Interaction, ui
+import nextcord
+from nextcord import Message, ButtonStyle, Interaction
+from nextcord.ui import View, Button
 
 if TYPE_CHECKING:
     from discordbot.cogs.gen_reply import ReplyGeneratorCogs
 
 
-class RegenerateView(ui.View):
+class RegenerateView(View):
     """Single-button view that re-runs reply generation for the original user message.
 
     Attributes:
@@ -45,8 +47,8 @@ class RegenerateView(ui.View):
             return False
         return True
 
-    @ui.button(label="重新生成", emoji="🔄", style=ButtonStyle.secondary)
-    async def regenerate(self, button: ui.Button, interaction: Interaction) -> None:
+    @nextcord.ui.button(label="重新生成", emoji="🔄", style=ButtonStyle.secondary)
+    async def regenerate(self, button: Button, interaction: Interaction) -> None:
         """Deletes the old AI reply and re-runs the dispatch flow on the user's message.
 
         Args:

--- a/tests/test_cogs_smoke.py
+++ b/tests/test_cogs_smoke.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
 
     from openai import AsyncOpenAI
     import pytest
+    from nextcord.ui import View
 
 
 class DiscordPayload(TypedDict, total=False):
@@ -58,7 +59,7 @@ class DiscordPayload(TypedDict, total=False):
     embeds: list[Embed]
     file: File
     files: list[File]
-    view: nextcord.ui.View
+    view: View
     wait: bool
     ephemeral: bool
     suppress: bool


### PR DESCRIPTION
## Summary
- Import uppercase nextcord.ui classes and types directly from nextcord.ui.
- Keep UI decorators as nextcord.ui.button and nextcord.ui.string_select.
- Update the cog smoke test payload typing to use the imported View type.

## Validation
- rg -n "\b(nextcord\.ui|ui)\.[A-Z][A-Za-z_]*\b" src/discordbot tests
- rg -n "from nextcord import .*\bui\b|@ui\.[a-z_]+" src/discordbot tests
- uv run pytest
- uv run pre-commit run -a

Closes #190.