### PR TITLE
feat: group game and maplestory commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,36 +27,36 @@ A self-hosted Discord bot for AI chat, image and video generation, Threads link 
 - **Threads parser**: paste a Threads.net or Threads.com URL and the bot expands the post, media, and reply chain.
 - **Video downloader**: `/download_video` downloads videos from YouTube, TikTok, Instagram, X, Facebook, Bilibili, and other yt-dlp supported sites, with automatic low-quality retry for large files.
 - **Virtual currency and finance**: users earn 虛擬歡樂豆 from messages and AI replies, can check in daily, transfer balances, buy VIP, use long-term personal credit or central-bank loans, issue player stocks, pay dividends, and view leaderboards.
-- **Casino games**: multiplayer `/blackjack` and `/dragon_gate` lobbies with AI dealer banter, public result embeds, and automatic cleanup.
-- **MapleStory Artale database**: `/maple_*` commands search monsters, equipment, scrolls, NPCs, quests, maps, item drops, and database stats.
+- **Casino games**: multiplayer `/games blackjack` and `/games dragon_gate` lobbies with AI dealer banter, public result embeds, and automatic cleanup.
+- **MapleStory Artale database**: `/maplestory` subcommands search monsters, equipment, scrolls, NPCs, quests, maps, item drops, and database stats.
 - **Localized commands**: slash command metadata and `/help` are localized for English, Traditional Chinese, and Japanese. AI replies follow the user's language.
 
 ## Commands
 
-| Command                                           | What it does                                                                                                |
-| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `@bot <message>`                                  | Chat with the AI. Attach supported files or images when you want the bot to inspect them.                   |
-| _Threads URL_                                     | Automatically expands Threads posts and media.                                                              |
-| `/download_video <url> [quality]`                 | Downloads a video and sends it back to Discord.                                                             |
-| `/balance`                                        | Privately shows your 虛擬歡樂豆 balance, debt, stock value, net worth, and VIP status.                      |
-| `/checkin`                                        | Claims the daily check-in reward.                                                                           |
-| `/vip`                                            | Buys permanent VIP perks.                                                                                   |
-| `/leaderboard`                                    | Shows the global top balances.                                                                              |
-| `/loss_leaderboard`                               | Shows today's accumulated casino losses.                                                                    |
-| `/credit status\|borrow\|call\|repay`             | Handles personal credit requests, approval/rejection/cancel buttons, repayment, collection, and status.     |
-| `/central_bank status\|borrow\|call\|repay`       | Handles central-bank loan requests, approval/rejection/cancel buttons, repayment, collection, and capacity. |
-| `/stock issue\|buy\|dividend\|info`               | Issues player stock, buys treasury shares, pays dividends, and shows stock profiles.                        |
-| `/portfolio [member]`                             | Shows wallet, stock holdings, debt, and estimated net worth.                                                |
-| `/give <member> <amount>`                         | Transfers 虛擬歡樂豆 to another member.                                                                     |
-| `/admin refund_tax\|collect_tax`                  | Admin-only manual balance adjustments.                                                                      |
-| `/blackjack <bet>`                                | Opens a multiplayer Blackjack lobby.                                                                        |
-| `/dragon_gate`                                    | Opens a multiplayer 射龍門 table backed by the shared jackpot pool.                                         |
-| `/house`                                          | Shows the Blackjack dealer ledger.                                                                          |
-| `/maple_monster`, `/maple_equip`, `/maple_scroll` | Search MapleStory Artale monsters, equipment, and scrolls.                                                  |
-| `/maple_npc`, `/maple_quest`, `/maple_map`        | Search NPCs, quests, and maps.                                                                              |
-| `/maple_item`, `/maple_stats`                     | Search item drop sources and database stats.                                                                |
-| `/help`                                           | Shows the in-Discord guide.                                                                                 |
-| `/ping`                                           | Checks bot latency.                                                                                         |
+| Command                                                          | What it does                                                                                                |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `@bot <message>`                                                 | Chat with the AI. Attach supported files or images when you want the bot to inspect them.                   |
+| _Threads URL_                                                    | Automatically expands Threads posts and media.                                                              |
+| `/download_video <url> [quality]`                                | Downloads a video and sends it back to Discord.                                                             |
+| `/balance`                                                       | Privately shows your 虛擬歡樂豆 balance, debt, stock value, net worth, and VIP status.                      |
+| `/checkin`                                                       | Claims the daily check-in reward.                                                                           |
+| `/vip`                                                           | Buys permanent VIP perks.                                                                                   |
+| `/leaderboard`                                                   | Shows the global top balances.                                                                              |
+| `/loss_leaderboard`                                              | Shows today's accumulated casino losses.                                                                    |
+| `/credit status\|borrow\|call\|repay`                            | Handles personal credit requests, approval/rejection/cancel buttons, repayment, collection, and status.     |
+| `/central_bank status\|borrow\|call\|repay`                      | Handles central-bank loan requests, approval/rejection/cancel buttons, repayment, collection, and capacity. |
+| `/stock issue\|buy\|dividend\|info`                              | Issues player stock, buys treasury shares, pays dividends, and shows stock profiles.                        |
+| `/portfolio [member]`                                            | Shows wallet, stock holdings, debt, and estimated net worth.                                                |
+| `/give <member> <amount>`                                        | Transfers 虛擬歡樂豆 to another member.                                                                     |
+| `/admin refund_tax\|collect_tax`                                 | Admin-only manual balance adjustments.                                                                      |
+| `/games blackjack <bet>`                                         | Opens a multiplayer Blackjack lobby.                                                                        |
+| `/games dragon_gate`                                             | Opens a multiplayer 射龍門 table backed by the shared jackpot pool.                                         |
+| `/house`                                                         | Shows the Blackjack dealer ledger.                                                                          |
+| `/maplestory monster`, `/maplestory equip`, `/maplestory scroll` | Search MapleStory Artale monsters, equipment, and scrolls.                                                  |
+| `/maplestory npc`, `/maplestory quest`, `/maplestory map`        | Search NPCs, quests, and maps.                                                                              |
+| `/maplestory item`, `/maplestory stats`                          | Search item drop sources and database stats.                                                                |
+| `/help`                                                          | Shows the in-Discord guide.                                                                                 |
+| `/ping`                                                          | Checks bot latency.                                                                                         |
 
 ## Self-Hosting
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,36 +27,36 @@
 - **Threads 解析**：贴上 Threads.net 或 Threads.com URL，机器人会展开贴文、媒体与 reply chain。
 - **视频下载**：`/download_video` 可从 YouTube、TikTok、Instagram、X、Facebook、Bilibili，以及其他 yt-dlp 支持的网站下载视频，文件太大时会自动 retry 低画质。
 - **虚拟欢乐豆与金融系统**：用户可从消息与 AI 回复获得虚拟欢乐豆，可每日签到、转账、购买 VIP、使用长期个人信贷或央行借款、发行玩家股票、配息，并查看排行榜。
-- **赌场游戏**：多人 `/blackjack` 与 `/dragon_gate` lobby，带 AI dealer 对话、公开结果 embed 与自动清理。
-- **MapleStory Artale 数据库**：`/maple_*` 指令可查询怪物、装备、卷轴、NPC、任务、地图、掉落来源与数据库统计。
+- **赌场游戏**：多人 `/games blackjack` 与 `/games dragon_gate` lobby，带 AI dealer 对话、公开结果 embed 与自动清理。
+- **MapleStory Artale 数据库**：`/maplestory` 子命令可查询怪物、装备、卷轴、NPC、任务、地图、掉落来源与数据库统计。
 - **本地化指令**：slash command metadata 与 `/help` 支持英文、繁体中文、日文。AI 回复会跟随用户语言。
 
 ## 指令
 
-| 指令                                              | 功能                                                             |
-| ------------------------------------------------- | ---------------------------------------------------------------- |
-| `@bot <message>`                                  | 和 AI 聊天。需要机器人检查文件或图片时，可附上支持的附件。       |
-| _Threads URL_                                     | 自动展开 Threads 贴文与媒体。                                    |
-| `/download_video <url> [quality]`                 | 下载视频并传回 Discord。                                         |
-| `/balance`                                        | 私密显示你的虚拟欢乐豆余额、债务、股票估值、净资产与 VIP 状态。  |
-| `/checkin`                                        | 领取每日签到奖励。                                               |
-| `/vip`                                            | 购买永久 VIP 权益。                                              |
-| `/leaderboard`                                    | 显示全域余额排行榜。                                             |
-| `/loss_leaderboard`                               | 显示今日赌场输钱累计排行榜。                                     |
-| `/credit status\|borrow\|call\|repay`             | 处理个人信贷申请、按钮批准或拒绝、取消、还款、催收与状态。       |
-| `/central_bank status\|borrow\|call\|repay`       | 处理央行借款申请、按钮批准或拒绝、取消、还款、催收与可放贷额度。 |
-| `/stock issue\|buy\|dividend\|info`               | 发行玩家股票、购买未售出股数、配息与查看股票信息。               |
-| `/portfolio [member]`                             | 查看钱包、持股、债务与预估净资产。                               |
-| `/give <member> <amount>`                         | 转账虚拟欢乐豆给其他成员。                                       |
-| `/admin refund_tax\|collect_tax`                  | admin-only 手动余额调整。                                        |
-| `/blackjack <bet>`                                | 开一个多人 Blackjack lobby。                                     |
-| `/dragon_gate`                                    | 开一个由共享 jackpot pool 支撑的多人射龙门桌。                   |
-| `/house`                                          | 显示 Blackjack dealer ledger。                                   |
-| `/maple_monster`, `/maple_equip`, `/maple_scroll` | 查询 MapleStory Artale 怪物、装备与卷轴。                        |
-| `/maple_npc`, `/maple_quest`, `/maple_map`        | 查询 NPC、任务与地图。                                           |
-| `/maple_item`, `/maple_stats`                     | 查询物品掉落来源与数据库统计。                                   |
-| `/help`                                           | 显示 Discord 内的使用指南。                                      |
-| `/ping`                                           | 检查 bot latency。                                               |
+| 指令                                                             | 功能                                                             |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `@bot <message>`                                                 | 和 AI 聊天。需要机器人检查文件或图片时，可附上支持的附件。       |
+| _Threads URL_                                                    | 自动展开 Threads 贴文与媒体。                                    |
+| `/download_video <url> [quality]`                                | 下载视频并传回 Discord。                                         |
+| `/balance`                                                       | 私密显示你的虚拟欢乐豆余额、债务、股票估值、净资产与 VIP 状态。  |
+| `/checkin`                                                       | 领取每日签到奖励。                                               |
+| `/vip`                                                           | 购买永久 VIP 权益。                                              |
+| `/leaderboard`                                                   | 显示全域余额排行榜。                                             |
+| `/loss_leaderboard`                                              | 显示今日赌场输钱累计排行榜。                                     |
+| `/credit status\|borrow\|call\|repay`                            | 处理个人信贷申请、按钮批准或拒绝、取消、还款、催收与状态。       |
+| `/central_bank status\|borrow\|call\|repay`                      | 处理央行借款申请、按钮批准或拒绝、取消、还款、催收与可放贷额度。 |
+| `/stock issue\|buy\|dividend\|info`                              | 发行玩家股票、购买未售出股数、配息与查看股票信息。               |
+| `/portfolio [member]`                                            | 查看钱包、持股、债务与预估净资产。                               |
+| `/give <member> <amount>`                                        | 转账虚拟欢乐豆给其他成员。                                       |
+| `/admin refund_tax\|collect_tax`                                 | admin-only 手动余额调整。                                        |
+| `/games blackjack <bet>`                                         | 开一个多人 Blackjack lobby。                                     |
+| `/games dragon_gate`                                             | 开一个由共享 jackpot pool 支撑的多人射龙门桌。                   |
+| `/house`                                                         | 显示 Blackjack dealer ledger。                                   |
+| `/maplestory monster`, `/maplestory equip`, `/maplestory scroll` | 查询 MapleStory Artale 怪物、装备与卷轴。                        |
+| `/maplestory npc`, `/maplestory quest`, `/maplestory map`        | 查询 NPC、任务与地图。                                           |
+| `/maplestory item`, `/maplestory stats`                          | 查询物品掉落来源与数据库统计。                                   |
+| `/help`                                                          | 显示 Discord 内的使用指南。                                      |
+| `/ping`                                                          | 检查 bot latency。                                               |
 
 ## 自托管
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -27,36 +27,36 @@
 - **Threads 解析**：貼上 Threads.net 或 Threads.com URL，bot 會展開貼文、media 與 reply chain。
 - **影片下載**：`/download_video` 可從 YouTube、TikTok、Instagram、X、Facebook、Bilibili，以及其他 yt-dlp 支援的網站下載影片，檔案太大時會自動 retry 低畫質。
 - **虛擬歡樂豆與金融系統**：使用者可從訊息與 AI 回覆獲得虛擬歡樂豆，可每日簽到、轉帳、購買 VIP、使用長期個人信貸或央行借款、發行玩家股票、配息，並查看排行榜。
-- **賭場遊戲**：多人 `/blackjack` 與 `/dragon_gate` lobby，帶 AI dealer 對話、公開結果 embed 與自動清理。
-- **MapleStory Artale 資料庫**：`/maple_*` 指令可查詢怪物、裝備、卷軸、NPC、任務、地圖、掉落來源與資料庫統計。
+- **賭場遊戲**：多人 `/games blackjack` 與 `/games dragon_gate` lobby，帶 AI dealer 對話、公開結果 embed 與自動清理。
+- **MapleStory Artale 資料庫**：`/maplestory` 子命令可查詢怪物、裝備、卷軸、NPC、任務、地圖、掉落來源與資料庫統計。
 - **本地化指令**：slash command metadata 與 `/help` 支援英文、繁體中文、日文。AI 回覆會跟隨使用者語言。
 
 ## 指令
 
-| 指令                                              | 功能                                                             |
-| ------------------------------------------------- | ---------------------------------------------------------------- |
-| `@bot <message>`                                  | 和 AI chat。需要 bot 檢查檔案或圖片時，可附上支援的附件。        |
-| _Threads URL_                                     | 自動展開 Threads 貼文與 media。                                  |
-| `/download_video <url> [quality]`                 | 下載影片並傳回 Discord。                                         |
-| `/balance`                                        | 私密顯示你的虛擬歡樂豆餘額、債務、股票估值、淨資產與 VIP 狀態。  |
-| `/checkin`                                        | 領取每日簽到獎勵。                                               |
-| `/vip`                                            | 購買永久 VIP 權益。                                              |
-| `/leaderboard`                                    | 顯示全域餘額排行榜。                                             |
-| `/loss_leaderboard`                               | 顯示今日賭場輸局累計排行榜。                                     |
-| `/credit status\|borrow\|call\|repay`             | 處理個人信貸申請、按鈕批准或拒絕、取消、還款、催收與狀態。       |
-| `/central_bank status\|borrow\|call\|repay`       | 處理央行借款申請、按鈕批准或拒絕、取消、還款、催收與可放貸額度。 |
-| `/stock issue\|buy\|dividend\|info`               | 發行玩家股票、購買未售出股數、配息與查看股票資訊。               |
-| `/portfolio [member]`                             | 查看錢包、持股、債務與預估淨資產。                               |
-| `/give <member> <amount>`                         | 轉帳虛擬歡樂豆給其他成員。                                       |
-| `/admin refund_tax\|collect_tax`                  | admin-only 手動餘額調整。                                        |
-| `/blackjack <bet>`                                | 開一個多人 Blackjack lobby。                                     |
-| `/dragon_gate`                                    | 開一個由共享 jackpot pool 支撐的多人射龍門桌。                   |
-| `/house`                                          | 顯示 Blackjack dealer ledger。                                   |
-| `/maple_monster`, `/maple_equip`, `/maple_scroll` | 查詢 MapleStory Artale 怪物、裝備與卷軸。                        |
-| `/maple_npc`, `/maple_quest`, `/maple_map`        | 查詢 NPC、任務與地圖。                                           |
-| `/maple_item`, `/maple_stats`                     | 查詢物品掉落來源與資料庫統計。                                   |
-| `/help`                                           | 顯示 Discord 內的使用指南。                                      |
-| `/ping`                                           | 檢查 bot latency。                                               |
+| 指令                                                             | 功能                                                             |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `@bot <message>`                                                 | 和 AI chat。需要 bot 檢查檔案或圖片時，可附上支援的附件。        |
+| _Threads URL_                                                    | 自動展開 Threads 貼文與 media。                                  |
+| `/download_video <url> [quality]`                                | 下載影片並傳回 Discord。                                         |
+| `/balance`                                                       | 私密顯示你的虛擬歡樂豆餘額、債務、股票估值、淨資產與 VIP 狀態。  |
+| `/checkin`                                                       | 領取每日簽到獎勵。                                               |
+| `/vip`                                                           | 購買永久 VIP 權益。                                              |
+| `/leaderboard`                                                   | 顯示全域餘額排行榜。                                             |
+| `/loss_leaderboard`                                              | 顯示今日賭場輸局累計排行榜。                                     |
+| `/credit status\|borrow\|call\|repay`                            | 處理個人信貸申請、按鈕批准或拒絕、取消、還款、催收與狀態。       |
+| `/central_bank status\|borrow\|call\|repay`                      | 處理央行借款申請、按鈕批准或拒絕、取消、還款、催收與可放貸額度。 |
+| `/stock issue\|buy\|dividend\|info`                              | 發行玩家股票、購買未售出股數、配息與查看股票資訊。               |
+| `/portfolio [member]`                                            | 查看錢包、持股、債務與預估淨資產。                               |
+| `/give <member> <amount>`                                        | 轉帳虛擬歡樂豆給其他成員。                                       |
+| `/admin refund_tax\|collect_tax`                                 | admin-only 手動餘額調整。                                        |
+| `/games blackjack <bet>`                                         | 開一個多人 Blackjack lobby。                                     |
+| `/games dragon_gate`                                             | 開一個由共享 jackpot pool 支撐的多人射龍門桌。                   |
+| `/house`                                                         | 顯示 Blackjack dealer ledger。                                   |
+| `/maplestory monster`, `/maplestory equip`, `/maplestory scroll` | 查詢 MapleStory Artale 怪物、裝備與卷軸。                        |
+| `/maplestory npc`, `/maplestory quest`, `/maplestory map`        | 查詢 NPC、任務與地圖。                                           |
+| `/maplestory item`, `/maplestory stats`                          | 查詢物品掉落來源與資料庫統計。                                   |
+| `/help`                                                          | 顯示 Discord 內的使用指南。                                      |
+| `/ping`                                                          | 檢查 bot latency。                                               |
 
 ## 自架
 

--- a/src/discordbot/cogs/_maplestory/embeds.py
+++ b/src/discordbot/cogs/_maplestory/embeds.py
@@ -553,5 +553,5 @@ def build_stats_embed(stats: MapleStats) -> Embed:
         popular_text = "\n".join(f"• {item}" for item in stats.popular_items[:15])
         embed.add_field(name="\U0001f525 熱門掉落物品", value=popular_text, inline=False)
 
-    embed.set_footer(text="資料來源：Artale | 使用 /maple_monster 或 /maple_item 搜尋")
+    embed.set_footer(text="資料來源：Artale | 使用 /maplestory monster 或 /maplestory item 搜尋")
     return embed

--- a/src/discordbot/cogs/_maplestory/models.py
+++ b/src/discordbot/cogs/_maplestory/models.py
@@ -735,7 +735,7 @@ class MiscItem(_Base):
         return self.name_zh or self.name
 
 
-# ── Stats (for /maple_stats command) ────────────────────────────────
+# ── Stats (for /maplestory stats command) ───────────────────────────
 
 
 class MapleStats(BaseModel):

--- a/src/discordbot/cogs/economy.py
+++ b/src/discordbot/cogs/economy.py
@@ -719,7 +719,7 @@ class EconomyCogs(commands.Cog):
         if not rows:
             embed = Embed(
                 title=f"🏆 {CURRENCY_NAME} Top 10",
-                description="### 尚未開張\n/blackjack 或 /dragon_gate 開局就會上榜",
+                description="### 尚未開張\n/games blackjack 或 /games dragon_gate 開局就會上榜",
                 color=_LEADERBOARD_COLOR,
             )
             await _send_expiring_followup(interaction=interaction, embed=embed)
@@ -764,7 +764,7 @@ class EconomyCogs(commands.Cog):
         if not rows:
             embed = Embed(
                 title=f"💸 今日輸局累計 {CURRENCY_NAME}",
-                description="### 今天還沒有人輸錢\n/blackjack 或 /dragon_gate 開局就可能進榜",
+                description="### 今天還沒有人輸錢\n/games blackjack 或 /games dragon_gate 開局就可能進榜",
                 color=_LOSS_LEADERBOARD_COLOR,
             )
             await _send_expiring_followup(interaction=interaction, embed=embed)

--- a/src/discordbot/cogs/games.py
+++ b/src/discordbot/cogs/games.py
@@ -1,4 +1,4 @@
-"""Casino-style games (`/blackjack`, `/dragon_gate`) wagering economy points."""
+"""Casino-style games (`/games blackjack`, `/games dragon_gate`) wagering economy points."""
 
 from random import SystemRandom
 from functools import partial, cached_property
@@ -216,6 +216,16 @@ class GamesCogs(commands.Cog):
         )
 
     @nextcord.slash_command(
+        name="games",
+        description="Game commands.",
+        name_localizations={Locale.zh_TW: "小遊戲", Locale.ja: "ゲーム"},
+        description_localizations={Locale.zh_TW: "小遊戲指令", Locale.ja: "ゲームコマンド。"},
+        nsfw=False,
+    )
+    async def games(self, interaction: Interaction) -> None:
+        """Slash command group for casino games."""
+
+    @games.subcommand(
         name="blackjack",
         description="Open a 21 lobby against the dealer.",
         name_localizations={Locale.zh_TW: "二十一點", Locale.ja: "ブラックジャック"},
@@ -223,7 +233,6 @@ class GamesCogs(commands.Cog):
             Locale.zh_TW: "開一桌 21 點 lobby",
             Locale.ja: "21（ブラックジャック）の lobby を開きます。",
         },
-        nsfw=False,
     )
     async def blackjack(
         self,
@@ -295,7 +304,7 @@ class GamesCogs(commands.Cog):
         await track_game_message(message=message, user_name=owner.account_name)
         view.message = message
 
-    @nextcord.slash_command(
+    @games.subcommand(
         name="dragon_gate",
         description="Open an In-Between table with a shared jackpot pool.",
         name_localizations={Locale.zh_TW: "射龍門", Locale.ja: "インビトウィーン"},
@@ -303,7 +312,6 @@ class GamesCogs(commands.Cog):
             Locale.zh_TW: "開一桌共享全域彩金池的射龍門",
             Locale.ja: "共有ジャックポットのインビトウィーン table を開きます。",
         },
-        nsfw=False,
     )
     async def dragon_gate(self, interaction: Interaction) -> None:
         """Opens a 射龍門 lobby. The owner starts the table from the lobby.

--- a/src/discordbot/cogs/help.py
+++ b/src/discordbot/cogs/help.py
@@ -38,11 +38,11 @@ _HELP_CONTENT = {
             "Use the optional quality setting; oversized files retry once at low quality."
         ),
         "maplestory": (
-            "**MapleStory Artale** — `/maple_*`\n"
+            "**MapleStory Artale** — `/maplestory`\n"
             "Search game data:\n"
-            "`/maple_monster` · `/maple_equip` · `/maple_scroll` · "
-            "`/maple_npc` · `/maple_quest` · `/maple_map` · "
-            "`/maple_item` · `/maple_stats`"
+            "`/maplestory monster` · `/maplestory equip` · `/maplestory scroll` · "
+            "`/maplestory npc` · `/maplestory quest` · `/maplestory map` · "
+            "`/maplestory item` · `/maplestory stats`"
         ),
         "points": (
             f"**{CURRENCY_NAME}**\n"
@@ -75,8 +75,8 @@ _HELP_CONTENT = {
             "VIP-boosted number; Blackjack final results show the VIP bonus when it applies."
         ),
         "games": (
-            "**Games**\n"
-            "`/blackjack` opens a 21 lobby. Other players can join before the owner starts, "
+            "**Games** — `/games`\n"
+            "`/games blackjack` opens a 21 lobby. Other players can join before the owner starts, "
             "single-player starts are still allowed, the table stake follows the owner's "
             "effective wager, and idle hands auto-stand after 180 seconds.\n"
             "Player actions: **Hit / Stand / Double Down / Split / Surrender**. Double doubles "
@@ -98,7 +98,7 @@ _HELP_CONTENT = {
             "After every hand stands / busts, the dealer hits on 16 or below; at 17+ "
             "the AI dealer decides hit / stand, and the final embed labels automatic draws "
             "and AI decisions in the dealer action path.\n"
-            "`/dragon_gate` opens an In-Between table over a **global jackpot pool** "
+            "`/games dragon_gate` opens an In-Between table over a **global jackpot pool** "
             "shared across every table. The ante is fixed at 5,000 (into the pool), the "
             "minimum bet is 10,000, the maximum bet is the entire pool, and every bet "
             "settles into the player row and the pool the instant it lands. Adjacent "
@@ -138,11 +138,11 @@ _HELP_CONTENT = {
             "可以選 quality；檔案太大時會自動 retry 一次低畫質"
         ),
         "maplestory": (
-            "**MapleStory Artale** — `/maple_*`\n"
+            "**MapleStory Artale** — `/maplestory`（`/楓之谷`）\n"
             "查詢遊戲資料：\n"
-            "`/maple_monster` · `/maple_equip` · `/maple_scroll` · "
-            "`/maple_npc` · `/maple_quest` · `/maple_map` · "
-            "`/maple_item` · `/maple_stats`"
+            "`/maplestory monster` 怪物 · `/maplestory equip` 裝備 · `/maplestory scroll` 卷軸 · "
+            "`/maplestory npc` · `/maplestory quest` 任務 · `/maplestory map` 地圖 · "
+            "`/maplestory item` 物品 · `/maplestory stats` 統計"
         ),
         "points": (
             f"**{CURRENCY_NAME}**\n"
@@ -171,8 +171,8 @@ _HELP_CONTENT = {
             "Blackjack final result 也會在套用時顯示 VIP加成"
         ),
         "games": (
-            "**小遊戲**\n"
-            "`/blackjack` 會開一個 21 點 lobby，其他玩家可以先加入，只有房主能開始，"
+            "**小遊戲** — `/games`（`/小遊戲`）\n"
+            "`/games blackjack` 會開一個 21 點 lobby，其他玩家可以先加入，只有房主能開始，"
             "單人也可以直接開始，房主超過餘額的 bet 會用實際餘額當 table stake，"
             "後續玩家預設跟這個金額，"
             "不操作 180 秒會自動 stand\n"
@@ -192,7 +192,7 @@ _HELP_CONTENT = {
             "或 peek 確認 Blackjack 時攤開\n"
             "所有玩家結束後莊家 16 點以下固定 hit；17 點以上交給 AI 莊家決定 hit / stand；"
             "final result 的 dealer action path 會標出自動抽牌與 AI 決定\n"
-            "`/dragon_gate` 開一桌射龍門, 共用一個**全域累計彩金池**, 所有桌都看到同一池"
+            "`/games dragon_gate` 開一桌射龍門, 共用一個**全域累計彩金池**, 所有桌都看到同一池"
             "入場費固定 5,000 點(進彩金池), 最低下注 10,000, 上限就是當下彩金池\n"
             "每次下注後玩家餘額與彩金池同步即時結算, 不再等桌結束\n"
             "輸錢最多只會扣到餘額 0, 歸零玩家會自動離桌, 其他玩家繼續玩\n"
@@ -231,11 +231,11 @@ _HELP_CONTENT = {
             "quality を選択でき、ファイルが大きすぎる場合は一度 low quality で retry します。"
         ),
         "maplestory": (
-            "**MapleStory Artale** — `/maple_*`\n"
+            "**MapleStory Artale** — `/maplestory`\n"
             "ゲームデータ検索：\n"
-            "`/maple_monster` · `/maple_equip` · `/maple_scroll` · "
-            "`/maple_npc` · `/maple_quest` · `/maple_map` · "
-            "`/maple_item` · `/maple_stats`"
+            "`/maplestory monster` · `/maplestory equip` · `/maplestory scroll` · "
+            "`/maplestory npc` · `/maplestory quest` · `/maplestory map` · "
+            "`/maplestory item` · `/maplestory stats`"
         ),
         "points": (
             f"**{CURRENCY_NAME}**\n"
@@ -265,8 +265,8 @@ _HELP_CONTENT = {
             "Blackjack final result も適用時に VIP bonus を表示します。"
         ),
         "games": (
-            "**ゲーム**\n"
-            "`/blackjack` 21の lobby を開きます。他のプレイヤーは owner が開始する前に参加でき、"
+            "**ゲーム** — `/games`\n"
+            "`/games blackjack` 21の lobby を開きます。他のプレイヤーは owner が開始する前に参加でき、"
             "1人でも開始できます。owner の有効ベットが table stake になり、"
             "参加者はその金額を既定で賭けます。"
             "180秒操作がない場合は自動 stand。\n"
@@ -288,7 +288,7 @@ _HELP_CONTENT = {
             "final settlement または peek で Blackjack 確認時だけ reveal されます。\n"
             "全 action 後、dealer は 16 以下で hit、17 以上は AI dealer が hit / stand を決め、"
             "final result の dealer action path は自動 draw と AI decision を区別して表示します。\n"
-            "`/dragon_gate` は全 table で共有する**グローバルジャックポット**を巡る "
+            "`/games dragon_gate` は全 table で共有する**グローバルジャックポット**を巡る "
             "In-Between table を開きます。anteは固定 5,000 (pool へ)、最低 bet は 10,000、"
             "上限は pool の全額、各 bet は player 残高と pool に即時反映されます。\n"
             "loss は残高 0 までに clamp され、0 になった player は自動で退場します。"

--- a/src/discordbot/cogs/maplestory.py
+++ b/src/discordbot/cogs/maplestory.py
@@ -65,12 +65,24 @@ class MapleStoryCogs(commands.Cog):
         )
         await interaction.followup.send(embed=embed)
 
-    # ── /maple_monster ──────────────────────────────────────────────
-
     @nextcord.slash_command(
-        name="maple_monster",
+        name="maplestory",
+        description="Search MapleStory Artale data.",
+        name_localizations={Locale.zh_TW: "楓之谷", Locale.ja: "メイプル"},
+        description_localizations={
+            Locale.zh_TW: "搜尋楓之谷 Artale 資料",
+            Locale.ja: "メイプルストーリー Artale データを検索します。",
+        },
+    )
+    async def maplestory(self, interaction: Interaction) -> None:
+        """Slash command group for MapleStory Artale data queries."""
+
+    # ── /maplestory monster ─────────────────────────────────────────
+
+    @maplestory.subcommand(
+        name="monster",
         description="Search for monster information in MapleStory",
-        name_localizations={Locale.zh_TW: "楓之谷怪物", Locale.ja: "メイプルモンスター"},
+        name_localizations={Locale.zh_TW: "怪物", Locale.ja: "モンスター"},
         description_localizations={
             Locale.zh_TW: "搜尋楓之谷怪物資訊",
             Locale.ja: "メイプルストーリーのモンスター情報を検索",
@@ -121,12 +133,12 @@ class MapleStoryCogs(commands.Cog):
         await interaction.followup.send(embed=embed, view=view)
         return None
 
-    # ── /maple_equip ────────────────────────────────────────────────
+    # ── /maplestory equip ───────────────────────────────────────────
 
-    @nextcord.slash_command(
-        name="maple_equip",
+    @maplestory.subcommand(
+        name="equip",
         description="Search for equipment in MapleStory",
-        name_localizations={Locale.zh_TW: "楓之谷裝備", Locale.ja: "メイプル装備"},
+        name_localizations={Locale.zh_TW: "裝備", Locale.ja: "装備"},
         description_localizations={
             Locale.zh_TW: "搜尋楓之谷裝備資訊",
             Locale.ja: "メイプルストーリーの装備情報を検索",
@@ -181,14 +193,14 @@ class MapleStoryCogs(commands.Cog):
         await interaction.followup.send(embed=embed, view=view)
         return None
 
-    # ── /maple_scroll ───────────────────────────────────────────────
+    # ── /maplestory scroll ──────────────────────────────────────────
 
-    @nextcord.slash_command(
-        name="maple_scroll",
+    @maplestory.subcommand(
+        name="scroll",
         description="Search for scrolls in MapleStory",
-        name_localizations={Locale.zh_TW: "楓之谷捲軸", Locale.ja: "メイプル巻物"},
+        name_localizations={Locale.zh_TW: "卷軸", Locale.ja: "巻物"},
         description_localizations={
-            Locale.zh_TW: "搜尋楓之谷捲軸資訊",
+            Locale.zh_TW: "搜尋楓之谷卷軸資訊",
             Locale.ja: "メイプルストーリーの巻物情報を検索",
         },
     )
@@ -241,12 +253,12 @@ class MapleStoryCogs(commands.Cog):
         await interaction.followup.send(embed=embed, view=view)
         return None
 
-    # ── /maple_npc ──────────────────────────────────────────────────
+    # ── /maplestory npc ─────────────────────────────────────────────
 
-    @nextcord.slash_command(
-        name="maple_npc",
+    @maplestory.subcommand(
+        name="npc",
         description="Search for NPCs in MapleStory",
-        name_localizations={Locale.zh_TW: "楓之谷npc", Locale.ja: "メイプルnpc"},
+        name_localizations={Locale.zh_TW: "npc", Locale.ja: "npc"},
         description_localizations={
             Locale.zh_TW: "搜尋楓之谷 NPC 資訊",
             Locale.ja: "メイプルストーリーのNPC情報を検索",
@@ -296,12 +308,12 @@ class MapleStoryCogs(commands.Cog):
         await interaction.followup.send(embed=embed, view=view)
         return None
 
-    # ── /maple_quest ────────────────────────────────────────────────
+    # ── /maplestory quest ───────────────────────────────────────────
 
-    @nextcord.slash_command(
-        name="maple_quest",
+    @maplestory.subcommand(
+        name="quest",
         description="Search for quests in MapleStory",
-        name_localizations={Locale.zh_TW: "楓之谷任務", Locale.ja: "メイプルクエスト"},
+        name_localizations={Locale.zh_TW: "任務", Locale.ja: "クエスト"},
         description_localizations={
             Locale.zh_TW: "搜尋楓之谷任務資訊",
             Locale.ja: "メイプルストーリーのクエスト情報を検索",
@@ -354,12 +366,12 @@ class MapleStoryCogs(commands.Cog):
         await interaction.followup.send(embed=embed, view=view)
         return None
 
-    # ── /maple_map ──────────────────────────────────────────────────
+    # ── /maplestory map ─────────────────────────────────────────────
 
-    @nextcord.slash_command(
-        name="maple_map",
+    @maplestory.subcommand(
+        name="map",
         description="Search for maps in MapleStory",
-        name_localizations={Locale.zh_TW: "楓之谷地圖", Locale.ja: "メイプルマップ"},
+        name_localizations={Locale.zh_TW: "地圖", Locale.ja: "マップ"},
         description_localizations={
             Locale.zh_TW: "搜尋楓之谷地圖資訊",
             Locale.ja: "メイプルストーリーのマップ情報を検索",
@@ -414,12 +426,12 @@ class MapleStoryCogs(commands.Cog):
         await interaction.followup.send(embed=embed, view=view)
         return None
 
-    # ── /maple_item ─────────────────────────────────────────────────
+    # ── /maplestory item ────────────────────────────────────────────
 
-    @nextcord.slash_command(
-        name="maple_item",
+    @maplestory.subcommand(
+        name="item",
         description="Search for item drop sources in MapleStory",
-        name_localizations={Locale.zh_TW: "楓之谷物品", Locale.ja: "メイプルアイテム"},
+        name_localizations={Locale.zh_TW: "物品", Locale.ja: "アイテム"},
         description_localizations={
             Locale.zh_TW: "搜尋楓之谷物品的掉落來源",
             Locale.ja: "メイプルストーリーのアイテムドロップ元を検索",
@@ -480,12 +492,12 @@ class MapleStoryCogs(commands.Cog):
         await interaction.followup.send(embed=embed, view=view)
         return None
 
-    # ── /maple_stats ────────────────────────────────────────────────
+    # ── /maplestory stats ───────────────────────────────────────────
 
-    @nextcord.slash_command(
-        name="maple_stats",
+    @maplestory.subcommand(
+        name="stats",
         description="Get MapleStory database statistics",
-        name_localizations={Locale.zh_TW: "楓之谷統計", Locale.ja: "メイプル統計"},
+        name_localizations={Locale.zh_TW: "統計", Locale.ja: "統計"},
         description_localizations={
             Locale.zh_TW: "顯示楓之谷資料庫統計資訊",
             Locale.ja: "メイプルストーリーデータベース統計を表示",

--- a/tests/test_blackjack.py
+++ b/tests/test_blackjack.py
@@ -1,4 +1,4 @@
-"""Tests for the /blackjack pure-rules module."""
+"""Tests for the Blackjack pure-rules module."""
 
 # ruff: noqa: S311 -- seeded Random() in tests is for determinism, not cryptography
 

--- a/tests/test_cogs_smoke.py
+++ b/tests/test_cogs_smoke.py
@@ -1276,6 +1276,17 @@ class FakeDealer:
         return "settled"
 
 
+def test_games_commands_are_grouped_under_games() -> None:
+    """Verifies casino games are registered as /games subcommands."""
+    assert GamesCogs.games.name == "games"
+    assert GamesCogs.games.name_localizations[nextcord.Locale.zh_TW] == "小遊戲"
+    assert set(GamesCogs.games.children) == {"blackjack", "dragon_gate"}
+    assert GamesCogs.blackjack.name == "blackjack"
+    assert GamesCogs.blackjack.name_localizations[nextcord.Locale.zh_TW] == "二十一點"
+    assert GamesCogs.dragon_gate.name == "dragon_gate"
+    assert GamesCogs.dragon_gate.name_localizations[nextcord.Locale.zh_TW] == "射龍門"
+
+
 async def test_games_commands_run_with_patched_settlement(monkeypatch: pytest.MonkeyPatch) -> None:
     """Verifies game commands create lobby views with patched dependencies."""
     monkeypatch.setenv(name="OPENAI_BASE_URL", value="https://example.test/v1")

--- a/tests/test_maplestory.py
+++ b/tests/test_maplestory.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING, Unpack, TypedDict
 
 import pytest
-from nextcord import Embed, SelectOption
+from nextcord import Embed, Locale, SelectOption
 
 from discordbot.cogs import maplestory
 from discordbot.cogs.maplestory import MapleStoryCogs
@@ -604,6 +604,30 @@ async def test_maplestory_view_select_result_handles_loading_and_valid_choice(
 def maple_cog(maple_data_dir: Path) -> MapleStoryCogs:
     """Returns a MapleStory cog backed by the generated fixture data."""
     return MapleStoryCogs(bot=SimpleNamespace(), data_dir=maple_data_dir)
+
+
+def test_maplestory_commands_are_grouped_under_maplestory() -> None:
+    """Verifies MapleStory lookups are registered as /maplestory subcommands."""
+    assert MapleStoryCogs.maplestory.name == "maplestory"
+    assert MapleStoryCogs.maplestory.name_localizations[Locale.zh_TW] == "楓之谷"
+    assert set(MapleStoryCogs.maplestory.children) == {
+        "equip",
+        "item",
+        "map",
+        "monster",
+        "npc",
+        "quest",
+        "scroll",
+        "stats",
+    }
+    assert MapleStoryCogs.maple_quest.name_localizations[Locale.zh_TW] == "任務"
+    assert MapleStoryCogs.maple_map.name_localizations[Locale.zh_TW] == "地圖"
+    assert MapleStoryCogs.maple_monster.name_localizations[Locale.zh_TW] == "怪物"
+    assert MapleStoryCogs.maple_item.name_localizations[Locale.zh_TW] == "物品"
+    assert MapleStoryCogs.maple_scroll.name_localizations[Locale.zh_TW] == "卷軸"
+    assert MapleStoryCogs.maple_stats.name_localizations[Locale.zh_TW] == "統計"
+    assert MapleStoryCogs.maple_equip.name_localizations[Locale.zh_TW] == "裝備"
+    assert MapleStoryCogs.maple_npc.name_localizations[Locale.zh_TW] == "npc"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Group Blackjack and Dragon Gate under /games subcommands with zh-TW localizations.
- Group MapleStory lookups under /maplestory subcommands with zh-TW localizations.
- Update help, runtime command references, tests, and README command tables.

## Tests
- uv run pre-commit run -a
- uv run pytest