### PR TITLE
fix: improve stock market settlement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,15 +79,17 @@ make gen-docs                    # regenerate docs/ from sources
 - Simulated stock state lives in `data/stock.db`; wallet cash remains in economy `user_wallet`. Do not store wallet balances in stock tables.
 - `/stock` sends one public market message. Stock selection, balance, positions, actions, news, validation, settlement, position summaries, recent trade history, and the 7D chart all edit that same public message. Only the user who opened the stock message can operate its controls. The active stock view deletes its message after 180 idle seconds.
 - `stock_profile` is the source of truth for virtual company symbols, names, categories, prices, liquidity, volatility, fair value, mean reversion, tick caps, and news cadence. Do not hardcode company rows or seed companies from runtime code; use `uv run python scripts/manage_stock_company.py ...` or direct DB maintenance while the bot is stopped. Add stock schema migrations when changing persisted profile or news columns.
+- Stock settlement uses `float_shares` as the cap for aggregate long exposure and aggregate short borrow capacity. Selling long or covering short is always allowed as risk-reducing flow; opening new long or new short clamps to the remaining DB-managed supply.
 - `stock_news` refreshes at most once per `news_cadence_hours` per symbol. `StockNewsAI` may use the existing `AsyncOpenAI` Responses API stack when LLM config is available, but database helpers must always have deterministic fallback news and must not block settlement on LLM failure.
 - Stock news AI prompts and fallback copy templates live in `src/discordbot/cogs/_stock/prompts.py`; keep generated news fictional, absurd, and harmless.
 - For Discord UI that needs precise layout beyond embed and Markdown limits, render a PNG with Pillow, attach it with `File`, then reference it from the embed via `attachment://...`. Use a CJK-capable font such as Noto Sans CJK for Traditional Chinese, and keep source data typed so the image renderer stays presentation-only.
 - Market pressure uses decayed order flow and per-stock liquidity. Do not reintroduce a multi-day aggregate pressure term that applies the same directional drift on every tick.
+- Execution price uses order-size slippage from `liquidity_shares`, capped by `max_tick_change_bps`. Store and display the per-leg execution `price_cents`; do not settle large orders at the quote price.
 - Stock tables that persist `user_id` also persist `user_name`. Public stock UI should display stored names instead of Discord IDs.
 - Stock settlement must go through `settle_stock_operation(...)`. Views must not split price reads, wallet reads, and position writes or import SQLAlchemy stock models directly.
 - Stock money uses `price_cents: int`; wallet deltas stay integer `CURRENCY_NAME`. Use `cash_ceil(...)` and `cash_floor(...)` for conversion.
 - Compound stock operations write one `stock_operation` and ordered `stock_trade_leg` rows. Do not net wallet legs before applying them through the public ordered economy helper.
-- Use `uv run python scripts/manage_stock_reconciliation.py list` to inspect non-final stock operations before manual repair.
+- Use `uv run python scripts/manage_stock_reconciliation.py list` to inspect non-final stock operations before manual repair. Use `uv run python scripts/manage_stock_company.py audit` to inspect float supply, aggregate exposure, and remaining long / short capacity.
 - Lazy market ticks advance on interaction. Long backlogs compress to at most `MAX_TICKS_PER_INTERACTION` ticks and still roll over Asia/Taipei day boundaries.
 
 ## Games

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A self-hosted Discord bot for AI chat, image and video generation, Threads link 
 - **Threads parser**: paste a Threads.net or Threads.com URL and the bot expands the post, media, and reply chain.
 - **Video downloader**: `/download_video` downloads videos from YouTube, TikTok, Instagram, X, Facebook, Bilibili, and other yt-dlp supported sites, with automatic low-quality retry for large files.
 - **Virtual currency and finance**: users earn 虛擬歡樂豆 from messages and AI replies, can check in daily, transfer balances, buy VIP, use long-term personal credit or central-bank loans, and view leaderboards.
-- **Simulated stock market**: `/stock` opens one public market message with DB-managed virtual companies; selecting a stock, trading, position summaries, recent trades, periodically refreshed news, and the 7D chart all update that same public message. Only the opener can operate its controls.
+- **Simulated stock market**: `/stock` opens one public market message with DB-managed virtual companies; selecting a stock, trading with float-supply and borrow caps, position summaries, recent trades, liquidity-based slippage, periodically refreshed news, and the 7D chart all update that same public message. Only the opener can operate its controls.
 - **Casino games**: multiplayer `/games blackjack` and `/games dragon_gate` lobbies with AI dealer banter, public result embeds, and automatic cleanup.
 - **MapleStory Artale database**: `/maplestory` subcommands search monsters, equipment, scrolls, NPCs, quests, maps, item drops, and database stats.
 - **Localized commands**: slash command metadata and `/help` are localized for English, Traditional Chinese, and Japanese. AI replies follow the user's language.
@@ -115,7 +115,7 @@ This bot stores runtime data locally under `data/`.
 
 - `messages.db`: human messages and this bot's replies, used for chat history and summaries.
 - `economy.db`: `user_wallet` spendable balances and gross totals, `user_account` cached Discord account names / avatar URLs plus VIP, admin, central banker, check-in, and leaderboard flags, long-term loan requests / contracts, and casino daily counters.
-- `stock.db`: DB-managed simulated stock profiles, price ticks, positions, trade operations, ordered trade legs, and AI-or-fallback stock news.
+- `stock.db`: DB-managed simulated stock profiles, float supply, price ticks, positions, trade operations, ordered trade legs, and AI-or-fallback stock news.
 - `global_state.db`: bot-wide shared state such as jackpot pools.
 - `game_cleanup.db`: Discord guild/channel names, user names, channel IDs, and message IDs for public expiring responses such as game, economy, and stock messages that should be cleaned up after restart.
 - `model_prices.json`: cached LiteLLM pricing metadata used for AI reply cost estimates.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,7 +27,7 @@
 - **Threads 解析**：贴上 Threads.net 或 Threads.com URL，机器人会展开贴文、媒体与 reply chain。
 - **视频下载**：`/download_video` 可从 YouTube、TikTok、Instagram、X、Facebook、Bilibili，以及其他 yt-dlp 支持的网站下载视频，文件太大时会自动 retry 低画质。
 - **虚拟欢乐豆与金融系统**：用户可从消息与 AI 回复获得虚拟欢乐豆，可每日签到、转账、购买 VIP、使用长期个人信贷或央行借款，并查看排行榜。
-- **模拟股市**：`/stock` 开启一则公开 market message，内含 DB-managed virtual companies；选股、交易、仓位摘要、近期交易记录、定期刷新新闻与 7 日图表都在同一则公开 message 内 edit 切换，只有发起 `/stock` 的 user 可以操作 controls。
+- **模拟股市**：`/stock` 开启一则公开 market message，内含 DB-managed virtual companies；选股、受 float supply 与 borrow cap 限制的交易、仓位摘要、近期交易记录、liquidity-based slippage、定期刷新新闻与 7 日图表都在同一则公开 message 内 edit 切换，只有发起 `/stock` 的 user 可以操作 controls。
 - **赌场游戏**：多人 `/games blackjack` 与 `/games dragon_gate` lobby，带 AI dealer 对话、公开结果 embed 与自动清理。
 - **MapleStory Artale 数据库**：`/maplestory` 子命令可查询怪物、装备、卷轴、NPC、任务、地图、掉落来源与数据库统计。
 - **本地化指令**：slash command metadata 与 `/help` 支持英文、繁体中文、日文。AI 回复会跟随用户语言。
@@ -115,7 +115,7 @@ OPENAI_BASE_URL=https://api.openai.com/v1
 
 - `messages.db`：human messages 与 bot 自己的回复，用于聊天历史与摘要。
 - `economy.db`：`user_wallet` 存每位用户的可用余额与 gross totals，`user_account` 存 cached Discord account name / avatar URL、VIP、admin、央行成员、签到与 leaderboard flags，另存长期信贷申请与契约，以及赌场每日统计。
-- `stock.db`：DB-managed 模拟 stock profile、price tick、position、trade operation、ordered trade leg 与 AI-or-fallback stock news。
+- `stock.db`：DB-managed 模拟 stock profile、float supply、price tick、position、trade operation、ordered trade leg 与 AI-or-fallback stock news。
 - `global_state.db`：bot-wide shared state，例如 jackpot pool。
 - `game_cleanup.db`：公开 expiring response 的 Discord guild/channel 名称、user name、channel ID 与 message ID，例如 game、economy 与 stock messages，用于 bot 重启后的清理。
 - `model_prices.json`：缓存的 LiteLLM pricing metadata，用于 AI 回复费用估算。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -27,7 +27,7 @@
 - **Threads 解析**：貼上 Threads.net 或 Threads.com URL，bot 會展開貼文、media 與 reply chain。
 - **影片下載**：`/download_video` 可從 YouTube、TikTok、Instagram、X、Facebook、Bilibili，以及其他 yt-dlp 支援的網站下載影片，檔案太大時會自動 retry 低畫質。
 - **虛擬歡樂豆與金融系統**：使用者可從訊息與 AI 回覆獲得虛擬歡樂豆，可每日簽到、轉帳、購買 VIP、使用長期個人信貸或央行借款，並查看排行榜。
-- **模擬股市**：`/stock` 開啟一則公開 market message，內含 DB-managed virtual companies；選股、交易、部位摘要、近期交易紀錄、定期刷新新聞與 7 日圖表都在同一則公開 message 內 edit 切換，只有發起 `/stock` 的 user 可以操作 controls。
+- **模擬股市**：`/stock` 開啟一則公開 market message，內含 DB-managed virtual companies；選股、受 float supply 與 borrow cap 限制的交易、部位摘要、近期交易紀錄、liquidity-based slippage、定期刷新新聞與 7 日圖表都在同一則公開 message 內 edit 切換，只有發起 `/stock` 的 user 可以操作 controls。
 - **賭場遊戲**：多人 `/games blackjack` 與 `/games dragon_gate` lobby，帶 AI dealer 對話、公開結果 embed 與自動清理。
 - **MapleStory Artale 資料庫**：`/maplestory` 子命令可查詢怪物、裝備、卷軸、NPC、任務、地圖、掉落來源與資料庫統計。
 - **本地化指令**：slash command metadata 與 `/help` 支援英文、繁體中文、日文。AI 回覆會跟隨使用者語言。
@@ -115,7 +115,7 @@ OPENAI_BASE_URL=https://api.openai.com/v1
 
 - `messages.db`：human messages 與 bot 自己的回覆，用於聊天歷史與摘要。
 - `economy.db`：`user_wallet` 存每位使用者的可用餘額與 gross totals，`user_account` 存 cached Discord account name / avatar URL、VIP、admin、央行成員、簽到與 leaderboard flags，另存長期信貸申請與契約，以及賭場每日統計。
-- `stock.db`：DB-managed 模擬 stock profile、price tick、position、trade operation、ordered trade leg 與 AI-or-fallback stock news。
+- `stock.db`：DB-managed 模擬 stock profile、float supply、price tick、position、trade operation、ordered trade leg 與 AI-or-fallback stock news。
 - `global_state.db`：bot-wide shared state，例如 jackpot pool。
 - `game_cleanup.db`：公開 expiring response 的 Discord guild/channel 名稱、user name、channel ID 與 message ID，例如 game、economy 與 stock messages，用於 bot 重啟後的清理。
 - `model_prices.json`：快取的 LiteLLM pricing metadata，用於 AI 回覆費用估算。

--- a/scripts/manage_stock_company.py
+++ b/scripts/manage_stock_company.py
@@ -14,7 +14,11 @@ from rich.table import Table
 from rich.console import Console
 
 from discordbot.typings.stock import StockProfileUpsert
-from discordbot.cogs._stock.database import list_stock_profiles, upsert_stock_profile
+from discordbot.cogs._stock.database import (
+    list_stock_profiles,
+    upsert_stock_profile,
+    list_stock_supply_audit,
+)
 
 console = Console()
 
@@ -26,6 +30,7 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
     subparsers.add_parser(name="list", help="List stock company profile rows.")
+    subparsers.add_parser(name="audit", help="List stock supply and aggregate exposure.")
 
     upsert = subparsers.add_parser(
         name="upsert", help="Create or update one stock company profile row."
@@ -83,11 +88,44 @@ async def _list_profiles() -> None:
     console.print(table)
 
 
+async def _audit_supply() -> None:
+    """Prints stock supply and aggregate exposure."""
+    table = Table(title="Stock supply audit")
+    for column in (
+        "Symbol",
+        "Name",
+        "Float",
+        "Long",
+        "Short",
+        "Long Available",
+        "Short Available",
+        "Liquidity",
+        "Non-final Ops",
+    ):
+        table.add_column(column)
+    for audit in await list_stock_supply_audit():
+        table.add_row(
+            audit.symbol,
+            audit.name,
+            f"{audit.float_shares:,}",
+            f"{audit.long_shares:,}",
+            f"{audit.short_shares:,}",
+            f"{audit.available_long_shares:,}",
+            f"{audit.available_short_shares:,}",
+            f"{audit.liquidity_shares:,}",
+            str(audit.non_final_operations),
+        )
+    console.print(table)
+
+
 async def _async_main(argv: Sequence[str] | None = None) -> None:
     """Runs the CLI."""
     args = _parse_args(argv=argv)
     if args.command == "list":
         await _list_profiles()
+        return
+    if args.command == "audit":
+        await _audit_supply()
         return
     profile = await upsert_stock_profile(profile=_profile_from_args(args=args))
     console.print(f"Upserted stock company: [bold]{profile.symbol}[/bold] {profile.name}")

--- a/src/discordbot/cogs/_stock/database.py
+++ b/src/discordbot/cogs/_stock/database.py
@@ -31,6 +31,7 @@ from discordbot.typings.stock import (
     StockProfileUpsert,
     StockDetailViewData,
     StockOperationStatus,
+    StockSupplyAuditView,
     StockSettlementResult,
     StockParticipantPositionView,
     StockReconciliationOperation,
@@ -47,6 +48,7 @@ from discordbot.cogs._stock.market import (
     format_price,
     tick_boundary,
     decay_news_sentiment,
+    execution_price_cents,
     pressure_from_order_flow,
     tick_boundaries_to_apply,
     calculate_next_price_cents,
@@ -223,8 +225,24 @@ class _StockExecutionSnapshot(BaseModel):
 
     action: StockAction
     price_cents: int
+    liquidity_shares: int
+    max_order_impact_bps: int
     wallet_balance: int
     position: StockPositionView
+    available_long_shares: int
+    available_short_shares: int
+
+
+class _StockMarketExposure(BaseModel):
+    """Aggregate market exposure for one symbol."""
+
+    model_config = ConfigDict(frozen=True)
+
+    symbol: str
+    long_shares: int
+    short_shares: int
+    available_long_shares: int
+    available_short_shares: int
 
 
 @event.listens_for(_engine.sync_engine, "connect")
@@ -617,6 +635,40 @@ async def list_stock_profiles() -> tuple[StockProfileView, ...]:
             statement=select(StockProfile).order_by(StockProfile.symbol.asc())
         )
         return tuple(_profile_view(profile=profile) for profile in result.scalars())
+
+
+async def list_stock_supply_audit() -> tuple[StockSupplyAuditView, ...]:
+    """Lists DB-owned stock supply and aggregate exposure without advancing ticks."""
+    await _ensure_schema()
+    async with open_stock_session() as session:
+        result = await session.execute(
+            statement=select(StockProfile).order_by(StockProfile.symbol.asc())
+        )
+        audits: list[StockSupplyAuditView] = []
+        for profile in result.scalars():
+            exposure = await _market_exposure(session=session, profile=profile)
+            non_final_count = await session.scalar(
+                statement=select(func.count(StockOperation.operation_id)).where(
+                    StockOperation.symbol == profile.symbol,
+                    StockOperation.status.notin_(_FINAL_OPERATION_STATUSES),
+                )
+            )
+            audits.append(
+                StockSupplyAuditView(
+                    symbol=profile.symbol,
+                    name=profile.name,
+                    price_cents=profile.price_cents,
+                    total_shares=profile.total_shares,
+                    float_shares=profile.float_shares,
+                    long_shares=exposure.long_shares,
+                    short_shares=exposure.short_shares,
+                    available_long_shares=exposure.available_long_shares,
+                    available_short_shares=exposure.available_short_shares,
+                    liquidity_shares=profile.liquidity_shares,
+                    non_final_operations=non_final_count or 0,
+                )
+            )
+        return tuple(audits)
 
 
 async def ensure_due_stock_news(
@@ -1112,6 +1164,26 @@ async def _public_position_views(
     return tuple(_participant_position_view(position=position) for position in result.scalars())
 
 
+async def _market_exposure(session: AsyncSession, profile: StockProfile) -> _StockMarketExposure:
+    """Returns aggregate long and short exposure against the configured float."""
+    result = await session.execute(
+        statement=select(
+            func.coalesce(func.sum(StockPosition.long_shares), 0),
+            func.coalesce(func.sum(StockPosition.short_shares), 0),
+        ).where(StockPosition.symbol == profile.symbol)
+    )
+    long_shares, short_shares = result.one()
+    available_long_shares = max(profile.float_shares - int(long_shares), 0)
+    available_short_shares = max(profile.float_shares - int(short_shares), 0)
+    return _StockMarketExposure(
+        symbol=profile.symbol,
+        long_shares=int(long_shares),
+        short_shares=int(short_shares),
+        available_long_shares=available_long_shares,
+        available_short_shares=available_short_shares,
+    )
+
+
 async def _news_views(session: AsyncSession, symbol: str) -> tuple[StockNewsView, ...]:
     """Returns recent news views inside the caller's stock session."""
     result = await session.execute(
@@ -1166,8 +1238,98 @@ def _prorated_amount(total: int, shares: int, current_shares: int) -> int:
     return total * shares // current_shares
 
 
+def _buy_execution_price(
+    price_cents: int, shares: int, liquidity_shares: int, max_impact_bps: int
+) -> int:
+    """Returns the execution price for a buy-side leg."""
+    return execution_price_cents(
+        reference_price_cents=price_cents,
+        shares=shares,
+        liquidity_shares=liquidity_shares,
+        max_impact_bps=max_impact_bps,
+        is_buy=True,
+    )
+
+
+def _sell_execution_price(
+    price_cents: int, shares: int, liquidity_shares: int, max_impact_bps: int
+) -> int:
+    """Returns the execution price for a sell-side leg."""
+    return execution_price_cents(
+        reference_price_cents=price_cents,
+        shares=shares,
+        liquidity_shares=liquidity_shares,
+        max_impact_bps=max_impact_bps,
+        is_buy=False,
+    )
+
+
+def _buy_cost(price_cents: int, shares: int, liquidity_shares: int, max_impact_bps: int) -> int:
+    """Returns integer cash needed for a buy-side leg."""
+    execution_price = _buy_execution_price(
+        price_cents=price_cents,
+        shares=shares,
+        liquidity_shares=liquidity_shares,
+        max_impact_bps=max_impact_bps,
+    )
+    return cash_ceil(cents=execution_price * shares)
+
+
+def _sell_proceeds(
+    price_cents: int, shares: int, liquidity_shares: int, max_impact_bps: int
+) -> int:
+    """Returns integer cash received from a sell-side leg."""
+    execution_price = _sell_execution_price(
+        price_cents=price_cents,
+        shares=shares,
+        liquidity_shares=liquidity_shares,
+        max_impact_bps=max_impact_bps,
+    )
+    return cash_floor(cents=execution_price * shares)
+
+
+def _max_affordable_buy_shares(
+    price_cents: int,
+    wallet_balance: int,
+    liquidity_shares: int,
+    max_impact_bps: int,
+    share_cap: int,
+) -> int:
+    """Returns the largest buy-side size affordable after execution impact."""
+    if wallet_balance <= 0 or share_cap <= 0:
+        return 0
+    low = 0
+    high = share_cap
+    while low < high:
+        shares = (low + high + 1) // 2
+        if (
+            _buy_cost(
+                price_cents=price_cents,
+                shares=shares,
+                liquidity_shares=liquidity_shares,
+                max_impact_bps=max_impact_bps,
+            )
+            <= wallet_balance
+        ):
+            low = shares
+        else:
+            high = shares - 1
+    return low
+
+
+def _max_collateralized_short_shares(price_cents: int, wallet_balance: int, share_cap: int) -> int:
+    """Returns the largest short size allowed by the reference-price collateral."""
+    if wallet_balance <= 0 or share_cap <= 0:
+        return 0
+    return min(share_cap, wallet_balance * 100 // price_cents)
+
+
 def _max_coverable_short_shares(
-    price_cents: int, wallet_balance: int, position: StockPositionView
+    price_cents: int,
+    wallet_balance: int,
+    position: StockPositionView,
+    liquidity_shares: int,
+    max_impact_bps: int,
 ) -> int:
     """Returns how many short shares can be covered from the submit-time state."""
     low = 0
@@ -1180,7 +1342,12 @@ def _max_coverable_short_shares(
         released_entry_value = _prorated_amount(
             total=position.short_entry_value, shares=shares, current_shares=position.short_shares
         )
-        cover_cost = cash_ceil(cents=price_cents * shares)
+        cover_cost = _buy_cost(
+            price_cents=price_cents,
+            shares=shares,
+            liquidity_shares=liquidity_shares,
+            max_impact_bps=max_impact_bps,
+        )
         if cover_cost <= wallet_balance + released_collateral + released_entry_value:
             low = shares
         else:
@@ -1191,39 +1358,75 @@ def _max_coverable_short_shares(
 def _max_executable_quantity(snapshot: _StockExecutionSnapshot) -> int:
     """Returns the largest quantity that can pass balance validation."""
     if snapshot.action == StockAction.SHORT:
-        sell_proceeds = cash_floor(cents=snapshot.price_cents * snapshot.position.long_shares)
+        sell_proceeds = _sell_proceeds(
+            price_cents=snapshot.price_cents,
+            shares=snapshot.position.long_shares,
+            liquidity_shares=snapshot.liquidity_shares,
+            max_impact_bps=snapshot.max_order_impact_bps,
+        )
         cash_after_selling = snapshot.wallet_balance + sell_proceeds
-        return snapshot.position.long_shares + cash_after_selling * 100 // snapshot.price_cents
+        short_shares = _max_collateralized_short_shares(
+            price_cents=snapshot.price_cents,
+            wallet_balance=cash_after_selling,
+            share_cap=snapshot.available_short_shares,
+        )
+        return snapshot.position.long_shares + short_shares
 
     if snapshot.position.short_shares <= 0:
-        return snapshot.wallet_balance * 100 // snapshot.price_cents
+        return _max_affordable_buy_shares(
+            price_cents=snapshot.price_cents,
+            wallet_balance=snapshot.wallet_balance,
+            liquidity_shares=snapshot.liquidity_shares,
+            max_impact_bps=snapshot.max_order_impact_bps,
+            share_cap=snapshot.available_long_shares,
+        )
 
     coverable_shares = _max_coverable_short_shares(
         price_cents=snapshot.price_cents,
         wallet_balance=snapshot.wallet_balance,
         position=snapshot.position,
+        liquidity_shares=snapshot.liquidity_shares,
+        max_impact_bps=snapshot.max_order_impact_bps,
     )
     if coverable_shares < snapshot.position.short_shares:
         return coverable_shares
-    cover_cost = cash_ceil(cents=snapshot.price_cents * snapshot.position.short_shares)
+    cover_cost = _buy_cost(
+        price_cents=snapshot.price_cents,
+        shares=snapshot.position.short_shares,
+        liquidity_shares=snapshot.liquidity_shares,
+        max_impact_bps=snapshot.max_order_impact_bps,
+    )
     cash_after_covering = (
         snapshot.wallet_balance
         + snapshot.position.short_collateral
         + snapshot.position.short_entry_value
         - cover_cost
     )
-    return (
-        snapshot.position.short_shares + max(cash_after_covering, 0) * 100 // snapshot.price_cents
+    return snapshot.position.short_shares + _max_affordable_buy_shares(
+        price_cents=snapshot.price_cents,
+        wallet_balance=max(cash_after_covering, 0),
+        liquidity_shares=snapshot.liquidity_shares,
+        max_impact_bps=snapshot.max_order_impact_bps,
+        share_cap=snapshot.available_long_shares,
     )
 
 
-def _clamp_quantity_to_available(
-    raw_quantity: str, parsed_quantity: int, snapshot: _StockExecutionSnapshot
-) -> int:
+def _clamp_quantity_to_available(parsed_quantity: int, snapshot: _StockExecutionSnapshot) -> int:
     """Treats oversized numeric quantities as the submit-time executable maximum."""
-    if _is_all_quantity(raw_quantity=raw_quantity) or parsed_quantity <= 0:
+    if parsed_quantity <= 0:
         return parsed_quantity
     return min(parsed_quantity, _max_executable_quantity(snapshot=snapshot))
+
+
+def _max_quantity_error(snapshot: _StockExecutionSnapshot) -> str:
+    """Returns the clearest validation error when nothing is executable."""
+    if snapshot.action == StockAction.BUY:
+        if snapshot.position.short_shares <= 0 and snapshot.available_long_shares <= 0:
+            return "目前沒有可買入的流通股"
+        return "餘額不足，無法買入或回補股票"
+    if snapshot.position.long_shares <= 0 and snapshot.available_short_shares <= 0:
+        return "目前沒有可借券做空的股數"
+    return "餘額不足，無法賣出或建立做空部位"
 
 
 def _leg_view(  # noqa: PLR0913 -- trade leg fields mirror the persisted audit row
@@ -1255,6 +1458,14 @@ def _leg_view(  # noqa: PLR0913 -- trade leg fields mirror the persisted audit r
         realized_pnl_delta=realized_pnl_delta,
         created_at=now,
     )
+
+
+def _average_leg_price(legs: tuple[StockTradeLegView, ...], fallback_price_cents: int) -> int:
+    """Returns a share-weighted execution price for a result summary."""
+    total_shares = sum(leg.shares for leg in legs)
+    if total_shares <= 0:
+        return fallback_price_cents
+    return sum(leg.price_cents * leg.shares for leg in legs) // total_shares
 
 
 def _insufficient_result(  # noqa: PLR0913 -- failed results preserve the submit-time context
@@ -1289,8 +1500,12 @@ def _build_plan(  # noqa: PLR0913 -- settlement plan needs the current wallet an
     action: StockAction,
     quantity: int,
     price_cents: int,
+    liquidity_shares: int,
+    max_order_impact_bps: int,
     wallet_balance: int,
     position: StockPositionView,
+    available_long_shares: int,
+    available_short_shares: int,
     now: datetime,
 ) -> _StockOperationPlan | StockSettlementResult:
     """Builds ordered stock and wallet mutations from the submit-time state."""
@@ -1311,8 +1526,11 @@ def _build_plan(  # noqa: PLR0913 -- settlement plan needs the current wallet an
             user_id=user_id,
             quantity=quantity,
             price_cents=price_cents,
+            liquidity_shares=liquidity_shares,
+            max_order_impact_bps=max_order_impact_bps,
             wallet_balance=wallet_balance,
             position=position,
+            available_long_shares=available_long_shares,
             now=now,
         )
     return _build_short_plan(
@@ -1321,8 +1539,11 @@ def _build_plan(  # noqa: PLR0913 -- settlement plan needs the current wallet an
         user_id=user_id,
         quantity=quantity,
         price_cents=price_cents,
+        liquidity_shares=liquidity_shares,
+        max_order_impact_bps=max_order_impact_bps,
         wallet_balance=wallet_balance,
         position=position,
+        available_short_shares=available_short_shares,
         now=now,
     )
 
@@ -1333,8 +1554,11 @@ def _build_buy_plan(  # noqa: PLR0913 -- buy can cover short and open long in or
     user_id: int,
     quantity: int,
     price_cents: int,
+    liquidity_shares: int,
+    max_order_impact_bps: int,
     wallet_balance: int,
     position: StockPositionView,
+    available_long_shares: int,
     now: datetime,
 ) -> _StockOperationPlan | StockSettlementResult:
     """Builds a buy/cover plan."""
@@ -1356,7 +1580,13 @@ def _build_buy_plan(  # noqa: PLR0913 -- buy can cover short and open long in or
         released_entry_value = _prorated_amount(
             total=short_entry_value, shares=cover_shares, current_shares=short_shares
         )
-        cover_cost = cash_ceil(cents=price_cents * cover_shares)
+        cover_price_cents = _buy_execution_price(
+            price_cents=price_cents,
+            shares=cover_shares,
+            liquidity_shares=liquidity_shares,
+            max_impact_bps=max_order_impact_bps,
+        )
+        cover_cost = cash_ceil(cents=cover_price_cents * cover_shares)
         if (
             cover_cost
             > released_collateral + released_entry_value + wallet_balance + wallet_delta_total
@@ -1380,7 +1610,7 @@ def _build_buy_plan(  # noqa: PLR0913 -- buy can cover short and open long in or
                 user_id=user_id,
                 leg_type=StockTradeLegType.COVER_SHORT,
                 shares=cover_shares,
-                price_cents=price_cents,
+                price_cents=cover_price_cents,
                 wallet_delta=wallet_delta,
                 basis_delta=-released_entry_value,
                 collateral_delta=-released_collateral,
@@ -1396,7 +1626,23 @@ def _build_buy_plan(  # noqa: PLR0913 -- buy can cover short and open long in or
         remaining -= cover_shares
 
     if remaining > 0:
-        cost = cash_ceil(cents=price_cents * remaining)
+        if remaining > available_long_shares:
+            return _insufficient_result(
+                symbol=symbol,
+                action=StockAction.BUY,
+                quantity=quantity,
+                price_cents=price_cents,
+                balance=wallet_balance,
+                position=position,
+                error=f"目前可買入流通股只剩 {available_long_shares:,} 股",
+            )
+        open_price_cents = _buy_execution_price(
+            price_cents=price_cents,
+            shares=remaining,
+            liquidity_shares=liquidity_shares,
+            max_impact_bps=max_order_impact_bps,
+        )
+        cost = cash_ceil(cents=open_price_cents * remaining)
         if cost > wallet_balance + wallet_delta_total:
             return _insufficient_result(
                 symbol=symbol,
@@ -1415,7 +1661,7 @@ def _build_buy_plan(  # noqa: PLR0913 -- buy can cover short and open long in or
                 user_id=user_id,
                 leg_type=StockTradeLegType.OPEN_LONG,
                 shares=remaining,
-                price_cents=price_cents,
+                price_cents=open_price_cents,
                 wallet_delta=-cost,
                 basis_delta=cost,
                 collateral_delta=0,
@@ -1443,7 +1689,7 @@ def _build_buy_plan(  # noqa: PLR0913 -- buy can cover short and open long in or
         symbol=symbol,
         requested_action=StockAction.BUY,
         shares=quantity,
-        price_cents=price_cents,
+        price_cents=_average_leg_price(legs=tuple(legs), fallback_price_cents=price_cents),
         wallet_delta=wallet_delta_total,
         balance_after=wallet_balance + wallet_delta_total,
         position=final_position,
@@ -1458,8 +1704,11 @@ def _build_short_plan(  # noqa: PLR0913 -- short can sell long and open short in
     user_id: int,
     quantity: int,
     price_cents: int,
+    liquidity_shares: int,
+    max_order_impact_bps: int,
     wallet_balance: int,
     position: StockPositionView,
+    available_short_shares: int,
     now: datetime,
 ) -> _StockOperationPlan | StockSettlementResult:
     """Builds a short/sell plan."""
@@ -1478,7 +1727,13 @@ def _build_short_plan(  # noqa: PLR0913 -- short can sell long and open short in
         released_basis = _prorated_amount(
             total=long_cost_basis, shares=sell_shares, current_shares=long_shares
         )
-        proceeds = cash_floor(cents=price_cents * sell_shares)
+        sell_price_cents = _sell_execution_price(
+            price_cents=price_cents,
+            shares=sell_shares,
+            liquidity_shares=liquidity_shares,
+            max_impact_bps=max_order_impact_bps,
+        )
+        proceeds = cash_floor(cents=sell_price_cents * sell_shares)
         realized = proceeds - released_basis
         legs.append(
             _leg_view(
@@ -1488,7 +1743,7 @@ def _build_short_plan(  # noqa: PLR0913 -- short can sell long and open short in
                 user_id=user_id,
                 leg_type=StockTradeLegType.SELL_LONG,
                 shares=sell_shares,
-                price_cents=price_cents,
+                price_cents=sell_price_cents,
                 wallet_delta=proceeds,
                 basis_delta=-released_basis,
                 collateral_delta=0,
@@ -1503,6 +1758,16 @@ def _build_short_plan(  # noqa: PLR0913 -- short can sell long and open short in
         remaining -= sell_shares
 
     if remaining > 0:
+        if remaining > available_short_shares:
+            return _insufficient_result(
+                symbol=symbol,
+                action=StockAction.SHORT,
+                quantity=quantity,
+                price_cents=price_cents,
+                balance=wallet_balance,
+                position=position,
+                error=f"目前可借券做空股數只剩 {available_short_shares:,} 股",
+            )
         collateral = cash_ceil(cents=price_cents * remaining)
         if collateral > wallet_balance + wallet_delta_total:
             return _insufficient_result(
@@ -1514,7 +1779,13 @@ def _build_short_plan(  # noqa: PLR0913 -- short can sell long and open short in
                 position=position,
                 error=f"餘額不足，需要 {collateral:,} 作為做空擔保金",
             )
-        entry_value = cash_floor(cents=price_cents * remaining)
+        short_price_cents = _sell_execution_price(
+            price_cents=price_cents,
+            shares=remaining,
+            liquidity_shares=liquidity_shares,
+            max_impact_bps=max_order_impact_bps,
+        )
+        entry_value = cash_floor(cents=short_price_cents * remaining)
         legs.append(
             _leg_view(
                 operation_id=operation_id,
@@ -1523,7 +1794,7 @@ def _build_short_plan(  # noqa: PLR0913 -- short can sell long and open short in
                 user_id=user_id,
                 leg_type=StockTradeLegType.OPEN_SHORT,
                 shares=remaining,
-                price_cents=price_cents,
+                price_cents=short_price_cents,
                 wallet_delta=-collateral,
                 basis_delta=entry_value,
                 collateral_delta=collateral,
@@ -1552,7 +1823,7 @@ def _build_short_plan(  # noqa: PLR0913 -- short can sell long and open short in
         symbol=symbol,
         requested_action=StockAction.SHORT,
         shares=quantity,
-        price_cents=price_cents,
+        price_cents=_average_leg_price(legs=tuple(legs), fallback_price_cents=price_cents),
         wallet_delta=wallet_delta_total,
         balance_after=wallet_balance + wallet_delta_total,
         position=final_position,
@@ -1628,7 +1899,94 @@ def _wallet_delta_legs_for_plan(plan: _StockOperationPlan) -> tuple[WalletDeltaL
     return tuple(deltas)
 
 
-async def settle_stock_operation(  # noqa: PLR0911, PLR0913 -- Service boundary returns typed validation and lifecycle failures directly
+async def _build_submit_time_operation_plan(  # noqa: PLR0913 -- submit-time planning needs every locked snapshot input
+    session: AsyncSession,
+    normalized_symbol: str,
+    operation_id: str,
+    user_id: int,
+    requested_action: StockAction,
+    quantity: str,
+    wallet_balance: int,
+    position: StockPositionView,
+    effective_now: datetime,
+    rng: Random | None,
+) -> _StockOperationPlan | StockSettlementResult:
+    """Builds a submit-time operation plan from locked market and position state."""
+    quote = await advance_market_in_session(
+        session=session,
+        symbol=normalized_symbol,
+        now=effective_now,
+        rng=rng,
+        begin_immediate=False,
+    )
+    profile = await session.get(entity=StockProfile, ident=normalized_symbol)
+    if profile is None:
+        msg = f"Unknown stock symbol: {normalized_symbol}"
+        raise ValueError(msg)
+    exposure = await _market_exposure(session=session, profile=profile)
+    try:
+        parsed_quantity = _parse_quantity(
+            raw_quantity=quantity,
+            action=requested_action,
+            price_cents=quote.profile.price_cents,
+            wallet_balance=wallet_balance,
+            position=position,
+        )
+    except ValueError:
+        return _insufficient_result(
+            symbol=normalized_symbol,
+            action=requested_action,
+            quantity=0,
+            price_cents=quote.profile.price_cents,
+            balance=wallet_balance,
+            position=position,
+            error="股數格式錯誤，請輸入正整數或 ALL",
+        )
+    snapshot = _StockExecutionSnapshot(
+        action=requested_action,
+        price_cents=quote.profile.price_cents,
+        liquidity_shares=quote.profile.liquidity_shares,
+        max_order_impact_bps=quote.profile.max_tick_change_bps,
+        wallet_balance=wallet_balance,
+        position=position,
+        available_long_shares=exposure.available_long_shares,
+        available_short_shares=exposure.available_short_shares,
+    )
+    requested_quantity = parsed_quantity
+    parsed_quantity = _clamp_quantity_to_available(
+        parsed_quantity=parsed_quantity, snapshot=snapshot
+    )
+    if (
+        requested_quantity > 0 or _is_all_quantity(raw_quantity=quantity)
+    ) and parsed_quantity <= 0:
+        return _insufficient_result(
+            symbol=normalized_symbol,
+            action=requested_action,
+            quantity=parsed_quantity,
+            price_cents=quote.profile.price_cents,
+            balance=wallet_balance,
+            position=position,
+            error=_max_quantity_error(snapshot=snapshot),
+        )
+
+    return _build_plan(
+        operation_id=operation_id,
+        symbol=normalized_symbol,
+        user_id=user_id,
+        action=requested_action,
+        quantity=parsed_quantity,
+        price_cents=quote.profile.price_cents,
+        liquidity_shares=quote.profile.liquidity_shares,
+        max_order_impact_bps=quote.profile.max_tick_change_bps,
+        wallet_balance=wallet_balance,
+        position=position,
+        available_long_shares=exposure.available_long_shares,
+        available_short_shares=exposure.available_short_shares,
+        now=effective_now,
+    )
+
+
+async def settle_stock_operation(  # noqa: PLR0913 -- Service boundary returns typed validation and lifecycle failures directly
     symbol: str,
     user_id: int,
     user_name: str,
@@ -1660,53 +2018,17 @@ async def settle_stock_operation(  # noqa: PLR0911, PLR0913 -- Service boundary 
                     balance=wallet_balance,
                     position=position,
                 )
-            quote = await advance_market_in_session(
+            plan = await _build_submit_time_operation_plan(
                 session=session,
-                symbol=normalized_symbol,
-                now=effective_now,
-                rng=rng,
-                begin_immediate=False,
-            )
-            try:
-                parsed_quantity = _parse_quantity(
-                    raw_quantity=quantity,
-                    action=requested_action,
-                    price_cents=quote.profile.price_cents,
-                    wallet_balance=wallet_balance,
-                    position=position,
-                )
-            except ValueError:
-                await session.rollback()
-                return _insufficient_result(
-                    symbol=normalized_symbol,
-                    action=requested_action,
-                    quantity=0,
-                    price_cents=quote.profile.price_cents,
-                    balance=wallet_balance,
-                    position=position,
-                    error="股數格式錯誤，請輸入正整數或 ALL",
-                )
-            parsed_quantity = _clamp_quantity_to_available(
-                raw_quantity=quantity,
-                parsed_quantity=parsed_quantity,
-                snapshot=_StockExecutionSnapshot(
-                    action=requested_action,
-                    price_cents=quote.profile.price_cents,
-                    wallet_balance=wallet_balance,
-                    position=position,
-                ),
-            )
-
-            plan = _build_plan(
+                normalized_symbol=normalized_symbol,
                 operation_id=operation_id,
-                symbol=normalized_symbol,
                 user_id=user_id,
-                action=requested_action,
-                quantity=parsed_quantity,
-                price_cents=quote.profile.price_cents,
+                requested_action=requested_action,
+                quantity=quantity,
                 wallet_balance=wallet_balance,
                 position=position,
-                now=effective_now,
+                effective_now=effective_now,
+                rng=rng,
             )
             if not plan.success:
                 await session.rollback()
@@ -1957,6 +2279,7 @@ __all__ = [
     "list_market_quotes",
     "list_reconciliation_operations",
     "list_stock_profiles",
+    "list_stock_supply_audit",
     "open_stock_session",
     "settle_stock_operation",
     "upsert_stock_profile",

--- a/src/discordbot/cogs/_stock/database.py
+++ b/src/discordbot/cogs/_stock/database.py
@@ -1166,22 +1166,67 @@ async def _public_position_views(
 
 async def _market_exposure(session: AsyncSession, profile: StockProfile) -> _StockMarketExposure:
     """Returns aggregate long and short exposure against the configured float."""
-    result = await session.execute(
+    return (await _market_exposures(session=session, profiles=(profile,)))[profile.symbol]
+
+
+async def _market_exposures(
+    session: AsyncSession, profiles: tuple[StockProfile, ...]
+) -> dict[str, _StockMarketExposure]:
+    """Returns aggregate exposure by symbol, reserving shares for non-final operations."""
+    profile_by_symbol = {profile.symbol: profile for profile in profiles}
+    if not profile_by_symbol:
+        return {}
+    symbols = tuple(profile_by_symbol)
+    exposure_totals = {symbol: {"long": 0, "short": 0} for symbol in symbols}
+
+    position_result = await session.execute(
         statement=select(
+            StockPosition.symbol,
             func.coalesce(func.sum(StockPosition.long_shares), 0),
             func.coalesce(func.sum(StockPosition.short_shares), 0),
-        ).where(StockPosition.symbol == profile.symbol)
+        )
+        .where(StockPosition.symbol.in_(symbols))
+        .group_by(StockPosition.symbol)
     )
-    long_shares, short_shares = result.one()
-    available_long_shares = max(profile.float_shares - int(long_shares), 0)
-    available_short_shares = max(profile.float_shares - int(short_shares), 0)
-    return _StockMarketExposure(
-        symbol=profile.symbol,
-        long_shares=int(long_shares),
-        short_shares=int(short_shares),
-        available_long_shares=available_long_shares,
-        available_short_shares=available_short_shares,
+    for symbol, long_shares, short_shares in position_result.all():
+        exposure_totals[symbol]["long"] = int(long_shares)
+        exposure_totals[symbol]["short"] = int(short_shares)
+
+    pending_result = await session.execute(
+        statement=select(
+            StockTradeLeg.symbol,
+            StockTradeLeg.leg_type,
+            func.coalesce(func.sum(StockTradeLeg.shares), 0),
+        )
+        .join(StockOperation, StockOperation.operation_id == StockTradeLeg.operation_id)
+        .where(
+            StockTradeLeg.symbol.in_(symbols),
+            StockTradeLeg.leg_type.in_((
+                StockTradeLegType.OPEN_LONG.value,
+                StockTradeLegType.OPEN_SHORT.value,
+            )),
+            StockOperation.status.notin_(_FINAL_OPERATION_STATUSES),
+        )
+        .group_by(StockTradeLeg.symbol, StockTradeLeg.leg_type)
     )
+    for symbol, leg_type, shares in pending_result.all():
+        if leg_type == StockTradeLegType.OPEN_LONG.value:
+            exposure_totals[symbol]["long"] += int(shares)
+        else:
+            exposure_totals[symbol]["short"] += int(shares)
+
+    exposures: dict[str, _StockMarketExposure] = {}
+    for symbol, profile in profile_by_symbol.items():
+        long_shares = exposure_totals[symbol]["long"]
+        short_shares = exposure_totals[symbol]["short"]
+        exposures[symbol] = _StockMarketExposure(
+            symbol=symbol,
+            long_shares=long_shares,
+            short_shares=short_shares,
+            available_long_shares=max(profile.float_shares - long_shares, 0),
+            available_short_shares=max(profile.float_shares - short_shares, 0),
+        )
+    return exposures
 
 
 async def _news_views(session: AsyncSession, symbol: str) -> tuple[StockNewsView, ...]:

--- a/src/discordbot/cogs/_stock/database.py
+++ b/src/discordbot/cogs/_stock/database.py
@@ -644,15 +644,23 @@ async def list_stock_supply_audit() -> tuple[StockSupplyAuditView, ...]:
         result = await session.execute(
             statement=select(StockProfile).order_by(StockProfile.symbol.asc())
         )
-        audits: list[StockSupplyAuditView] = []
-        for profile in result.scalars():
-            exposure = await _market_exposure(session=session, profile=profile)
-            non_final_count = await session.scalar(
-                statement=select(func.count(StockOperation.operation_id)).where(
-                    StockOperation.symbol == profile.symbol,
+        profiles = tuple(result.scalars())
+        exposures = await _market_exposures(session=session, profiles=profiles)
+        symbols = tuple(profile.symbol for profile in profiles)
+        non_final_counts: dict[str, int] = {}
+        if symbols:
+            count_result = await session.execute(
+                statement=select(StockOperation.symbol, func.count(StockOperation.operation_id))
+                .where(
+                    StockOperation.symbol.in_(symbols),
                     StockOperation.status.notin_(_FINAL_OPERATION_STATUSES),
                 )
+                .group_by(StockOperation.symbol)
             )
+            non_final_counts = {symbol: int(count) for symbol, count in count_result.all()}
+        audits: list[StockSupplyAuditView] = []
+        for profile in profiles:
+            exposure = exposures[profile.symbol]
             audits.append(
                 StockSupplyAuditView(
                     symbol=profile.symbol,
@@ -665,7 +673,7 @@ async def list_stock_supply_audit() -> tuple[StockSupplyAuditView, ...]:
                     available_long_shares=exposure.available_long_shares,
                     available_short_shares=exposure.available_short_shares,
                     liquidity_shares=profile.liquidity_shares,
-                    non_final_operations=non_final_count or 0,
+                    non_final_operations=non_final_counts.get(profile.symbol, 0),
                 )
             )
         return tuple(audits)

--- a/src/discordbot/cogs/_stock/market.py
+++ b/src/discordbot/cogs/_stock/market.py
@@ -66,6 +66,32 @@ def pressure_from_order_flow(net_shares: float, liquidity_shares: int) -> int:
     )
 
 
+def order_impact_bps(shares: int, liquidity_shares: int, max_impact_bps: int) -> int:
+    """Converts an order size into bounded execution impact."""
+    if shares <= 0 or liquidity_shares <= 0 or max_impact_bps <= 0:
+        return 0
+    return clamp_bps(
+        value=round(shares * max_impact_bps / liquidity_shares), lower=0, upper=max_impact_bps
+    )
+
+
+def execution_price_cents(
+    reference_price_cents: int,
+    shares: int,
+    liquidity_shares: int,
+    max_impact_bps: int,
+    is_buy: bool,
+) -> int:
+    """Returns a side-adjusted execution price for one order leg."""
+    reference_price = max(reference_price_cents, 1)
+    impact_bps = order_impact_bps(
+        shares=shares, liquidity_shares=liquidity_shares, max_impact_bps=max_impact_bps
+    )
+    if is_buy:
+        return max(reference_price * (10_000 + impact_bps) + 9_999, 1) // 10_000
+    return max(reference_price * max(10_000 - impact_bps, 1) // 10_000, 1)
+
+
 def mean_reversion_bps(
     previous_price_cents: int, fair_value_cents: int, mean_reversion_strength_bps: int
 ) -> int:

--- a/src/discordbot/cogs/_stock/market.py
+++ b/src/discordbot/cogs/_stock/market.py
@@ -70,9 +70,10 @@ def order_impact_bps(shares: int, liquidity_shares: int, max_impact_bps: int) ->
     """Converts an order size into bounded execution impact."""
     if shares <= 0 or liquidity_shares <= 0 or max_impact_bps <= 0:
         return 0
-    return clamp_bps(
-        value=round(shares * max_impact_bps / liquidity_shares), lower=0, upper=max_impact_bps
-    )
+    raw_impact, remainder = divmod(shares * max_impact_bps, liquidity_shares)
+    if remainder * 2 >= liquidity_shares:
+        raw_impact += 1
+    return clamp_bps(value=raw_impact, lower=0, upper=max_impact_bps)
 
 
 def execution_price_cents(

--- a/src/discordbot/cogs/_stock/presentation.py
+++ b/src/discordbot/cogs/_stock/presentation.py
@@ -131,7 +131,8 @@ def build_tutorial_embed() -> Embed:
             "`買入 / 回補做空` 會先回補既有做空，剩餘數量才建立持股。\n"
             "`做空 / 賣出持股` 會先賣出既有持股，剩餘數量才建立做空。\n"
             "選擇操作後會跳出數量視窗，可以輸入整數或 `ALL`，實際價格與部位會在送出當下重新讀取。"
-            "如果輸入股數超過當下餘額可執行上限，會自動改用可執行的最大股數。"
+            "如果輸入股數超過當下餘額、流通股或可借券上限，會自動改用可執行的最大股數。"
+            "大單會依照 liquidity 產生 execution slippage。"
         ),
         color=DETAIL_COLOR,
     )
@@ -234,7 +235,8 @@ def _leg_lines(legs: tuple[StockTradeLegView, ...]) -> str:
         name = leg.user_name or str(leg.user_id)
         lines.append(
             f"{name} · #{leg.leg_order} {_leg_type_label(leg_type=leg.leg_type)} "
-            f"`{leg.shares:,}` 股 · 錢包變化 {amount_code(amount=leg.wallet_delta, signed=True)} · "
+            f"`{leg.shares:,}` 股 · 成交價 `{format_price(price_cents=leg.price_cents)}` · "
+            f"錢包變化 {amount_code(amount=leg.wallet_delta, signed=True)} · "
             f"損益 {amount_code(amount=leg.realized_pnl_delta, signed=True)}"
         )
     return "\n".join(lines) if lines else "無"

--- a/src/discordbot/cogs/help.py
+++ b/src/discordbot/cogs/help.py
@@ -43,7 +43,7 @@ _HELP_CONTENT = {
         "checkin": ("**Daily Check-in**\n`/checkin` claims the daily reward and streak bonus."),
         "stocks": (
             "**Simulated Stock Market**\n"
-            "`/stock` opens the market UI for prices, news, positions, charts, supply-limited buy, short, and cover actions."
+            "`/stock` opens the market UI for prices, news, positions, charts, supply-capped buy and short entries, plus sell and cover exits."
         ),
         "vip": (
             "**VIP**\n"

--- a/src/discordbot/cogs/help.py
+++ b/src/discordbot/cogs/help.py
@@ -117,7 +117,7 @@ _HELP_CONTENT = {
         ),
         "stocks": (
             "**シミュレーション株式市場**\n"
-            "`/stock` で market UI を開き、price、news、position、chart、supply-limited buy、short、cover を扱えます。"
+            "`/stock` で market UI を開き、price、news、position、chart、supply cap 付きの buy/short entry、sell/cover exit を扱えます。"
         ),
         "vip": (
             "**VIP**\n"

--- a/src/discordbot/cogs/help.py
+++ b/src/discordbot/cogs/help.py
@@ -43,7 +43,7 @@ _HELP_CONTENT = {
         "checkin": ("**Daily Check-in**\n`/checkin` claims the daily reward and streak bonus."),
         "stocks": (
             "**Simulated Stock Market**\n"
-            "`/stock` opens the market UI for prices, news, positions, charts, buy, short, and cover actions."
+            "`/stock` opens the market UI for prices, news, positions, charts, supply-limited buy, short, and cover actions."
         ),
         "vip": (
             "**VIP**\n"
@@ -79,7 +79,7 @@ _HELP_CONTENT = {
         "checkin": ("**每日簽到**\n`/checkin` 領每日獎勵和 streak bonus。"),
         "stocks": (
             "**模擬股市**\n"
-            "`/stock` 開啟 market UI，可以看價格、news、position、chart，也能 buy、short、cover。"
+            "`/stock` 開啟 market UI，可以看價格、news、position、chart，也能做 supply-limited buy、short、cover。"
         ),
         "vip": ("**VIP**\n`/vip` 購買或查看 VIP 狀態，VIP 會加成 check-in 和 Blackjack reward。"),
         "games": (
@@ -117,7 +117,7 @@ _HELP_CONTENT = {
         ),
         "stocks": (
             "**シミュレーション株式市場**\n"
-            "`/stock` で market UI を開き、price、news、position、chart、buy、short、cover を扱えます。"
+            "`/stock` で market UI を開き、price、news、position、chart、supply-limited buy、short、cover を扱えます。"
         ),
         "vip": (
             "**VIP**\n"

--- a/src/discordbot/cogs/help.py
+++ b/src/discordbot/cogs/help.py
@@ -79,7 +79,7 @@ _HELP_CONTENT = {
         "checkin": ("**每日簽到**\n`/checkin` 領每日獎勵和 streak bonus。"),
         "stocks": (
             "**模擬股市**\n"
-            "`/stock` 開啟 market UI，可以看價格、news、position、chart，也能做 supply-limited buy、short、cover。"
+            "`/stock` 開啟 market UI，可以看價格、news、position、chart，也能建立受 supply cap 限制的 buy/short，或執行 sell/cover 出場。"
         ),
         "vip": ("**VIP**\n`/vip` 購買或查看 VIP 狀態，VIP 會加成 check-in 和 Blackjack reward。"),
         "games": (

--- a/src/discordbot/typings/stock.py
+++ b/src/discordbot/typings/stock.py
@@ -232,6 +232,24 @@ class StockReconciliationOperation(BaseModel):
     legs: tuple[StockTradeLegView, ...]
 
 
+class StockSupplyAuditView(BaseModel):
+    """Read-only stock supply and exposure snapshot for maintenance."""
+
+    model_config = ConfigDict(frozen=True)
+
+    symbol: str
+    name: str
+    price_cents: int
+    total_shares: int
+    float_shares: int
+    long_shares: int
+    short_shares: int
+    available_long_shares: int
+    available_short_shares: int
+    liquidity_shares: int
+    non_final_operations: int
+
+
 __all__ = [
     "MAX_TICKS_PER_INTERACTION",
     "STOCK_ACTION_TIMEOUT_SECONDS",
@@ -251,6 +269,7 @@ __all__ = [
     "StockProfileView",
     "StockReconciliationOperation",
     "StockSettlementResult",
+    "StockSupplyAuditView",
     "StockTradeLegType",
     "StockTradeLegView",
 ]

--- a/tests/test_stock.py
+++ b/tests/test_stock.py
@@ -1142,6 +1142,76 @@ async def test_stock_short_clamps_to_available_borrow(
     assert "借券" in blocked.error
 
 
+async def test_stock_pending_operations_reserve_supply(
+    stock_isolated_db: None, economy_isolated_db: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Non-final operation legs reserve float and borrow capacity until reconciliation."""
+    await _upsert_illiquid_profile()
+    await adjust_balance(user_id=1, name="alice", delta=200_000)
+    await adjust_balance(user_id=2, name="bob", delta=1_000)
+    await adjust_balance(user_id=3, name="carol", delta=100_000_000)
+    await adjust_balance(user_id=4, name="dave", delta=1_000)
+    original_apply = stock_db.apply_ordered_wallet_deltas
+
+    async def fail_wallet(**_kwargs: object) -> OrderedWalletDeltaResult:
+        """Simulates uncertainty after the stock operation reserves market supply."""
+        raise RuntimeError("wallet unavailable")
+
+    monkeypatch.setattr(stock_db, "apply_ordered_wallet_deltas", fail_wallet)
+    pending_long = await stock_db.settle_stock_operation(
+        symbol="THIN",
+        user_id=1,
+        user_name="alice",
+        requested_action=StockAction.BUY,
+        quantity="1,000",
+        now=datetime(2026, 1, 1),
+        rng=_rng(seed=1),
+    )
+    pending_short = await stock_db.settle_stock_operation(
+        symbol=BCAT_SYMBOL,
+        user_id=3,
+        user_name="carol",
+        requested_action=StockAction.SHORT,
+        quantity=str(BCAT_FLOAT_SHARES),
+        now=datetime(2026, 1, 1),
+        rng=_rng(seed=1),
+    )
+    monkeypatch.setattr(stock_db, "apply_ordered_wallet_deltas", original_apply)
+
+    blocked_long = await stock_db.settle_stock_operation(
+        symbol="THIN",
+        user_id=2,
+        user_name="bob",
+        requested_action=StockAction.BUY,
+        quantity="1",
+        now=datetime(2026, 1, 1),
+        rng=_rng(seed=1),
+    )
+    blocked_short = await stock_db.settle_stock_operation(
+        symbol=BCAT_SYMBOL,
+        user_id=4,
+        user_name="dave",
+        requested_action=StockAction.SHORT,
+        quantity="1",
+        now=datetime(2026, 1, 1),
+        rng=_rng(seed=1),
+    )
+    audits = {audit.symbol: audit for audit in await stock_db.list_stock_supply_audit()}
+
+    assert pending_long.status == StockOperationStatus.RECONCILE_REQUIRED
+    assert pending_short.status == StockOperationStatus.RECONCILE_REQUIRED
+    assert not blocked_long.success
+    assert "流通股" in blocked_long.error
+    assert not blocked_short.success
+    assert "借券" in blocked_short.error
+    assert audits["THIN"].long_shares == 1_000
+    assert audits["THIN"].available_long_shares == 0
+    assert audits["THIN"].non_final_operations == 1
+    assert audits[BCAT_SYMBOL].short_shares == BCAT_FLOAT_SHARES
+    assert audits[BCAT_SYMBOL].available_short_shares == 0
+    assert audits[BCAT_SYMBOL].non_final_operations == 1
+
+
 async def test_stock_cover_can_use_withheld_short_entry_value(
     stock_isolated_db: None, economy_isolated_db: None
 ) -> None:

--- a/tests/test_stock.py
+++ b/tests/test_stock.py
@@ -259,6 +259,7 @@ def test_stock_order_flow_pressure_scales_with_liquidity() -> None:
 def test_stock_execution_price_uses_order_size_and_liquidity() -> None:
     """Large orders execute away from the quote, bounded by the per-stock cap."""
     assert order_impact_bps(shares=0, liquidity_shares=10, max_impact_bps=1_000) == 0
+    assert order_impact_bps(shares=1, liquidity_shares=2, max_impact_bps=1) == 1
     assert order_impact_bps(shares=5, liquidity_shares=10, max_impact_bps=1_000) == 500
     assert order_impact_bps(shares=100, liquidity_shares=10, max_impact_bps=1_000) == 1_000
     assert (

--- a/tests/test_stock.py
+++ b/tests/test_stock.py
@@ -29,7 +29,9 @@ from discordbot.cogs._stock.market import (
     cash_floor,
     format_price,
     tick_boundary,
+    order_impact_bps,
     decay_news_sentiment,
+    execution_price_cents,
     pressure_from_order_flow,
     tick_boundaries_to_apply,
     calculate_next_price_cents,
@@ -162,6 +164,28 @@ async def _upsert_bcat_profile(
     )
 
 
+async def _upsert_illiquid_profile() -> StockProfileView:
+    """Creates a stock whose small orders visibly move execution price."""
+    return await stock_db.upsert_stock_profile(
+        profile=StockProfileUpsert(
+            symbol="THIN",
+            name="薄量測試股份有限公司",
+            category="測試",
+            price_cents=10_000,
+            total_shares=1_000,
+            float_shares=1_000,
+            base_volatility_bps=0,
+            volatility_amplifier_bps=0,
+            liquidity_shares=10,
+            fair_value_cents=10_000,
+            mean_reversion_bps=0,
+            max_tick_change_bps=1_000,
+            news_cadence_hours=8,
+        ),
+        now=datetime(2026, 1, 1),
+    )
+
+
 def test_stock_cash_rounding_and_price_format() -> None:
     """Prices are cent-based and cash conversion is explicit."""
     assert cash_ceil(cents=10_001) == 101
@@ -232,6 +256,33 @@ def test_stock_order_flow_pressure_scales_with_liquidity() -> None:
     assert pressure_from_order_flow(net_shares=1_000, liquidity_shares=0) == 0
 
 
+def test_stock_execution_price_uses_order_size_and_liquidity() -> None:
+    """Large orders execute away from the quote, bounded by the per-stock cap."""
+    assert order_impact_bps(shares=0, liquidity_shares=10, max_impact_bps=1_000) == 0
+    assert order_impact_bps(shares=5, liquidity_shares=10, max_impact_bps=1_000) == 500
+    assert order_impact_bps(shares=100, liquidity_shares=10, max_impact_bps=1_000) == 1_000
+    assert (
+        execution_price_cents(
+            reference_price_cents=10_000,
+            shares=10,
+            liquidity_shares=10,
+            max_impact_bps=1_000,
+            is_buy=True,
+        )
+        == 11_000
+    )
+    assert (
+        execution_price_cents(
+            reference_price_cents=10_000,
+            shares=10,
+            liquidity_shares=10,
+            max_impact_bps=1_000,
+            is_buy=False,
+        )
+        == 9_000
+    )
+
+
 def test_stock_order_flow_decay_preserves_small_trade_pressure() -> None:
     """Small trades retain fractional decay before aggregate pressure conversion."""
     at = datetime(2026, 1, 2, tzinfo=TAIWAN_TIMEZONE)
@@ -286,6 +337,9 @@ async def test_stock_profile_upsert_manages_database_company(stock_empty_db: Non
     assert profile.liquidity_shares == BCAT_LIQUIDITY_SHARES
     profiles = await stock_db.list_stock_profiles()
     assert tuple(profile.symbol for profile in profiles) == (BCAT_SYMBOL,)
+    audits = await stock_db.list_stock_supply_audit()
+    assert audits[0].available_long_shares == BCAT_FLOAT_SHARES
+    assert audits[0].available_short_shares == BCAT_FLOAT_SHARES
     async with stock_db.open_stock_session() as session:
         tick_count = await session.scalar(
             statement=select(stock_db.StockPriceTick).where(
@@ -875,10 +929,72 @@ async def test_stock_oversized_buy_defaults_to_affordable_all(
     assert detail.position.long_shares == 1
 
 
+async def test_stock_buy_clamps_to_remaining_float(
+    stock_isolated_db: None, economy_isolated_db: None
+) -> None:
+    """New long exposure cannot exceed the DB-managed floating share supply."""
+    await adjust_balance(user_id=1, name="alice", delta=100_000_000)
+
+    result = await stock_db.settle_stock_operation(
+        symbol=BCAT_SYMBOL,
+        user_id=1,
+        user_name="alice",
+        requested_action=StockAction.BUY,
+        quantity=f"{BCAT_FLOAT_SHARES + 10:,}",
+        now=datetime(2026, 1, 1),
+        rng=_rng(seed=1),
+    )
+
+    assert result.success
+    assert result.shares == BCAT_FLOAT_SHARES
+    detail = await stock_db.get_stock_detail(symbol=BCAT_SYMBOL, user_id=1)
+    assert detail.position.long_shares == BCAT_FLOAT_SHARES
+    audits = await stock_db.list_stock_supply_audit()
+    bcat_audit = next(audit for audit in audits if audit.symbol == BCAT_SYMBOL)
+    assert bcat_audit.available_long_shares == 0
+
+    blocked = await stock_db.settle_stock_operation(
+        symbol=BCAT_SYMBOL,
+        user_id=1,
+        user_name="alice",
+        requested_action=StockAction.BUY,
+        quantity="1",
+        now=datetime(2026, 1, 1),
+        rng=_rng(seed=1),
+    )
+
+    assert not blocked.success
+    assert "流通股" in blocked.error
+
+
+async def test_stock_large_buy_uses_execution_slippage(
+    stock_empty_db: None, economy_isolated_db: None
+) -> None:
+    """Buy-side settlement stores the execution price after liquidity impact."""
+    await _upsert_illiquid_profile()
+    await adjust_balance(user_id=1, name="alice", delta=2_000)
+
+    result = await stock_db.settle_stock_operation(
+        symbol="THIN",
+        user_id=1,
+        user_name="alice",
+        requested_action=StockAction.BUY,
+        quantity="10",
+        now=datetime(2026, 1, 1),
+        rng=_rng(seed=1),
+    )
+
+    assert result.success
+    assert result.price_cents == 11_000
+    assert result.legs[0].price_cents == 11_000
+    assert result.legs[0].wallet_delta == -1_100
+    assert result.balance_after == 900
+
+
 async def test_stock_zero_affordable_buy_leaves_stock_untouched(
     stock_isolated_db: None, economy_isolated_db: None
 ) -> None:
-    """Oversized numeric requests still fail when the executable ALL quantity is zero."""
+    """Oversized numeric requests still fail with the real root cause when nothing is executable."""
     result = await stock_db.settle_stock_operation(
         symbol=BCAT_SYMBOL,
         user_id=1,
@@ -890,7 +1006,7 @@ async def test_stock_zero_affordable_buy_leaves_stock_untouched(
     )
 
     assert not result.success
-    assert "股數必須是正整數" in result.error
+    assert "餘額不足" in result.error
     detail = await stock_db.get_stock_detail(symbol=BCAT_SYMBOL, user_id=1)
     assert detail.position.long_shares == 0
     async with stock_db.open_stock_session() as session:
@@ -987,6 +1103,43 @@ async def test_stock_oversized_short_defaults_to_affordable_all(
     assert result.shares == 1
     assert result.balance_after == 0
     assert result.position.short_shares == 1
+
+
+async def test_stock_short_clamps_to_available_borrow(
+    stock_isolated_db: None, economy_isolated_db: None
+) -> None:
+    """New short exposure cannot exceed the DB-managed floating share supply."""
+    await adjust_balance(user_id=1, name="alice", delta=100_000_000)
+
+    result = await stock_db.settle_stock_operation(
+        symbol=BCAT_SYMBOL,
+        user_id=1,
+        user_name="alice",
+        requested_action=StockAction.SHORT,
+        quantity=str(BCAT_FLOAT_SHARES + 10),
+        now=datetime(2026, 1, 1),
+        rng=_rng(seed=1),
+    )
+
+    assert result.success
+    assert result.shares == BCAT_FLOAT_SHARES
+    assert result.position.short_shares == BCAT_FLOAT_SHARES
+    audits = await stock_db.list_stock_supply_audit()
+    bcat_audit = next(audit for audit in audits if audit.symbol == BCAT_SYMBOL)
+    assert bcat_audit.available_short_shares == 0
+
+    blocked = await stock_db.settle_stock_operation(
+        symbol=BCAT_SYMBOL,
+        user_id=1,
+        user_name="alice",
+        requested_action=StockAction.SHORT,
+        quantity="1",
+        now=datetime(2026, 1, 1),
+        rng=_rng(seed=1),
+    )
+
+    assert not blocked.success
+    assert "借券" in blocked.error
 
 
 async def test_stock_cover_can_use_withheld_short_entry_value(

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -1,10 +1,18 @@
 """Tests for Threads URL parsing and media extraction."""
 
+import json
 from pathlib import Path
 
 import pytest
 
-from discordbot.utils.threads import Post, ThreadData, ThreadItem, ThreadsOutput, ThreadsDownloader
+from discordbot.utils.threads import (
+    Post,
+    ThreadData,
+    ThreadItem,
+    ThreadsURL,
+    ThreadsOutput,
+    ThreadsDownloader,
+)
 
 
 @pytest.fixture
@@ -66,6 +74,67 @@ def test_threads_output_mutable_defaults_are_isolated(tmp_path: Path) -> None:
     assert second.video_paths == []
 
 
+def _thread_post_payload(
+    code: str, username: str, text: str, reply_to_username: str = ""
+) -> dict[str, object]:
+    """Returns a minimal Threads post payload with parser-relevant fields."""
+    return {
+        "post": {
+            "code": code,
+            "caption": {"text": text},
+            "user": {
+                "username": username,
+                "profile_pic_url": f"https://cdn.example/{username}.jpg",
+            },
+            "image_versions2": {"candidates": [{"url": f"https://cdn.example/{code}.jpg"}]},
+            "text_post_app_info": {
+                "direct_reply_count": 1,
+                "repost_count": 2,
+                "quote_count": 3,
+                "reshare_count": 4,
+                "is_reply": bool(reply_to_username),
+                "reply_to_author": (
+                    {"username": reply_to_username, "profile_pic_url": ""}
+                    if reply_to_username
+                    else None
+                ),
+            },
+            "like_count": 5,
+            "taken_at": 1_735_689_600,
+        }
+    }
+
+
+def _thread_html(post_code: str) -> str:
+    """Builds deterministic Threads SJS HTML for parser tests."""
+    payload = {
+        "require": [
+            {
+                "__bbox": {
+                    "result": {
+                        "data": {
+                            "thread_items": [
+                                _thread_post_payload(
+                                    code="ROOT", username="root_author", text="Root post"
+                                ),
+                                _thread_post_payload(
+                                    code=post_code,
+                                    username="target_author",
+                                    text=f"Target post {post_code}",
+                                    reply_to_username="root_author",
+                                ),
+                            ]
+                        }
+                    }
+                }
+            }
+        ]
+    }
+    return (
+        f'<html><script type="application/json" data-sjs>{json.dumps(obj=payload)}</script></html>'
+    )
+
+
 @pytest.mark.parametrize(
     "url",
     [
@@ -79,11 +148,22 @@ def test_threads_output_mutable_defaults_are_isolated(tmp_path: Path) -> None:
         "https://www.threads.com/@babe.0530/post/DXyk3qXGT6o",
     ],
 )
-def test_parse(downloader: ThreadsDownloader, url: str) -> None:
+def test_parse(downloader: ThreadsDownloader, url: str, monkeypatch: pytest.MonkeyPatch) -> None:
     """Verifies that parsing valid Threads URLs returns expected post data."""
+    threads_url = ThreadsURL(raw_url=url)
+    fetched_urls: list[str] = []
+
+    def fake_fetch_html(self: ThreadsDownloader, url: str) -> str:
+        """Returns deterministic HTML for the requested Threads URL."""
+        fetched_urls.append(url)
+        return _thread_html(post_code=threads_url.post_code)
+
+    monkeypatch.setattr(target=ThreadsDownloader, name="_fetch_html", value=fake_fetch_html)
+
     with downloader.parse(url=url) as results:
         assert results, "should yield at least one post"
         target = results[-1]
         assert target.text or target.image_urls or target.video_urls, "post should have content"
         assert target.author_name, "author_name should not be empty"
         assert target.taken_at is not None, "taken_at should not be None"
+    assert fetched_urls == [threads_url.clean_url]


### PR DESCRIPTION
## Summary

- Cap new stock long and short exposure against DB-managed float supply while preserving sell and cover flows.
- Apply liquidity-based execution slippage and display per-leg execution prices.
- Add a stock supply audit command plus docs and tests for the new settlement behavior.

## Tests

- `uv run pre-commit run -a`
- `uv run pytest tests/test_stock.py tests/test_stock_views.py --no-cov`
- `uv run pytest`