### PR TITLE
refactor: code quality pass and DB-backed Dragon Gate balance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ make gen-docs                    # regenerate docs/ from sources
 - Blackjack player losses clamp at balance 0. `apply_round_settlement` mirrors only the actual collected player debit into the bot's house ledger; full positive payouts still mirror the dealer-paid delta.
 - Dragon Gate is backed by the shared `jackpot_pool` row `game_id="dragon_gate"` in `data/global_state.db`. Jackpot money columns also use decimal-string storage. Do not route it through the house ledger.
 - Dragon Gate ante, losses, wins, leave refunds, and timeout refunds settle through jackpot helpers. Losses clamp at balance 0.
+- Tunable game balance values live in `game_setting` (also in `data/global_state.db`), keyed by `(game_id, setting_key)`. Defaults seed on schema bootstrap; Dragon Gate ante / min_bet load through `cogs/_games/settings.py` getters with a process cache, with `cogs/_games/dragon_gate.py` module constants kept only as offline / test fallback. Adjust with `scripts/manage_game_setting.py set <game_id> <setting_key> <int>`.
 - On Dragon Gate leave or timeout, positive per-player running delta is refunded into the pool unless the whole-pool win branch already cleared the jackpot.
 - Interactive game and lobby views use 180-second idle timeouts. Terminal public messages schedule deletion 180 seconds after settlement or send through `utils.message_cleanup`; do not add cog-local delete/forget loops.
 - `build_dealer_talk_embed` is the dedicated dealer-talk embed. In-progress and final game messages may send multiple embeds in order `[dealer talk, main, history?]`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,12 +19,12 @@ nav:
               - _auto_unmute:
                   - prompts: Reference/discordbot/cogs/_auto_unmute/prompts.md
               - _economy:
+                  - boards: Reference/discordbot/cogs/_economy/boards.md
                   - database: Reference/discordbot/cogs/_economy/database.md
                   - presentation: Reference/discordbot/cogs/_economy/presentation.md
               - _games:
                   - blackjack: Reference/discordbot/cogs/_games/blackjack.md
                   - blackjack_views: Reference/discordbot/cogs/_games/blackjack_views.md
-                  - cleanup: Reference/discordbot/cogs/_games/cleanup.md
                   - dealer: Reference/discordbot/cogs/_games/dealer.md
                   - dragon_gate: Reference/discordbot/cogs/_games/dragon_gate.md
                   - dragon_gate_views: Reference/discordbot/cogs/_games/dragon_gate_views.md
@@ -32,6 +32,7 @@ nav:
                   - lobby: Reference/discordbot/cogs/_games/lobby.md
                   - presentation: Reference/discordbot/cogs/_games/presentation.md
                   - prompts: Reference/discordbot/cogs/_games/prompts.md
+                  - settings: Reference/discordbot/cogs/_games/settings.md
                   - settlement: Reference/discordbot/cogs/_games/settlement.md
                   - wagers: Reference/discordbot/cogs/_games/wagers.md
               - _gen_reply:
@@ -49,6 +50,7 @@ nav:
                   - market: Reference/discordbot/cogs/_stock/market.md
                   - news: Reference/discordbot/cogs/_stock/news.md
                   - presentation: Reference/discordbot/cogs/_stock/presentation.md
+                  - prompts: Reference/discordbot/cogs/_stock/prompts.md
                   - views: Reference/discordbot/cogs/_stock/views.md
               - auto_unmute: Reference/discordbot/cogs/auto_unmute.md
               - economy: Reference/discordbot/cogs/economy.md
@@ -72,7 +74,11 @@ nav:
               - avatars: Reference/discordbot/utils/avatars.md
               - downloader: Reference/discordbot/utils/downloader.md
               - images: Reference/discordbot/utils/images.md
+              - message_cleanup: Reference/discordbot/utils/message_cleanup.md
               - model_pricing: Reference/discordbot/utils/model_pricing.md
+              - number_text: Reference/discordbot/utils/number_text.md
+              - pillow_text: Reference/discordbot/utils/pillow_text.md
+              - stored_integer: Reference/discordbot/utils/stored_integer.md
               - threads: Reference/discordbot/utils/threads.md
           - cli: Reference/discordbot/cli.md
   - Scripts:
@@ -82,6 +88,7 @@ nav:
       - image_dev: Scripts/image_dev.md
       - manage_admin: Scripts/manage_admin.md
       - manage_central_banker: Scripts/manage_central_banker.md
+      - manage_game_setting: Scripts/manage_game_setting.md
       - manage_stock_company: Scripts/manage_stock_company.md
       - manage_stock_reconciliation: Scripts/manage_stock_reconciliation.md
       - modify_balance: Scripts/modify_balance.md

--- a/scripts/manage_game_setting.py
+++ b/scripts/manage_game_setting.py
@@ -1,0 +1,86 @@
+"""Manage tunable game balance settings stored in `data/global_state.db`.
+
+Usage::
+
+    uv run python scripts/manage_game_setting.py list
+    uv run python scripts/manage_game_setting.py list dragon_gate
+    uv run python scripts/manage_game_setting.py get dragon_gate ante
+    uv run python scripts/manage_game_setting.py set dragon_gate ante 6000
+"""
+
+import asyncio
+import argparse
+from collections.abc import Sequence
+
+from rich.console import Console
+
+from discordbot.cogs._games.settings import (
+    get_game_setting,
+    set_game_setting,
+    list_game_settings,
+)
+
+console = Console()
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parses CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Read or write rows in the `game_setting` table of data/global_state.db."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = subparsers.add_parser(name="list", help="List persisted game settings.")
+    list_parser.add_argument(
+        "game_id", nargs="?", default=None, help="Optional game id filter (e.g. dragon_gate)."
+    )
+
+    get_parser = subparsers.add_parser(name="get", help="Print one persisted setting.")
+    get_parser.add_argument("game_id", help="Game id (e.g. dragon_gate).")
+    get_parser.add_argument("setting_key", help="Setting key (e.g. ante).")
+
+    set_parser = subparsers.add_parser(name="set", help="Insert or update one setting.")
+    set_parser.add_argument("game_id", help="Game id (e.g. dragon_gate).")
+    set_parser.add_argument("setting_key", help="Setting key (e.g. ante).")
+    set_parser.add_argument("value", type=int, help="Integer value to persist.")
+    return parser.parse_args(args=argv)
+
+
+def _print_rows(rows: tuple[tuple[str, str, int], ...]) -> None:
+    """Prints persisted game settings to the console."""
+    console.print(f"[bold]Game settings[/bold]: {len(rows)}")
+    for game_id, setting_key, value in rows:
+        console.print(f"{game_id}.{setting_key} = {value:,}")
+
+
+async def _async_main(argv: Sequence[str] | None = None) -> None:
+    """Runs the CLI."""
+    args = _parse_args(argv=argv)
+    if args.command == "list":
+        rows = await list_game_settings(game_id=args.game_id)
+        _print_rows(rows=rows)
+    elif args.command == "get":
+        value = await get_game_setting(
+            game_id=args.game_id, setting_key=args.setting_key, default=0
+        )
+        console.print(f"{args.game_id}.{args.setting_key} = {value:,}")
+    else:
+        await set_game_setting(
+            game_id=args.game_id, setting_key=args.setting_key, value=args.value
+        )
+        console.print(
+            f"[bold]Updated[/bold] {args.game_id}.{args.setting_key} = {args.value:,}"
+        )
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Runs the game setting management CLI.
+
+    Args:
+        argv (Sequence[str] | None): Optional argument sequence to parse instead of `sys.argv`.
+    """
+    asyncio.run(main=_async_main(argv=argv))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/discordbot/cogs/_economy/boards.py
+++ b/src/discordbot/cogs/_economy/boards.py
@@ -6,11 +6,18 @@ from typing import Final, TypedDict
 from functools import cache
 from collections.abc import Sequence
 
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageDraw
 from pydantic import BaseModel, ConfigDict
 
 from discordbot.typings.economy import LeaderboardEntry, LossLeaderboardEntry
 from discordbot.utils.number_text import compact_amount
+from discordbot.utils.pillow_text import (
+    BoardFont,
+    fit_text,
+    load_font,
+    draw_text_right,
+    draw_text_center,
+)
 from discordbot.cogs._economy.presentation import CURRENCY_NAME
 
 BALANCE_LEADERBOARD_BOARD_FILENAME = "economy_leaderboard.png"
@@ -34,29 +41,16 @@ _NAME_X = 128
 _AMOUNT_RIGHT = 908
 _NAME_MAX_WIDTH = 520
 _BOARD_IMAGE_CACHE_TTL_SECONDS: Final[float] = 5.0
-_REGULAR_FONT_CANDIDATES = (
-    "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
-    "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
-    "NotoSansCJK-Regular.ttc",
-    "DejaVuSans.ttf",
-)
-_BOLD_FONT_CANDIDATES = (
-    "/usr/share/fonts/opentype/noto/NotoSansCJK-Bold.ttc",
-    "/usr/share/fonts/truetype/noto/NotoSansCJK-Bold.ttc",
-    "NotoSansCJK-Bold.ttc",
-    "DejaVuSans-Bold.ttf",
-)
-type _BoardFont = ImageFont.ImageFont | ImageFont.FreeTypeFont
 
 
 class _BoardFonts(TypedDict):
     """Font set used by economy board images."""
 
-    title: _BoardFont
-    header: _BoardFont
-    rank: _BoardFont
-    body: _BoardFont
-    small: _BoardFont
+    title: BoardFont
+    header: BoardFont
+    rank: BoardFont
+    body: BoardFont
+    small: BoardFont
 
 
 class _RankingBoardSpec(BaseModel):
@@ -173,23 +167,12 @@ def _render_ranking_board_image(spec: _RankingBoardSpec) -> bytes:
 def _board_fonts() -> _BoardFonts:
     """Loads CJK-capable fonts for ranking boards."""
     return {
-        "title": _load_font(size=34, bold=True),
-        "header": _load_font(size=19, bold=True),
-        "rank": _load_font(size=26, bold=True),
-        "body": _load_font(size=24, bold=False),
-        "small": _load_font(size=16, bold=False),
+        "title": load_font(size=34, bold=True),
+        "header": load_font(size=19, bold=True),
+        "rank": load_font(size=26, bold=True),
+        "body": load_font(size=24, bold=False),
+        "small": load_font(size=16, bold=False),
     }
-
-
-def _load_font(size: int, bold: bool) -> _BoardFont:
-    """Loads a CJK-capable font when available."""
-    candidates = _BOLD_FONT_CANDIDATES if bold else _REGULAR_FONT_CANDIDATES
-    for candidate in candidates:
-        try:
-            return ImageFont.truetype(font=candidate, size=size)
-        except OSError:
-            continue
-    return ImageFont.load_default()
 
 
 def _draw_header(
@@ -211,7 +194,7 @@ def _draw_header(
         outline=accent,
         width=2,
     )
-    _draw_text_center(
+    draw_text_center(
         draw=draw,
         text="PUBLIC",
         center=(_BOARD_WIDTH - 96, y + 23),
@@ -235,7 +218,7 @@ def _draw_table_header(
     baseline = y + 12
     draw.text(xy=(_RANK_X, baseline), text="排名", font=fonts["header"], fill=_MUTED)
     draw.text(xy=(_NAME_X, baseline), text="玩家", font=fonts["header"], fill=_MUTED)
-    _draw_text_right(
+    draw_text_right(
         draw=draw,
         text=amount_header,
         xy=(_AMOUNT_RIGHT, baseline),
@@ -266,11 +249,11 @@ def _draw_rank_row(
         font=fonts["rank"],
         fill=spec.accent if position <= 3 else _MUTED,
     )
-    display_name = _fit_text(
+    display_name = fit_text(
         draw=draw, text=row.name or "未知玩家", font=fonts["body"], max_width=_NAME_MAX_WIDTH
     )
     draw.text(xy=(_NAME_X, y + 13), text=display_name, font=fonts["body"], fill=_TEXT)
-    _draw_text_right(
+    draw_text_right(
         draw=draw,
         text=_ranking_amount_text(spec=spec, amount=row.amount),
         xy=(_AMOUNT_RIGHT, y + 13),
@@ -293,58 +276,6 @@ def _ranking_amount_text(spec: _RankingBoardSpec, amount: int) -> str:
     if not spec.amount_label:
         return amount_text
     return f"{spec.amount_label} {amount_text}"
-
-
-def _draw_text_right(
-    draw: ImageDraw.ImageDraw,
-    text: str,
-    xy: tuple[int, int],
-    font: _BoardFont,
-    fill: tuple[int, int, int],
-) -> None:
-    """Draws text with its right edge anchored at x."""
-    right, y = xy
-    bbox = draw.textbbox(xy=(0, 0), text=text, font=font)
-    draw.text(xy=(right - (bbox[2] - bbox[0]), y), text=text, font=font, fill=fill)
-
-
-def _draw_text_center(
-    draw: ImageDraw.ImageDraw,
-    text: str,
-    center: tuple[int, int],
-    font: _BoardFont,
-    fill: tuple[int, int, int],
-) -> None:
-    """Draws text centered around a point."""
-    x, y = center
-    bbox = draw.textbbox(xy=(0, 0), text=text, font=font)
-    width = bbox[2] - bbox[0]
-    draw.text(xy=(x - width // 2, y), text=text, font=font, fill=fill)
-
-
-def _fit_text(draw: ImageDraw.ImageDraw, text: str, font: _BoardFont, max_width: int) -> str:
-    """Truncates text to fit the requested pixel width."""
-    if _text_width(draw=draw, text=text, font=font) <= max_width:
-        return text
-    suffix = "..."
-    low = 0
-    high = len(text)
-    while low < high:
-        midpoint = (low + high + 1) // 2
-        candidate = f"{text[:midpoint]}{suffix}"
-        if _text_width(draw=draw, text=candidate, font=font) <= max_width:
-            low = midpoint
-        else:
-            high = midpoint - 1
-    if low == 0:
-        return suffix
-    return f"{text[:low]}{suffix}"
-
-
-def _text_width(draw: ImageDraw.ImageDraw, text: str, font: _BoardFont) -> int:
-    """Returns rendered text width."""
-    bbox = draw.textbbox(xy=(0, 0), text=text, font=font)
-    return bbox[2] - bbox[0]
 
 
 def _rank_text(position: int) -> str:

--- a/src/discordbot/cogs/_economy/database.py
+++ b/src/discordbot/cogs/_economy/database.py
@@ -381,6 +381,31 @@ class LoanContract(Base):
     )
 
 
+class GameSetting(GlobalStateBase):
+    """Tunable game balance values that may be adjusted without redeploy.
+
+    One row per `(game_id, setting_key)`. Stores integer setting values
+    via `StoredInteger` so persisted decimals stay consistent with
+    economy / jackpot tables. Seeded with defaults on first schema bootstrap;
+    later edits via `scripts/manage_game_setting.py` persist across restarts.
+
+    Attributes:
+        game_id: Stable game identifier (e.g. `"dragon_gate"`).
+        setting_key: Setting identifier within the game (e.g. `"ante"`).
+        setting_value: Tunable integer value used by the rules engine.
+        updated_at: Taiwan-local timestamp of the last write.
+    """
+
+    __tablename__ = "game_setting"
+
+    game_id: Mapped[str] = mapped_column(String(length=32), primary_key=True)
+    setting_key: Mapped[str] = mapped_column(String(length=64), primary_key=True)
+    setting_value: Mapped[int] = mapped_column(StoredInteger(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_database_now, onupdate=_database_now
+    )
+
+
 class JackpotPool(GlobalStateBase):
     """Per-game cumulative jackpot shared across every table of that game.
 
@@ -422,6 +447,14 @@ class JackpotPool(GlobalStateBase):
 # it, so /house P&L stays unaffected by the donation. Seeded pools are also
 # topped back up to this amount whenever they are drained.
 _JACKPOT_SEEDS: Final[tuple[tuple[str, int], ...]] = (("dragon_gate", 100_000),)
+
+# Default values seeded into `game_setting` on first schema bootstrap. INSERT
+# OR IGNORE: admin-edited rows survive subsequent restarts; only missing rows
+# get the default. Read via `discordbot.cogs._games.settings.get_game_setting`.
+_GAME_SETTING_SEEDS: Final[tuple[tuple[str, str, int], ...]] = (
+    ("dragon_gate", "ante", 5_000),
+    ("dragon_gate", "min_bet", 10_000),
+)
 
 
 def _jackpot_seed_amount(game_id: str) -> int:
@@ -553,6 +586,17 @@ async def _ensure_global_state_schema() -> None:
                         updated_at=_database_now(),
                     )
                     .on_conflict_do_nothing(index_elements=["game_id"])
+                )
+            for setting_game_id, setting_key, setting_value in _GAME_SETTING_SEEDS:
+                await conn.execute(
+                    statement=insert(GameSetting)
+                    .values(
+                        game_id=setting_game_id,
+                        setting_key=setting_key,
+                        setting_value=_stored_int_to_text(value=setting_value),
+                        updated_at=_database_now(),
+                    )
+                    .on_conflict_do_nothing(index_elements=["game_id", "setting_key"])
                 )
         _global_state_schema_ready_for = _global_state_engine
 

--- a/src/discordbot/cogs/_games/blackjack_views.py
+++ b/src/discordbot/cogs/_games/blackjack_views.py
@@ -35,6 +35,9 @@ from discordbot.cogs._games.blackjack import (
     is_five_card_win,
     is_five_card_twenty_one,
 )
+from discordbot.utils.message_cleanup import (
+    PUBLIC_MESSAGE_TTL_SECONDS as BLACKJACK_ACTION_TIMEOUT_SECONDS,
+)
 from discordbot.utils.message_cleanup import schedule_public_message_delete
 from discordbot.cogs._games.settlement import (
     settle_blackjack_player,
@@ -74,7 +77,6 @@ if TYPE_CHECKING:
     from discordbot.cogs._games.dealer import DealerAI
 
 MAX_BLACKJACK_PLAYERS: Final[int] = 5
-BLACKJACK_ACTION_TIMEOUT_SECONDS: Final[int] = 180
 MAX_DEALER_DECISION_STEPS: Final[int] = 8
 FINAL_EDIT_TIMEOUT_SECONDS: Final[float] = 8.0
 PEEK_REVEAL_DELAY_SECONDS: Final[float] = 1.6

--- a/src/discordbot/cogs/_games/dragon_gate.py
+++ b/src/discordbot/cogs/_games/dragon_gate.py
@@ -136,12 +136,18 @@ class DragonGateRound(BaseModel):
     layer reads this on withdraw / timeout to decide whether to apply the
     "逆贏不拿" refund (clawing winnings back into the jackpot when a
     player leaves while ahead).
+
+    `min_bet` lets the caller override the floor of the legal bet range so
+    runtime tuning (DB-backed game_setting) does not require editing the
+    rules module; defaults to the module-level `MIN_BET` so tests stay
+    deterministic without DB.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     rng: Random
     participants: list[GameParticipant]
+    min_bet: int = MIN_BET
     current_player_index: int = 0
     turn_number: int = 0
     active_turn: DragonGateTurn | None = None
@@ -152,12 +158,12 @@ class DragonGateRound(BaseModel):
 
     @classmethod
     def from_participants(
-        cls, rng: Random, participants: list[GameParticipant]
+        cls, rng: Random, participants: list[GameParticipant], min_bet: int = MIN_BET
     ) -> "DragonGateRound":
         """Builds and starts a 射龍門 round from lobby participants."""
         if not participants:
             raise ValueError("At least one participant is required")
-        round_state = cls(rng=rng, participants=participants)
+        round_state = cls(rng=rng, participants=participants, min_bet=min_bet)
         round_state.player_deltas = {participant.user_id: 0 for participant in participants}
         round_state._deal_next_turn()
         return round_state
@@ -166,7 +172,7 @@ class DragonGateRound(BaseModel):
         """Returns the minimum legal bet given the live jackpot snapshot."""
         if jackpot <= 0:
             return 0
-        return min(MIN_BET, jackpot)
+        return min(self.min_bet, jackpot)
 
     def current_max_bet(self, jackpot: int) -> int:
         """Returns the maximum legal bet given the live jackpot snapshot."""

--- a/src/discordbot/cogs/_games/dragon_gate_views.py
+++ b/src/discordbot/cogs/_games/dragon_gate_views.py
@@ -19,6 +19,9 @@ from discordbot.cogs._games.lobby import (
 )
 from discordbot.utils.number_text import compact_amount
 from discordbot.cogs._games.wagers import parse_wager_amount
+from discordbot.utils.message_cleanup import (
+    PUBLIC_MESSAGE_TTL_SECONDS as DRAGON_GATE_ACTION_TIMEOUT_SECONDS,
+)
 from discordbot.utils.message_cleanup import schedule_public_message_delete
 from discordbot.cogs._economy.database import (
     get_balance,
@@ -26,7 +29,6 @@ from discordbot.cogs._economy.database import (
     apply_jackpot_settlement,
 )
 from discordbot.cogs._games.dragon_gate import (
-    ANTE,
     GAME_ID,
     DragonGateTurn,
     DragonGateError,
@@ -69,7 +71,6 @@ if TYPE_CHECKING:
     from discordbot.typings.economy import JackpotSnapshot
     from discordbot.cogs._games.dealer import DealerAI
 
-DRAGON_GATE_ACTION_TIMEOUT_SECONDS = 180
 DRAGON_GATE_VISIBLE_PLAYER_LINES = 20
 DRAGON_GATE_FINAL_EDIT_TIMEOUT_SECONDS: Final[float] = 8.0
 
@@ -235,6 +236,7 @@ def build_dragon_gate_lobby_embed(
     owner: GameParticipant,
     participants: list[GameParticipant],
     jackpot: int,
+    ante: int,
     status: str = "等待玩家加入",
 ) -> Embed:
     """Builds the lobby embed shown before a 射龍門 table starts."""
@@ -253,7 +255,7 @@ def build_dragon_gate_lobby_embed(
     )
     if owner.avatar_url:
         embed.set_thumbnail(url=owner.avatar_url)
-    embed.set_footer(text=f"入場費 {currency_text(amount=ANTE, compact=True)} 進彩金池")
+    embed.set_footer(text=f"入場費 {currency_text(amount=ante, compact=True)} 進彩金池")
     return embed
 
 
@@ -352,7 +354,6 @@ class DragonGateLobbyView(BaseJackpotLobbyView):
     """Join / leave / start lobby for a 射龍門 game session."""
 
     game_id = GAME_ID
-    ante = ANTE
 
     def __init__(  # noqa: PLR0913 -- lobby owns all table dependencies
         self,
@@ -364,6 +365,8 @@ class DragonGateLobbyView(BaseJackpotLobbyView):
         prepare_participant: PrepareParticipant,
         refresh_participants: RefreshParticipants,
         initial_jackpot: int,
+        ante: int,
+        min_bet: int,
         initial_jackpot_generation: int | None = None,
     ) -> None:
         """Initializes a 射龍門 lobby with the current jackpot snapshot."""
@@ -376,9 +379,11 @@ class DragonGateLobbyView(BaseJackpotLobbyView):
             prepare_participant=prepare_participant,
             refresh_participants=refresh_participants,
             initial_jackpot=initial_jackpot,
+            ante=ante,
             timeout=DRAGON_GATE_ACTION_TIMEOUT_SECONDS,
             initial_jackpot_generation=initial_jackpot_generation,
         )
+        self._min_bet = min_bet
 
     def _build_lobby_embed(self, status: str = "等待玩家加入") -> Embed:
         """Builds the 射龍門 lobby embed from participants and jackpot state."""
@@ -387,6 +392,7 @@ class DragonGateLobbyView(BaseJackpotLobbyView):
             participants=self.participants,
             jackpot=self._jackpot_snapshot,
             status=status,
+            ante=self.ante,
         )
 
     async def _start_game_after_antes(
@@ -394,14 +400,14 @@ class DragonGateLobbyView(BaseJackpotLobbyView):
     ) -> None:
         """Starts the active table after all lobby antes have been charged."""
         round_state = DragonGateRound.from_participants(
-            rng=self.rng, participants=self.participants
+            rng=self.rng, participants=self.participants, min_bet=self._min_bet
         )
         table_balance = sum(participant.balance_at_start for participant in self.participants)
         dealer_line = await self.dealer.taunt_bet(
             author_name=self.owner.account_name,
             player_name=f"{len(self.participants)} 位玩家",
             balance_at_start=table_balance,
-            bet=ANTE * len(self.participants),
+            bet=self.ante * len(self.participants),
             game="dragon_gate",
         )
         view = DragonGateView(

--- a/src/discordbot/cogs/_games/lobby.py
+++ b/src/discordbot/cogs/_games/lobby.py
@@ -213,14 +213,13 @@ class BaseJackpotLobbyView(BaseGameLobbyView):
 
     On Start, each participant is charged `ante` into the jackpot via
     one `apply_jackpot_settlement_batch` call before the table begins.
-    Subclasses must declare `game_id` / `ante` and override
-    `_start_game_after_antes`.
+    Subclasses must declare `game_id`, pass an `ante` into `__init__`,
+    and override `_start_game_after_antes`.
     """
 
     game_id: ClassVar[str]
-    ante: ClassVar[int]
 
-    def __init__(  # noqa: PLR0913 -- jackpot lobby adds initial_jackpot on top of base deps
+    def __init__(  # noqa: PLR0913 -- jackpot lobby adds initial_jackpot + ante on top of base deps
         self,
         owner: GameParticipant,
         rng: Random,
@@ -230,6 +229,7 @@ class BaseJackpotLobbyView(BaseGameLobbyView):
         prepare_participant: PrepareParticipant,
         refresh_participants: RefreshParticipants,
         initial_jackpot: int,
+        ante: int,
         timeout: int,
         initial_jackpot_generation: int | None = None,
     ) -> None:
@@ -244,6 +244,7 @@ class BaseJackpotLobbyView(BaseGameLobbyView):
             refresh_participants=refresh_participants,
             timeout=timeout,
         )
+        self.ante = ante
         self._jackpot_snapshot = initial_jackpot
         self._jackpot_generation = initial_jackpot_generation
 

--- a/src/discordbot/cogs/_games/settings.py
+++ b/src/discordbot/cogs/_games/settings.py
@@ -1,0 +1,133 @@
+"""DB-backed game balance settings with a small process cache.
+
+Default seed values live in `_economy.database._GAME_SETTING_SEEDS` and are
+inserted on first schema bootstrap. Admin edits via
+`scripts/manage_game_setting.py` persist across restarts; this module reads
+them once per process and caches the result. Rules modules keep
+their module-level `_DEFAULT_*` constants as fallback when the DB row is
+missing or unreadable, so tests and offline tooling stay deterministic.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+import logfire
+from sqlalchemy import select
+
+from discordbot.cogs._games.dragon_gate import ANTE as DRAGON_GATE_DEFAULT_ANTE
+from discordbot.cogs._games.dragon_gate import GAME_ID as DRAGON_GATE_GAME_ID
+from discordbot.cogs._games.dragon_gate import MIN_BET as DRAGON_GATE_DEFAULT_MIN_BET
+
+_DRAGON_GATE_ANTE_KEY: Final[str] = "ante"
+_DRAGON_GATE_MIN_BET_KEY: Final[str] = "min_bet"
+
+_setting_cache: dict[tuple[str, str], int] = {}
+
+
+def invalidate_game_setting_cache() -> None:
+    """Clears the process-local game setting cache."""
+    _setting_cache.clear()
+
+
+async def get_game_setting(game_id: str, setting_key: str, default: int) -> int:
+    """Returns the persisted value for one setting, with a process cache."""
+    cache_key = (game_id, setting_key)
+    cached = _setting_cache.get(cache_key)
+    if cached is not None:
+        return cached
+    value = await _read_game_setting(
+        game_id=game_id, setting_key=setting_key, default=default
+    )
+    _setting_cache[cache_key] = value
+    return value
+
+
+async def set_game_setting(game_id: str, setting_key: str, value: int) -> None:
+    """Persists a setting value and refreshes the process cache."""
+    from discordbot.cogs._economy.database import (
+        GameSetting,
+        _ensure_global_state_schema,
+        open_global_state_session,
+    )
+
+    await _ensure_global_state_schema()
+    async with open_global_state_session() as session:
+        existing = await session.get(
+            entity=GameSetting, ident={"game_id": game_id, "setting_key": setting_key}
+        )
+        if existing is None:
+            session.add(
+                instance=GameSetting(
+                    game_id=game_id, setting_key=setting_key, setting_value=value
+                )
+            )
+        else:
+            existing.setting_value = value
+        await session.commit()
+    _setting_cache[(game_id, setting_key)] = value
+
+
+async def list_game_settings(game_id: str | None = None) -> tuple[tuple[str, str, int], ...]:
+    """Lists persisted settings, optionally filtered by game id."""
+    from discordbot.cogs._economy.database import (
+        GameSetting,
+        _ensure_global_state_schema,
+        open_global_state_session,
+    )
+
+    await _ensure_global_state_schema()
+    async with open_global_state_session() as session:
+        statement = select(
+            GameSetting.game_id, GameSetting.setting_key, GameSetting.setting_value
+        ).order_by(GameSetting.game_id.asc(), GameSetting.setting_key.asc())
+        if game_id is not None:
+            statement = statement.where(GameSetting.game_id == game_id)
+        result = await session.execute(statement=statement)
+        return tuple((row[0], row[1], row[2]) for row in result.all())
+
+
+async def get_dragon_gate_ante() -> int:
+    """Returns the Dragon Gate ante in points."""
+    return await get_game_setting(
+        game_id=DRAGON_GATE_GAME_ID,
+        setting_key=_DRAGON_GATE_ANTE_KEY,
+        default=DRAGON_GATE_DEFAULT_ANTE,
+    )
+
+
+async def get_dragon_gate_min_bet() -> int:
+    """Returns the Dragon Gate minimum bet in points."""
+    return await get_game_setting(
+        game_id=DRAGON_GATE_GAME_ID,
+        setting_key=_DRAGON_GATE_MIN_BET_KEY,
+        default=DRAGON_GATE_DEFAULT_MIN_BET,
+    )
+
+
+async def _read_game_setting(game_id: str, setting_key: str, default: int) -> int:
+    """Reads one setting row, returning `default` on DB error or missing row."""
+    from discordbot.cogs._economy.database import (
+        GameSetting,
+        _ensure_global_state_schema,
+        open_global_state_session,
+    )
+
+    try:
+        await _ensure_global_state_schema()
+        async with open_global_state_session() as session:
+            row = await session.get(
+                entity=GameSetting, ident={"game_id": game_id, "setting_key": setting_key}
+            )
+            if row is None:
+                return default
+            return row.setting_value
+    except Exception:
+        logfire.warn(
+            "Failed to read game setting; falling back to default",
+            game_id=game_id,
+            setting_key=setting_key,
+            default=default,
+            _exc_info=True,
+        )
+        return default

--- a/src/discordbot/cogs/_maplestory/service.py
+++ b/src/discordbot/cogs/_maplestory/service.py
@@ -81,19 +81,6 @@ class MapleStoryService:
         svc._load_all(data_dir)
         return svc
 
-    # Keep backwards compat for existing callers
-    @classmethod
-    def from_file(cls, file_path: Path = DEFAULT_DATA_DIR / "monsters.json") -> MapleStoryService:
-        """Creates a service instance, inferring the directory from a file path.
-
-        Args:
-            file_path: Path to a data file (e.g., monsters.json).
-
-        Returns:
-            An initialized MapleStoryService instance.
-        """
-        return cls.from_directory(file_path.parent)
-
     def _load_all(self, data_dir: Path) -> None:
         """Loads all MapleStory JSON data and resets derived caches."""
         self._monsters = _load_json(path=data_dir / "monsters.json", model=Monster)

--- a/src/discordbot/cogs/_stock/database.py
+++ b/src/discordbot/cogs/_stock/database.py
@@ -1775,7 +1775,7 @@ def _max_quantity_error(snapshot: _StockExecutionSnapshot) -> str:
     """Returns the clearest validation error when nothing is executable."""
     if snapshot.action == StockAction.BUY:
         if snapshot.position.short_shares <= 0 and snapshot.available_individual_long_shares <= 0:
-            return "單一玩家持股上限為 49%，目前無法再買入這檔股票"
+            return f"單一玩家持股上限為 {STOCK_INDIVIDUAL_OWNERSHIP_CAP_BPS // 100}%，目前無法再買入這檔股票"
         if snapshot.position.short_shares <= 0 and snapshot.available_long_shares <= 0:
             return "目前沒有可買入的流通股"
         return "餘額不足，無法買入或回補股票"
@@ -1992,7 +1992,7 @@ def _build_buy_plan(  # noqa: PLR0913 -- buy can cover short and open long in or
                 price_cents=price_cents,
                 balance=wallet_balance,
                 position=position,
-                error="單一玩家持股上限為 49%，目前無法再買入這檔股票",
+                error=f"單一玩家持股上限為 {STOCK_INDIVIDUAL_OWNERSHIP_CAP_BPS // 100}%，目前無法再買入這檔股票",
             )
         if remaining > available_long_shares:
             return _insufficient_result(

--- a/src/discordbot/cogs/_stock/presentation.py
+++ b/src/discordbot/cogs/_stock/presentation.py
@@ -4,7 +4,7 @@ from io import BytesIO
 from typing import TypedDict
 from functools import cache, lru_cache
 
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageDraw
 from nextcord import Embed
 from pydantic import BaseModel, ConfigDict
 
@@ -20,6 +20,7 @@ from discordbot.typings.stock import (
     StockParticipantPositionView,
 )
 from discordbot.utils.number_text import compact_amount, share_quantity_text
+from discordbot.utils.pillow_text import BoardFont, fit_text, load_font, draw_text_right
 from discordbot.cogs._stock.market import cash_floor, format_price
 from discordbot.cogs._economy.presentation import CURRENCY_NAME, amount_code, currency_text
 
@@ -58,29 +59,16 @@ _MARKET_PRESSURE_RIGHT = 930
 _MARKET_CAP_RIGHT = 1068
 _MARKET_NAME_MAX_WIDTH = 280
 _MARKET_CATEGORY_MAX_WIDTH = 112
-_REGULAR_FONT_CANDIDATES = (
-    "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
-    "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
-    "NotoSansCJK-Regular.ttc",
-    "DejaVuSans.ttf",
-)
-_BOLD_FONT_CANDIDATES = (
-    "/usr/share/fonts/opentype/noto/NotoSansCJK-Bold.ttc",
-    "/usr/share/fonts/truetype/noto/NotoSansCJK-Bold.ttc",
-    "NotoSansCJK-Bold.ttc",
-    "DejaVuSans-Bold.ttf",
-)
-type _MarketFont = ImageFont.ImageFont | ImageFont.FreeTypeFont
 
 
 class _MarketFonts(TypedDict):
     """Font set used by the stock market board image."""
 
-    title: _MarketFont
-    header: _MarketFont
-    symbol: _MarketFont
-    body: _MarketFont
-    small: _MarketFont
+    title: BoardFont
+    header: BoardFont
+    symbol: BoardFont
+    body: BoardFont
+    small: BoardFont
 
 
 class _MarketBoardQuote(BaseModel):
@@ -236,23 +224,12 @@ def _market_page[MarketPageRow](
 def _market_fonts() -> _MarketFonts:
     """Loads the market board fonts with a bundled-system fallback chain."""
     return {
-        "title": _load_font(size=34, bold=True),
-        "header": _load_font(size=20, bold=True),
-        "symbol": _load_font(size=28, bold=True),
-        "body": _load_font(size=24, bold=False),
-        "small": _load_font(size=16, bold=False),
+        "title": load_font(size=34, bold=True),
+        "header": load_font(size=20, bold=True),
+        "symbol": load_font(size=28, bold=True),
+        "body": load_font(size=24, bold=False),
+        "small": load_font(size=16, bold=False),
     }
-
-
-def _load_font(size: int, bold: bool) -> _MarketFont:
-    """Loads a CJK-capable font when available."""
-    candidates = _BOLD_FONT_CANDIDATES if bold else _REGULAR_FONT_CANDIDATES
-    for candidate in candidates:
-        try:
-            return ImageFont.truetype(font=candidate, size=size)
-        except OSError:
-            continue
-    return ImageFont.load_default()
 
 
 def _draw_market_header(
@@ -270,7 +247,7 @@ def _draw_market_header(
     if page_count > 1:
         summary = f"{summary} · 第 {page_index + 1}/{page_count} 頁"
     draw.text(xy=(x, y + 40), text=summary, font=fonts["small"], fill=_MARKET_MUTED)
-    _draw_text_right(
+    draw_text_right(
         draw=draw,
         text=f"單位: {CURRENCY_NAME}",
         xy=(_MARKET_CAP_RIGHT, y + 40),
@@ -295,28 +272,28 @@ def _draw_market_table_header(draw: ImageDraw.ImageDraw, fonts: _MarketFonts, y:
     draw.text(
         xy=(_MARKET_CATEGORY_X, baseline), text="分類", font=fonts["header"], fill=_MARKET_MUTED
     )
-    _draw_text_right(
+    draw_text_right(
         draw=draw,
         text="股價",
         xy=(_MARKET_PRICE_RIGHT, baseline),
         font=fonts["header"],
         fill=_MARKET_MUTED,
     )
-    _draw_text_right(
+    draw_text_right(
         draw=draw,
         text="今日",
         xy=(_MARKET_CHANGE_RIGHT, baseline),
         font=fonts["header"],
         fill=_MARKET_MUTED,
     )
-    _draw_text_right(
+    draw_text_right(
         draw=draw,
         text="買賣壓力",
         xy=(_MARKET_PRESSURE_RIGHT, baseline),
         font=fonts["header"],
         fill=_MARKET_MUTED,
     )
-    _draw_text_right(
+    draw_text_right(
         draw=draw,
         text="市值",
         xy=(_MARKET_CAP_RIGHT, baseline),
@@ -348,10 +325,10 @@ def _draw_market_row(
         width=1,
     )
     market_cap = cash_floor(cents=quote.price_cents * quote.total_shares)
-    name = _fit_text(
+    name = fit_text(
         draw=draw, text=quote.name, font=fonts["body"], max_width=_MARKET_NAME_MAX_WIDTH
     )
-    category = _fit_text(
+    category = fit_text(
         draw=draw, text=quote.category, font=fonts["small"], max_width=_MARKET_CATEGORY_MAX_WIDTH
     )
     draw.text(
@@ -359,28 +336,28 @@ def _draw_market_row(
     )
     draw.text(xy=(_MARKET_COMPANY_X, y + 8), text=name, font=fonts["body"], fill=_MARKET_TEXT)
     _draw_tag(draw=draw, text=category, xy=(_MARKET_CATEGORY_X, y + 19), font=fonts["small"])
-    _draw_text_right(
+    draw_text_right(
         draw=draw,
         text=format_price(price_cents=quote.price_cents),
         xy=(_MARKET_PRICE_RIGHT, y + 12),
         font=fonts["body"],
         fill=_MARKET_TEXT,
     )
-    _draw_text_right(
+    draw_text_right(
         draw=draw,
         text=signed_percent(bps=quote.change_bps),
         xy=(_MARKET_CHANGE_RIGHT, y + 12),
         font=fonts["body"],
         fill=_metric_color(bps=quote.change_bps),
     )
-    _draw_text_right(
+    draw_text_right(
         draw=draw,
         text=signed_percent(bps=quote.pressure_bps),
         xy=(_MARKET_PRESSURE_RIGHT, y + 12),
         font=fonts["body"],
         fill=_metric_color(bps=quote.pressure_bps),
     )
-    _draw_text_right(
+    draw_text_right(
         draw=draw,
         text=compact_amount(amount=market_cap),
         xy=(_MARKET_CAP_RIGHT, y + 12),
@@ -403,9 +380,7 @@ def _draw_empty_market_row(draw: ImageDraw.ImageDraw, fonts: _MarketFonts, y: in
     )
 
 
-def _draw_tag(
-    draw: ImageDraw.ImageDraw, text: str, xy: tuple[int, int], font: _MarketFont
-) -> None:
+def _draw_tag(draw: ImageDraw.ImageDraw, text: str, xy: tuple[int, int], font: BoardFont) -> None:
     """Draws a compact category tag."""
     x, y = xy
     bbox = draw.textbbox(xy=(0, 0), text=text, font=font)
@@ -414,44 +389,6 @@ def _draw_tag(
         xy=(x, y, x + width, y + 20), radius=8, fill=(67, 57, 35), outline=(94, 78, 44)
     )
     draw.text(xy=(x + 8, y + 1), text=text, font=font, fill=_MARKET_TAG)
-
-
-def _draw_text_right(
-    draw: ImageDraw.ImageDraw,
-    text: str,
-    xy: tuple[int, int],
-    font: _MarketFont,
-    fill: tuple[int, int, int],
-) -> None:
-    """Draws text with its right edge anchored at x."""
-    right, y = xy
-    bbox = draw.textbbox(xy=(0, 0), text=text, font=font)
-    draw.text(xy=(right - (bbox[2] - bbox[0]), y), text=text, font=font, fill=fill)
-
-
-def _fit_text(draw: ImageDraw.ImageDraw, text: str, font: _MarketFont, max_width: int) -> str:
-    """Truncates text to fit the requested pixel width."""
-    if _text_width(draw=draw, text=text, font=font) <= max_width:
-        return text
-    suffix = "..."
-    low = 0
-    high = len(text)
-    while low < high:
-        midpoint = (low + high + 1) // 2
-        candidate = f"{text[:midpoint]}{suffix}"
-        if _text_width(draw=draw, text=candidate, font=font) <= max_width:
-            low = midpoint
-        else:
-            high = midpoint - 1
-    if low == 0:
-        return suffix
-    return f"{text[:low]}{suffix}"
-
-
-def _text_width(draw: ImageDraw.ImageDraw, text: str, font: _MarketFont) -> int:
-    """Returns rendered text width."""
-    bbox = draw.textbbox(xy=(0, 0), text=text, font=font)
-    return bbox[2] - bbox[0]
 
 
 def _metric_color(bps: int) -> tuple[int, int, int]:

--- a/src/discordbot/cogs/_stock/views.py
+++ b/src/discordbot/cogs/_stock/views.py
@@ -8,7 +8,7 @@ from nextcord import File, User, Member, Message, ButtonStyle, Interaction, Sele
 from pydantic import BaseModel, ConfigDict, SkipValidation
 from nextcord.ui import View, Modal, Button, TextInput, StringSelect
 
-from discordbot.typings.stock import STOCK_ACTION_TIMEOUT_SECONDS, StockAction, StockMarketQuote
+from discordbot.typings.stock import StockAction, StockMarketQuote
 from discordbot.utils.avatars import guild_avatar_url
 from discordbot.cogs._stock.chart import build_price_chart, invalidate_stock_chart_cache
 from discordbot.cogs._stock.database import (
@@ -16,6 +16,9 @@ from discordbot.cogs._stock.database import (
     get_stock_detail,
     list_market_quotes,
     settle_stock_operation,
+)
+from discordbot.utils.message_cleanup import (
+    PUBLIC_MESSAGE_TTL_SECONDS as STOCK_ACTION_TIMEOUT_SECONDS,
 )
 from discordbot.utils.message_cleanup import (
     track_public_message,

--- a/src/discordbot/cogs/games.py
+++ b/src/discordbot/cogs/games.py
@@ -21,13 +21,13 @@ from discordbot.utils.avatars import guild_avatar_url
 from discordbot.typings.models import RuntimeModelCatalog
 from discordbot.cogs._games.dealer import DealerAI
 from discordbot.cogs._games.wagers import WagerMode, parse_wager_amount, build_wager_participant
+from discordbot.cogs._games.settings import get_dragon_gate_ante, get_dragon_gate_min_bet
 from discordbot.utils.message_cleanup import (
     track_public_message,
     delete_tracked_public_messages,
     schedule_public_message_delete,
 )
 from discordbot.cogs._economy.database import get_balance
-from discordbot.cogs._games.dragon_gate import ANTE
 from discordbot.cogs._games.presentation import ERROR_COLOR
 from discordbot.cogs._economy.presentation import CURRENCY_NAME, bold_currency
 from discordbot.cogs._games.blackjack_views import (
@@ -227,13 +227,13 @@ class GamesCogs(commands.Cog):
             color=ERROR_COLOR,
         )
 
-    def _dragon_gate_insufficient_balance_embed(self, balance: int) -> Embed:
+    def _dragon_gate_insufficient_balance_embed(self, balance: int, ante: int) -> Embed:
         """Builds the insufficient-balance embed for 射龍門 ante checks."""
         return Embed(
             title="餘額不足",
             description=(
                 f"### {bold_currency(amount=balance, compact=True)}\n"
-                f"射龍門入場費固定 {bold_currency(amount=ANTE, compact=True)} 進彩金池\n"
+                f"射龍門入場費固定 {bold_currency(amount=ante, compact=True)} 進彩金池\n"
                 f"-# 跟機器人聊天可以累積{CURRENCY_NAME}"
             ),
             color=ERROR_COLOR,
@@ -357,19 +357,20 @@ class GamesCogs(commands.Cog):
         if interaction.user is None:
             return
 
+        ante = await get_dragon_gate_ante()
+        min_bet = await get_dragon_gate_min_bet()
+        insufficient_embed = partial(self._dragon_gate_insufficient_balance_embed, ante=ante)
+
         participant_result = await self._participant_from_user(
             user=interaction.user,
-            wager=ANTE,
+            wager=ante,
             mode="exact",
             guild=getattr(interaction, "guild", None),
         )
         owner = participant_result.participant
         if owner is None:
             message = await interaction.followup.send(
-                embed=self._dragon_gate_insufficient_balance_embed(
-                    balance=participant_result.balance
-                ),
-                wait=True,
+                embed=insufficient_embed(balance=participant_result.balance), wait=True
             )
             schedule_public_message_delete(message=message, user_name=interaction.user.name)
             return
@@ -384,16 +385,18 @@ class GamesCogs(commands.Cog):
             dealer_avatar_url=dealer_identity.dealer_avatar_url,
             prepare_participant=partial(
                 self._prepare_participant,
-                wager=ANTE,
+                wager=ante,
                 mode="exact",
-                insufficient_embed_builder=self._dragon_gate_insufficient_balance_embed,
+                insufficient_embed_builder=insufficient_embed,
             ),
-            refresh_participants=partial(self._refresh_participants, wager=ANTE, mode="exact"),
+            refresh_participants=partial(self._refresh_participants, wager=ante, mode="exact"),
             initial_jackpot=initial_jackpot.balance,
+            ante=ante,
+            min_bet=min_bet,
             initial_jackpot_generation=initial_jackpot.generation,
         )
         embed = build_dragon_gate_lobby_embed(
-            owner=owner, participants=view.participants, jackpot=initial_jackpot.balance
+            owner=owner, participants=view.participants, jackpot=initial_jackpot.balance, ante=ante
         )
         message = await interaction.followup.send(embed=embed, view=view, wait=True)
         await track_public_message(message=message, user_name=owner.account_name)

--- a/src/discordbot/typings/stock.py
+++ b/src/discordbot/typings/stock.py
@@ -7,7 +7,6 @@ from pydantic import Field, BaseModel, ConfigDict, model_validator
 STOCK_TICK_SECONDS: Final[int] = 5 * 60
 MAX_TICKS_PER_INTERACTION: Final[int] = 12 * 24
 STOCK_HISTORY_DAYS: Final[int] = 7
-STOCK_ACTION_TIMEOUT_SECONDS: Final[int] = 180
 STOCK_NEWS_CADENCE_HOURS: Final[int] = 4
 STOCK_INDIVIDUAL_OWNERSHIP_CAP_BPS: Final[int] = 4_900
 STOCK_BPS_DENOMINATOR: Final[int] = 10_000
@@ -304,7 +303,6 @@ class StockSupplyAuditView(BaseModel):
 
 __all__ = [
     "MAX_TICKS_PER_INTERACTION",
-    "STOCK_ACTION_TIMEOUT_SECONDS",
     "STOCK_BPS_DENOMINATOR",
     "STOCK_HISTORY_DAYS",
     "STOCK_INDIVIDUAL_OWNERSHIP_CAP_BPS",

--- a/src/discordbot/utils/message_cleanup.py
+++ b/src/discordbot/utils/message_cleanup.py
@@ -12,7 +12,7 @@ from sqlalchemy import Engine, text, event, create_engine
 from nextcord.ext import commands
 from sqlalchemy.engine import Connection
 
-PUBLIC_MESSAGE_TTL_SECONDS = 180
+PUBLIC_MESSAGE_TTL_SECONDS: Final[int] = 180
 _PENDING_PUBLIC_MESSAGE_DB_PATH = Path("data/game_cleanup.db")
 _pending_engine: Engine | None = None
 _pending_engine_path: Path | None = None

--- a/src/discordbot/utils/pillow_text.py
+++ b/src/discordbot/utils/pillow_text.py
@@ -1,0 +1,81 @@
+"""Shared Pillow text drawing helpers for board / market PNG renderers."""
+
+from PIL import ImageDraw, ImageFont
+
+type BoardFont = ImageFont.ImageFont | ImageFont.FreeTypeFont
+
+REGULAR_FONT_CANDIDATES: tuple[str, ...] = (
+    "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+    "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
+    "NotoSansCJK-Regular.ttc",
+    "DejaVuSans.ttf",
+)
+BOLD_FONT_CANDIDATES: tuple[str, ...] = (
+    "/usr/share/fonts/opentype/noto/NotoSansCJK-Bold.ttc",
+    "/usr/share/fonts/truetype/noto/NotoSansCJK-Bold.ttc",
+    "NotoSansCJK-Bold.ttc",
+    "DejaVuSans-Bold.ttf",
+)
+
+
+def load_font(size: int, bold: bool) -> BoardFont:
+    """Loads a CJK-capable font when available."""
+    candidates = BOLD_FONT_CANDIDATES if bold else REGULAR_FONT_CANDIDATES
+    for candidate in candidates:
+        try:
+            return ImageFont.truetype(font=candidate, size=size)
+        except OSError:
+            continue
+    return ImageFont.load_default()
+
+
+def text_width(draw: ImageDraw.ImageDraw, text: str, font: BoardFont) -> int:
+    """Returns rendered text width."""
+    bbox = draw.textbbox(xy=(0, 0), text=text, font=font)
+    return bbox[2] - bbox[0]
+
+
+def draw_text_right(
+    draw: ImageDraw.ImageDraw,
+    text: str,
+    xy: tuple[int, int],
+    font: BoardFont,
+    fill: tuple[int, int, int],
+) -> None:
+    """Draws text with its right edge anchored at x."""
+    right, y = xy
+    bbox = draw.textbbox(xy=(0, 0), text=text, font=font)
+    draw.text(xy=(right - (bbox[2] - bbox[0]), y), text=text, font=font, fill=fill)
+
+
+def draw_text_center(
+    draw: ImageDraw.ImageDraw,
+    text: str,
+    center: tuple[int, int],
+    font: BoardFont,
+    fill: tuple[int, int, int],
+) -> None:
+    """Draws text centered around a point."""
+    x, y = center
+    bbox = draw.textbbox(xy=(0, 0), text=text, font=font)
+    width = bbox[2] - bbox[0]
+    draw.text(xy=(x - width // 2, y), text=text, font=font, fill=fill)
+
+
+def fit_text(draw: ImageDraw.ImageDraw, text: str, font: BoardFont, max_width: int) -> str:
+    """Truncates text with an ellipsis suffix to fit the requested pixel width."""
+    if text_width(draw=draw, text=text, font=font) <= max_width:
+        return text
+    suffix = "..."
+    low = 0
+    high = len(text)
+    while low < high:
+        midpoint = (low + high + 1) // 2
+        candidate = f"{text[:midpoint]}{suffix}"
+        if text_width(draw=draw, text=candidate, font=font) <= max_width:
+            low = midpoint
+        else:
+            high = midpoint - 1
+    if low == 0:
+        return suffix
+    return f"{text[:low]}{suffix}"

--- a/tests/test_dragon_gate.py
+++ b/tests/test_dragon_gate.py
@@ -26,6 +26,7 @@ from discordbot.typings.economy import (
 from discordbot.cogs._games.dragon_gate import (
     ANTE,
     GAME_ID,
+    MIN_BET,
     DragonGateRound,
     DragonGateParticipantUnknownError,
     card_value,
@@ -503,7 +504,7 @@ def test_dragon_gate_embeds_show_lobby_progress_and_final_state() -> None:
     owner = _participant(user_id=1, display_name="Alice")
     bob = _participant(user_id=2, display_name="Bob")
     lobby = build_dragon_gate_lobby_embed(
-        owner=owner, participants=[owner, bob], jackpot=100_000, status="ready"
+        owner=owner, participants=[owner, bob], jackpot=100_000, ante=ANTE, status="ready"
     )
     assert isinstance(lobby, Embed)
     assert isinstance(lobby.title, str)
@@ -613,6 +614,8 @@ async def test_dragon_gate_lobby_join_leave_and_owner_start(
         prepare_participant=prepare_participant,
         refresh_participants=refresh_participants,
         initial_jackpot=state.jackpot,
+        ante=ANTE,
+        min_bet=MIN_BET,
     )
     view.message = message
 
@@ -696,6 +699,8 @@ async def test_dragon_gate_lobby_ante_rejection_keeps_lobby_open(
         prepare_participant=prepare_participant,
         refresh_participants=refresh_participants,
         initial_jackpot=100_000,
+        ante=ANTE,
+        min_bet=MIN_BET,
     )
     view.message = message
 

--- a/tests/test_economy.py
+++ b/tests/test_economy.py
@@ -17,6 +17,14 @@ from discordbot.typings.games import (
     BlackjackHandSettlement,
     BlackjackPlayerSettlement,
 )
+from discordbot.cogs._games.settings import (
+    get_game_setting,
+    set_game_setting,
+    list_game_settings,
+    get_dragon_gate_ante,
+    get_dragon_gate_min_bet,
+    invalidate_game_setting_cache,
+)
 from discordbot.cogs._games.blackjack import Card, BlackjackRound, BlackjackHandState
 from discordbot.cogs._economy.database import (
     TAIWAN_TIMEZONE,
@@ -538,7 +546,7 @@ async def test_ensure_schema_bootstraps_current_databases(
         "loan_contract",
         "casino_account",
     }
-    assert global_state_tables == {"jackpot_pool"}
+    assert global_state_tables == {"jackpot_pool", "game_setting"}
     assert {"user_id", "name", "is_central_banker"} <= table_columns["user_account"]
     assert {"user_id", "name", "balance", "total_earned", "total_spent"} <= table_columns[
         "user_wallet"
@@ -2775,3 +2783,43 @@ async def test_ensure_schema_seeds_dragon_gate_jackpot_once(
 
     await engine.dispose()
     await global_state_engine.dispose()
+
+
+async def test_game_setting_seeds_and_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """game_setting rows seed Dragon Gate defaults and round-trip through set/get."""
+    monkeypatch.setattr("discordbot.cogs._economy.database._global_state_schema_ready_for", None)
+    invalidate_game_setting_cache()
+
+    assert await get_dragon_gate_ante() == 5_000
+    assert await get_dragon_gate_min_bet() == 10_000
+
+    await set_game_setting(game_id="dragon_gate", setting_key="ante", value=6_500)
+    assert await get_dragon_gate_ante() == 6_500
+    rows = await list_game_settings(game_id="dragon_gate")
+    assert ("dragon_gate", "ante", 6_500) in rows
+
+
+async def test_invalidate_game_setting_cache_forces_db_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After invalidate, a getter hits the DB again instead of returning a stale value."""
+    monkeypatch.setattr("discordbot.cogs._economy.database._global_state_schema_ready_for", None)
+    invalidate_game_setting_cache()
+
+    assert await get_game_setting(game_id="dragon_gate", setting_key="ante", default=0) == 5_000
+
+    async with open_global_state_session() as session:
+        await session.execute(
+            statement=text(
+                text=(
+                    "UPDATE game_setting SET setting_value = '9999' "
+                    "WHERE game_id = 'dragon_gate' AND setting_key = 'ante'"
+                )
+            )
+        )
+        await session.commit()
+
+    # Stale process cache still returns the original value.
+    assert await get_game_setting(game_id="dragon_gate", setting_key="ante", default=0) == 5_000
+    invalidate_game_setting_cache()
+    assert await get_game_setting(game_id="dragon_gate", setting_key="ante", default=0) == 9_999


### PR DESCRIPTION
## Summary
- One-pass code quality cleanup: remove a backwards-compat shim, fix the DRY violation in the stock ownership-cap error message, extract shared Pillow text helpers, and collapse four hardcoded 180s idle-timeout constants to a single source of truth in `utils/message_cleanup.PUBLIC_MESSAGE_TTL_SECONDS`.
- Add the `game_setting` table in `data/global_state.db`. Dragon Gate `ante` / `min_bet` now load from DB through `cogs/_games/settings.py` getters (process cache, with module constants as offline / test fallback).
- Add `scripts/manage_game_setting.py` for runtime tuning, plus two new test cases covering seed defaults, set/get round-trip, and cache invalidation.

## Test plan
- [x] `uv run pytest` (466 passed, coverage 84.45%)
- [x] `uv run pre-commit run -a` (ruff / ruff-format / mypy / codespell all green)
- [x] `make gen-docs` regenerated the `mkdocs.yml` nav
- [ ] Manual: `/leaderboard` and `/loss_leaderboard` PNG render correctly
- [ ] Manual: `/stock` buy beyond the 49% cap shows the correct error
- [ ] Manual: `/games dragon_gate` open / join / bet / leave behavior unchanged
- [ ] Manual: `uv run python scripts/manage_game_setting.py set dragon_gate ante 6000` then restart and confirm the new ante takes effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)