### PR TITLE
refactor: share Discord reaction helper

### DIFF
--- a/src/discordbot/cogs/gen_reply.py
+++ b/src/discordbot/cogs/gen_reply.py
@@ -27,6 +27,7 @@ from discordbot.utils.avatars import guild_avatar_url
 from discordbot.typings.models import RouteDecision, RuntimeModelCatalog
 from discordbot.utils.model_pricing import get_token_rates, get_supported_modalities
 from discordbot.cogs._economy.database import credit_with_repayment
+from discordbot.utils.discord_messages import DiscordMessageOperations
 from discordbot.cogs._gen_reply.prompts import (
     IMAGE_PROMPT,
     REPLY_PROMPT,
@@ -71,6 +72,7 @@ class ReplyGeneratorCogs(commands.Cog):
         self.bot = bot
         self.config = LLMConfig()
         self.runtime_models = RuntimeModelCatalog()
+        self.discord_messages = DiscordMessageOperations(bot=bot)
 
     @cached_property
     def client(self) -> AsyncOpenAI:
@@ -444,16 +446,6 @@ class ReplyGeneratorCogs(commands.Cog):
         final_content = f"{message.author.mention} {image_description}"
         await message.reply(content=final_content, file=image_file)
 
-    async def _handle_reaction(
-        self, message: Message, emoji: str, previous: str | None = None
-    ) -> None:
-        """Handles adding and removing reactions on a message."""
-        if previous and self.bot.user:
-            with contextlib.suppress(Exception):
-                await message.remove_reaction(emoji=previous, member=self.bot.user)
-        with contextlib.suppress(Exception):
-            await message.add_reaction(emoji=emoji)
-
     async def _route_message(self, message: Message) -> Literal["IMAGE", "QA", "SUMMARY", "VIDEO"]:
         """Routes the message to the appropriate handler."""
         message_list: list[EasyInputMessageParam] = []
@@ -617,7 +609,7 @@ class ReplyGeneratorCogs(commands.Cog):
         stored_content += usage_footer
 
         if used_web_search:
-            await self._handle_reaction(message=message, emoji="🌐")
+            await self.discord_messages.set_status_reaction(message=message, emoji="🌐")
 
         return stored_content
 
@@ -675,39 +667,46 @@ class ReplyGeneratorCogs(commands.Cog):
         has_attachment = bool(message.attachments or message.stickers)
 
         if not user_prompt and not has_attachment:
-            await self._handle_reaction(message=message, emoji="❓")
+            await self.discord_messages.set_status_reaction(message=message, emoji="❓")
             await message.reply(content="?")
             return
 
         try:
-            await self._handle_reaction(message=message, emoji="🔀")
-            current_emoji = "🔀"
+            current_emoji = await self.discord_messages.set_status_reaction(
+                message=message, emoji="🔀"
+            )
             route = await self._route_message(message=message)
             if route == "IMAGE":
-                await self._handle_reaction(message=message, emoji="🎨", previous=current_emoji)
-                current_emoji = "🎨"
+                current_emoji = await self.discord_messages.set_status_reaction(
+                    message=message, emoji="🎨", previous=current_emoji
+                )
                 await self._handle_image_reply(message=message, user_prompt=user_prompt)
             elif route == "VIDEO":
-                await self._handle_reaction(message=message, emoji="🎬", previous=current_emoji)
-                current_emoji = "🎬"
+                current_emoji = await self.discord_messages.set_status_reaction(
+                    message=message, emoji="🎬", previous=current_emoji
+                )
                 await self._handle_video_reply(message=message, user_prompt=user_prompt)
             elif route == "SUMMARY":
-                await self._handle_reaction(message=message, emoji="📖", previous=current_emoji)
-                current_emoji = "📖"
+                current_emoji = await self.discord_messages.set_status_reaction(
+                    message=message, emoji="📖", previous=current_emoji
+                )
                 await self._handle_message_reply(
                     message=message, system_prompt=SUMMARY_PROMPT, history_limit=50
                 )
             else:
-                await self._handle_reaction(message=message, emoji="❓", previous=current_emoji)
-                current_emoji = "❓"
+                current_emoji = await self.discord_messages.set_status_reaction(
+                    message=message, emoji="❓", previous=current_emoji
+                )
                 await self._handle_message_reply(
                     message=message, system_prompt=REPLY_PROMPT, history_limit=30
                 )
-            await self._handle_reaction(message=message, emoji="🆗", previous=current_emoji)
+            await self.discord_messages.set_status_reaction(
+                message=message, emoji="🆗", previous=current_emoji
+            )
         except Exception as e:
             logfire.error("Failed to generate reply", user_id=message.author.name, _exc_info=True)
             with contextlib.suppress(Exception):
-                await self._handle_reaction(message=message, emoji="❌")
+                await self.discord_messages.set_status_reaction(message=message, emoji="❌")
                 error_embed = Embed(
                     title="Something went wrong",
                     description=f"```\n{extract_friendly_error(exc=e)}\n```",

--- a/src/discordbot/cogs/parse_threads.py
+++ b/src/discordbot/cogs/parse_threads.py
@@ -9,6 +9,7 @@ from nextcord import File, Color, Embed, Message
 from nextcord.ext import commands
 
 from discordbot.utils.threads import ThreadsOutput, ThreadsDownloader
+from discordbot.utils.discord_messages import DiscordMessageOperations
 
 URL_REGEX = re.compile(r"https?://(?:www\.)?threads\.(?:net|com)/@[^/]+/post/[^\s\"'<>)]+")
 
@@ -32,16 +33,7 @@ class ThreadsCogs(commands.Cog):
         self.output_folder = Path("./data/downloads")
         self.output_folder.mkdir(parents=True, exist_ok=True)
         self.downloader = ThreadsDownloader(output_folder=str(self.output_folder))
-
-    async def _handle_reaction(
-        self, message: Message, emoji: str, previous_emoji: str | None = None
-    ) -> None:
-        """Handles adding and removing reactions on a message."""
-        if previous_emoji and self.bot.user:
-            with contextlib.suppress(Exception):
-                await message.remove_reaction(emoji=previous_emoji, member=self.bot.user)
-        with contextlib.suppress(Exception):
-            await message.add_reaction(emoji=emoji)
+        self.discord_messages = DiscordMessageOperations(bot=bot)
 
     @staticmethod
     def _gradient_color(index: int, total: int) -> Color:
@@ -138,14 +130,15 @@ class ThreadsCogs(commands.Cog):
             return
 
         url = match.group(0)
-        current_emoji = "🔗"
-        await self._handle_reaction(message=message, emoji=current_emoji)
+        current_emoji = await self.discord_messages.set_status_reaction(
+            message=message, emoji="🔗"
+        )
 
         try:
             with self.downloader.parse(url) as results:
                 if not results:
-                    await self._handle_reaction(
-                        message=message, emoji="⚠️", previous_emoji=current_emoji
+                    await self.discord_messages.set_status_reaction(
+                        message=message, emoji="⚠️", previous=current_emoji
                     )
                     return
 
@@ -163,8 +156,8 @@ class ThreadsCogs(commands.Cog):
                     or len(target.video_paths) + len(target.image_urls) > 10
                     or len(target.text) > 4096
                 ):
-                    await self._handle_reaction(
-                        message=message, emoji="⚠️", previous_emoji=current_emoji
+                    await self.discord_messages.set_status_reaction(
+                        message=message, emoji="⚠️", previous=current_emoji
                     )
                     return
 
@@ -180,14 +173,14 @@ class ThreadsCogs(commands.Cog):
                     await message.edit(suppress=True)
 
                 await message.reply(embeds=embeds, files=files, mention_author=False)
-                await self._handle_reaction(
-                    message=message, emoji="🆗", previous_emoji=current_emoji
+                await self.discord_messages.set_status_reaction(
+                    message=message, emoji="🆗", previous=current_emoji
                 )
         except Exception:
             logfire.error("Failed to send Threads message", _exc_info=True)
             with contextlib.suppress(Exception):
-                await self._handle_reaction(
-                    message=message, emoji="❌", previous_emoji=current_emoji
+                await self.discord_messages.set_status_reaction(
+                    message=message, emoji="❌", previous=current_emoji
                 )
 
 

--- a/src/discordbot/utils/discord_messages.py
+++ b/src/discordbot/utils/discord_messages.py
@@ -1,0 +1,31 @@
+"""Small Discord message operation helpers."""
+
+from typing import Protocol
+import contextlib
+
+from nextcord import ClientUser, Message
+
+
+class BotUserProvider(Protocol):
+    """Bot-like object that exposes the current Discord client user."""
+
+    user: ClientUser | None
+
+
+class DiscordMessageOperations:
+    """Reusable operations for mutating Discord messages."""
+
+    def __init__(self, bot: BotUserProvider) -> None:
+        """Initializes the operation helper with the owning bot."""
+        self.bot = bot
+
+    async def set_status_reaction(
+        self, message: Message, emoji: str, previous: str | None = None
+    ) -> str:
+        """Adds the current status reaction and removes the previous one."""
+        if previous and self.bot.user:
+            with contextlib.suppress(Exception):
+                await message.remove_reaction(emoji=previous, member=self.bot.user)
+        with contextlib.suppress(Exception):
+            await message.add_reaction(emoji=emoji)
+        return emoji

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -14,6 +14,7 @@ from nextcord import File, Embed
 
 from discordbot.cogs.gen_reply import _USAGE_FOOTER_RE, _DISCORD_MESSAGE_LIMIT, ReplyGeneratorCogs
 from discordbot.typings.models import ModelSettings, RouteDecision, RuntimeModelCatalog
+from discordbot.utils.discord_messages import DiscordMessageOperations
 from discordbot.cogs._gen_reply.exceptions import extract_friendly_error
 
 TEST_LLM_MODEL = "test-llm-model"
@@ -281,6 +282,7 @@ def _cog(bot_user_id: int = 999) -> ReplyGeneratorCogs:
     cog = ReplyGeneratorCogs.__new__(ReplyGeneratorCogs)
     cog.bot = SimpleNamespace(user=SimpleNamespace(id=bot_user_id, name="bot"))
     cog.runtime_models = RuntimeModelCatalog()
+    cog.discord_messages = DiscordMessageOperations(bot=cog.bot)
     cog.__dict__["client"] = FakeClient()
     return cog
 
@@ -510,6 +512,22 @@ async def test_gen_reply_message_content_and_attachment_helpers(
     assert [part["type"] for part in parts] == ["input_image", "input_image", "input_image"]
 
 
+async def test_discord_message_operations_sets_status_reaction() -> None:
+    """Verifies status reaction transitions return the active emoji."""
+    bot_user = FakeAuthor(bot=True, user_id=999)
+    message = FakeMessage()
+    operations = DiscordMessageOperations(bot=SimpleNamespace(user=bot_user))
+
+    current = await operations.set_status_reaction(message=message, emoji="🔀")
+    assert current == "🔀"
+    assert message.added_reactions == ["🔀"]
+
+    current = await operations.set_status_reaction(message=message, emoji="🎨", previous=current)
+    assert current == "🎨"
+    assert message.added_reactions == ["🔀", "🎨"]
+    assert message.removed_reactions == [("🔀", bot_user)]
+
+
 async def test_gen_reply_processes_history_reference_and_current_messages(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -608,9 +626,11 @@ async def test_gen_reply_on_message_dispatches_routes(
         """Returns the parametrized route."""
         return route
 
-    async def fake_reaction(message: FakeMessage, emoji: str, previous: str | None = None) -> None:
+    async def fake_reaction(message: FakeMessage, emoji: str, previous: str | None = None) -> str:
         """Records reaction state transitions."""
+        del message, previous
         calls.append(f"reaction:{emoji}")
+        return emoji
 
     async def fake_image_handler(message: FakeMessage, user_prompt: str) -> None:
         """Records image handler dispatch."""
@@ -627,7 +647,7 @@ async def test_gen_reply_on_message_dispatches_routes(
         calls.append("_handle_message_reply")
 
     monkeypatch.setattr(cog, "_route_message", fake_route)
-    monkeypatch.setattr(cog, "_handle_reaction", fake_reaction)
+    monkeypatch.setattr(cog.discord_messages, "set_status_reaction", fake_reaction)
     monkeypatch.setattr(cog, "_handle_image_reply", fake_image_handler)
     monkeypatch.setattr(cog, "_handle_video_reply", fake_video_handler)
     monkeypatch.setattr(cog, "_handle_message_reply", fake_message_handler)


### PR DESCRIPTION
## Summary

- Add `DiscordMessageOperations` for reusable Discord message status reactions.
- Update reply generation and Threads parsing to reuse the shared helper and receive the active emoji from the helper return value.
- Cover reaction state transitions in tests.

## Tests

- `uv run pytest tests/test_gen_reply.py tests/test_cogs_smoke.py -q --no-cov`
- `uv run pre-commit run -a`

## Docs

- No documentation update needed. This is an internal helper refactor with no user-facing command or behavior change.