### PR TITLE
refactor: extract Discord message and stream helpers into utils

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ make gen-docs                    # regenerate docs/ from sources
 - Prefer string-content shorthand when there are no attachments.
 - Processed Discord messages with attachments fall back to `role=user` because assistant content cannot contain `input_image` or `input_file`.
 - Separator messages use `role=system`, not `developer`, for Gemini and Claude compatibility through LiteLLM.
-- Gemini may prepend leading newlines to streamed reasoning output when `reasoning.effort != "none"`. `_handle_streaming` strips them on the first content delta; keep that guard.
+- Gemini may prepend leading newlines to streamed reasoning output when `reasoning.effort != "none"`. `DiscordStreamOps.handle_streaming` strips them on the first content delta; keep that guard.
 - Gemini thought summaries only flow through the Responses API.
 - `client.images.edit(image=...)` needs raw `bytes`, not image-reference dicts.
 - Per-token pricing comes from `utils.model_pricing` and its cached LiteLLM JSON. Do not hardcode rates in `gen_reply.py`.

--- a/src/discordbot/cogs/gen_reply.py
+++ b/src/discordbot/cogs/gen_reply.py
@@ -1,57 +1,35 @@
 """Cog that routes Discord messages through the AI reply pipeline."""
 
 from io import BytesIO
-import re
 import base64
 from typing import TYPE_CHECKING, Literal, cast
 import asyncio
 from functools import cached_property
-from mimetypes import guess_type
 import contextlib
 
-from PIL import Image
-from openai import AsyncOpenAI, AsyncStream
+from openai import AsyncOpenAI
 import logfire
-from nextcord import File, Embed, Message, Attachment, StickerItem
+from nextcord import File, Embed, Message
 from pydantic import ValidationError
 from nextcord.ext import commands
-from openai.types.responses import ResponseStreamEvent
 from openai.types.responses.response_input_param import ResponseInputParam, EasyInputMessageParam
-from openai.types.responses.response_input_file_param import ResponseInputFileParam
 from openai.types.responses.response_input_text_param import ResponseInputTextParam
 from openai.types.responses.response_input_image_param import ResponseInputImageParam
 
 from discordbot.typings.llm import LLMConfig
-from discordbot.utils.images import get_pil_image, get_image_data, convert_base64_to_data_uri
-from discordbot.utils.avatars import guild_avatar_url
+from discordbot.utils.images import get_image_data, convert_base64_to_data_uri
 from discordbot.typings.models import RouteDecision, RuntimeModelCatalog
-from discordbot.utils.model_pricing import get_token_rates, get_supported_modalities
-from discordbot.cogs._economy.database import credit_with_repayment
+from discordbot.utils.discord_ops import DiscordStreamOps, DiscordMessageOps
 from discordbot.cogs._gen_reply.prompts import (
     IMAGE_PROMPT,
     REPLY_PROMPT,
     ROUTE_PROMPT,
     SUMMARY_PROMPT,
 )
-from discordbot.cogs._economy.presentation import currency_text
 from discordbot.cogs._gen_reply.exceptions import extract_friendly_error
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable
-
-# Gemini occasionally wraps Discord mention syntax in backticks (inline code),
-# which stops Discord from rendering the actual mention. Strip those wrappers
-# before sending; matches user (<@id>, <@!id>), role (<@&id>) and channel (<#id>) mentions.
-_CODED_MENTION_RE = re.compile(r"`(<(?:@[!&]?|#)\d+>)`")
-
-# Strips the usage_footer appended by `_handle_streaming` from bot-authored
-# messages before feeding them back as `role=assistant` history. Without this,
-# the model performs in-context learning on its own past footers and starts
-# hallucinating fake "-# model · ⬆ ... ⬇ ... · $... · ..." lines into fresh
-# replies. Anchored on the `\n\n-# ` separator plus the ⬆/⬇ token-count icons,
-# which never appear together in user-authored content.
-_USAGE_FOOTER_RE = re.compile(r"\n\n-#[^\n]*⬆[^\n]*⬇[^\n]*$")
-_DISCORD_MESSAGE_LIMIT = 2000
 
 
 class ReplyGeneratorCogs(commands.Cog):
@@ -71,6 +49,8 @@ class ReplyGeneratorCogs(commands.Cog):
         self.bot = bot
         self.config = LLMConfig()
         self.runtime_models = RuntimeModelCatalog()
+        self.discord_messages = DiscordMessageOps(bot=bot, runtime_models=self.runtime_models)
+        self.discord_stream = DiscordStreamOps(bot=bot, msg_ops=self.discord_messages)
 
     @cached_property
     def client(self) -> AsyncOpenAI:
@@ -81,175 +61,6 @@ class ReplyGeneratorCogs(commands.Cog):
         """
         client = AsyncOpenAI(base_url=self.config.base_url, api_key=self.config.api_key)
         return client
-
-    async def _get_user_prompt(self, content: str) -> str:
-        """Removes the bot mention from the content and strips whitespace."""
-        if self.bot.user:
-            content = content.replace(f"<@{self.bot.user.id}>", "")
-        return content.strip()
-
-    @staticmethod
-    def _extract_embed_text(embeds: list[Embed]) -> str:
-        """Joins author / title / description / fields / footer text from embeds."""
-        embed_parts: list[str] = []
-        for embed in embeds:
-            parts: list[str] = []
-            if embed.author and embed.author.name:
-                parts.append(f"Author: {embed.author.name}")
-            if embed.title:
-                parts.append(f"Title: {embed.title}")
-            if embed.description:
-                parts.append(embed.description)
-            for field in embed.fields:
-                parts.append(f"{field.name}: {field.value}")
-            if embed.footer and embed.footer.text:
-                parts.append(f"Footer: {embed.footer.text}")
-            if parts:
-                embed_parts.append("\n".join(parts))
-        return "\n\n".join(embed_parts)
-
-    async def _get_cleaned_content(self, message: Message) -> str:
-        """Returns the textual content of a message without the author prefix."""
-        content = await self._get_user_prompt(content=message.content)
-        if content and self.bot.user and message.author.id == self.bot.user.id:
-            content = _USAGE_FOOTER_RE.sub("", content)
-        if not content and message.embeds:
-            content = self._extract_embed_text(embeds=list(message.embeds))
-        if not content and message.is_system():
-            content = message.system_content
-        return content
-
-    async def _image_to_part(
-        self, source: Attachment | StickerItem | str
-    ) -> ResponseInputImageParam | None:
-        """Converts an image source to a content part for the API."""
-        url = source if isinstance(source, str) else source.url
-        try:
-            if isinstance(source, str):
-                downloaded = get_pil_image(image_file=source)
-            else:
-                downloaded = Image.open(BytesIO(await source.read()))
-            downloaded.thumbnail(size=(1568, 1568))
-            if downloaded.mode != "RGB":
-                downloaded = downloaded.convert("RGB")
-            buffer = BytesIO()
-            downloaded.save(buffer, format="JPEG", quality=85, optimize=True)
-            b64 = base64.b64encode(buffer.getvalue()).decode("utf-8")
-            converted = convert_base64_to_data_uri(b64)
-            return ResponseInputImageParam(image_url=converted, detail="auto", type="input_image")
-        except Exception:
-            logfire.warn(f"Failed to convert this image: {url}")
-            return None
-
-    async def _attachment_to_part(self, attachment: Attachment) -> ResponseInputFileParam | None:
-        """Converts a file attachment to a content part for the API."""
-        try:
-            file_bytes = await attachment.read()
-            b64_data = base64.b64encode(file_bytes).decode()
-            content_type = attachment.content_type or guess_type(attachment.filename)[0] or ""
-            mime_type = content_type.split(";")[0].strip()
-            if not mime_type:
-                logfire.warn(
-                    f"Skipping attachment with unknown MIME type: {attachment.filename} ({attachment.url})"
-                )
-                return None
-            data_uri = f"data:{mime_type};base64,{b64_data}"
-            return ResponseInputFileParam(
-                filename=attachment.filename, file_data=data_uri, type="input_file"
-            )
-        except Exception:
-            logfire.warn(f"Failed to download this attachment: {attachment.url}")
-            return None
-
-    @staticmethod
-    def _required_modality(content_type: str) -> Literal["image", "video", "audio"]:
-        """Maps a MIME type to the input modality the model must accept.
-
-        Document-style files (PDF / text / json / ...) collapse to `image`
-        because LiteLLM's `supported_modalities` exposes no separate document
-        bucket, and every multimodal model that takes `input_image` also
-        accepts inline `input_file` payloads.
-        """
-        if content_type.startswith("video/"):
-            return "video"
-        if content_type.startswith("audio/"):
-            return "audio"
-        return "image"
-
-    async def _get_attachment_parts(
-        self, message: Message
-    ) -> list[ResponseInputImageParam | ResponseInputFileParam]:
-        """Extracts attachment content parts from a message."""
-        slow_model = self.runtime_models.slow_model
-        modalities = get_supported_modalities(model_name=slow_model.name)
-        content_parts: list[ResponseInputImageParam | ResponseInputFileParam | None] = []
-
-        for attachment in message.attachments:
-            content_type = attachment.content_type or guess_type(attachment.filename)[0] or ""
-            required = self._required_modality(content_type=content_type)
-            if required in modalities:
-                if content_type.startswith("image/"):
-                    content_parts.append(await self._image_to_part(source=attachment))
-                else:
-                    content_parts.append(await self._attachment_to_part(attachment=attachment))
-            else:
-                logfire.warn(
-                    f"Skipping {required} attachment for {slow_model.name}: {attachment.filename}"
-                )
-
-        if "image" in modalities:
-            for sticker in message.stickers:
-                content_parts.append(await self._image_to_part(source=sticker))
-
-            # Prefer Discord's proxy_url (media.discordapp.net) over the original URL, since sources like Threads CDN expire and reject requests without specific headers.
-            for embed in message.embeds:
-                if embed.image and (url := embed.image.proxy_url or embed.image.url):
-                    content_parts.append(await self._image_to_part(source=url))
-                if embed.thumbnail and (url := embed.thumbnail.proxy_url or embed.thumbnail.url):
-                    content_parts.append(await self._image_to_part(source=url))
-
-        content_parts = [part for part in content_parts if part is not None]
-        return content_parts
-
-    async def _process_single_message(self, message: Message) -> EasyInputMessageParam:
-        """Processes a single Discord message into a Responses API input message."""
-        try:
-            content = await self._get_cleaned_content(message=message)
-            attachment_parts = await self._get_attachment_parts(message=message)
-            is_bot = bool(self.bot.user and message.author.id == self.bot.user.id)
-
-            # Bot's own history without attachments → role=assistant carries identity,
-            # so the sender-prefix is dropped here. Without this, the model sees its
-            # own past replies prefixed with `Bot (bot) [id: ...]:` and learns to mimic
-            # that header, which leaks into output despite the prompt-level guard.
-            if is_bot and not attachment_parts:
-                return EasyInputMessageParam(role="assistant", content=content)
-
-            prefixed = (
-                f"{message.author.display_name} ({message.author.name}) "
-                f"[id: {message.author.id}]: {content}"
-            )
-
-            # No attachments → use EasyInputMessageParam's string-content shorthand.
-            # The SDK serializes it as `input_text` for role=user, which satisfies
-            # GPT-5.4's strict rule about content-part types per role.
-            if not attachment_parts:
-                return EasyInputMessageParam(role="user", content=prefixed)
-
-            # Has attachments → must use a content list with input_text/input_image.
-            # role=assistant cannot carry `input_image` (only output_text/refusal),
-            # so bot replies that include generated images (from _handle_image_reply)
-            # fall back to role=user; the author prefix above preserves bot identity.
-            return EasyInputMessageParam(
-                role="user",
-                content=[
-                    ResponseInputTextParam(text=prefixed, type="input_text"),
-                    *attachment_parts,
-                ],
-            )
-        except Exception:
-            logfire.warn(f"Failed to process message {message.id}", _exc_info=True)
-            return EasyInputMessageParam(role="user", content="")
 
     async def _get_history_message(
         self, message: Message, limit: int
@@ -263,7 +74,7 @@ class ReplyGeneratorCogs(commands.Cog):
         if hist_messages:
             tasks: list[Awaitable[EasyInputMessageParam]] = []
             for hist_msg in hist_messages:
-                task = self._process_single_message(message=hist_msg)
+                task = self.discord_messages.process_single_message(message=hist_msg)
                 tasks.append(task)
             processed: list[EasyInputMessageParam] = await asyncio.gather(*tasks)
 
@@ -303,7 +114,7 @@ class ReplyGeneratorCogs(commands.Cog):
 
         tasks: list[Awaitable[EasyInputMessageParam]] = []
         for ref in chain:
-            task = self._process_single_message(message=ref)
+            task = self.discord_messages.process_single_message(message=ref)
             tasks.append(task)
         processed: list[EasyInputMessageParam] = await asyncio.gather(*tasks)
 
@@ -340,7 +151,7 @@ class ReplyGeneratorCogs(commands.Cog):
                 ],
             )
         ]
-        current_msg = await self._process_single_message(message=message)
+        current_msg = await self.discord_messages.process_single_message(message=message)
         messages.append(current_msg)
         return messages
 
@@ -370,12 +181,12 @@ class ReplyGeneratorCogs(commands.Cog):
         image_model = self.runtime_models.image_model
         if message.reference and isinstance(message.reference.resolved, Message):
             own_parts, ref_parts = await asyncio.gather(
-                self._get_attachment_parts(message=message),
-                self._get_attachment_parts(message=message.reference.resolved),
+                self.discord_messages.get_attachment_parts(message=message),
+                self.discord_messages.get_attachment_parts(message=message.reference.resolved),
             )
             attachment_parts = own_parts + ref_parts
         else:
-            attachment_parts = await self._get_attachment_parts(message=message)
+            attachment_parts = await self.discord_messages.get_attachment_parts(message=message)
 
         data_uris: list[str] = []
         for part in attachment_parts:
@@ -444,16 +255,6 @@ class ReplyGeneratorCogs(commands.Cog):
         final_content = f"{message.author.mention} {image_description}"
         await message.reply(content=final_content, file=image_file)
 
-    async def _handle_reaction(
-        self, message: Message, emoji: str, previous: str | None = None
-    ) -> None:
-        """Handles adding and removing reactions on a message."""
-        if previous and self.bot.user:
-            with contextlib.suppress(Exception):
-                await message.remove_reaction(emoji=previous, member=self.bot.user)
-        with contextlib.suppress(Exception):
-            await message.add_reaction(emoji=emoji)
-
     async def _route_message(self, message: Message) -> Literal["IMAGE", "QA", "SUMMARY", "VIDEO"]:
         """Routes the message to the appropriate handler."""
         message_list: list[EasyInputMessageParam] = []
@@ -486,141 +287,6 @@ class ReplyGeneratorCogs(commands.Cog):
             logfire.warn("RouteDecision parse failed, model returned no text; defaulting to QA")
             return "QA"
 
-    @staticmethod
-    def _split_reply_for_discord(content: str, footer: str) -> tuple[str, list[str]]:
-        """Splits a completed reply into one parent message plus follow-up chunks."""
-        if len(f"{content}{footer}") <= _DISCORD_MESSAGE_LIMIT:
-            return f"{content}{footer}", []
-
-        tail_capacity = _DISCORD_MESSAGE_LIMIT - len(footer)
-        if tail_capacity <= 0:
-            raise ValueError("Usage footer is too long for Discord message content")
-
-        parent_content = content[:_DISCORD_MESSAGE_LIMIT]
-        remaining = content[_DISCORD_MESSAGE_LIMIT:]
-        follow_up_chunks: list[str] = []
-
-        while len(remaining) > _DISCORD_MESSAGE_LIMIT:
-            follow_up_chunks.append(remaining[:_DISCORD_MESSAGE_LIMIT])
-            remaining = remaining[_DISCORD_MESSAGE_LIMIT:]
-
-        if len(remaining) <= tail_capacity:
-            follow_up_chunks.append(f"{remaining}{footer}")
-        else:
-            follow_up_chunks.append(remaining[:tail_capacity])
-            follow_up_chunks.append(f"{remaining[tail_capacity:]}{footer}")
-        return parent_content, follow_up_chunks
-
-    async def _write_streaming_preview(
-        self, message: Message, reply: Message | None, content: str, displayed_content: str
-    ) -> tuple[Message | None, str]:
-        """Writes at most one Discord message worth of streaming preview text."""
-        preview = content[:_DISCORD_MESSAGE_LIMIT]
-        if preview == displayed_content:
-            return reply, displayed_content
-        if reply is None:
-            reply = await message.reply(content=preview)
-        else:
-            await reply.edit(content=preview)
-        return reply, preview
-
-    async def _finalize_streaming_reply(
-        self, message: Message, reply: Message | None, content: str, footer: str
-    ) -> Message:
-        """Writes the final reply, continuing overflow as follow-up replies in the same channel."""
-        parent_content, follow_up_chunks = self._split_reply_for_discord(
-            content=content, footer=footer
-        )
-        if reply is None:
-            reply = await message.reply(content=parent_content)
-        else:
-            await reply.edit(content=parent_content)
-        previous = reply
-        for chunk in follow_up_chunks:
-            previous = await previous.reply(content=chunk)
-        return reply
-
-    async def _handle_streaming(  # noqa: C901 -- dispatches on multiple Responses API stream event types
-        self, responses: AsyncStream[ResponseStreamEvent], message: Message
-    ) -> str:
-        """Handles streaming responses from the API and updates the Discord message."""
-        stored_content = ""
-        counted_content = 0
-        reply: Message | None = None
-        displayed_content = ""
-        content_started = False
-        model_name = ""
-        input_tokens = 0
-        output_tokens = 0
-        used_web_search = False
-
-        async for response in responses:
-            if response.type == "response.completed":
-                model_name = response.response.model
-                if response.response.usage:
-                    input_tokens = response.response.usage.input_tokens
-                    output_tokens = response.response.usage.output_tokens
-            elif response.type in {
-                "response.web_search_call.in_progress",
-                "response.web_search_call.searching",
-                "response.web_search_call.completed",
-                "response.output_text.annotation.added",
-            }:
-                used_web_search = True
-            elif response.type == "response.output_text.delta":
-                delta = response.delta
-                if not content_started:
-                    delta = delta.lstrip("\n")
-                    if not delta:
-                        continue
-                    content_started = True
-                stored_content += delta
-                counted_content += len(delta)
-
-                if counted_content >= 30:
-                    reply, displayed_content = await self._write_streaming_preview(
-                        message=message,
-                        reply=reply,
-                        content=stored_content,
-                        displayed_content=displayed_content,
-                    )
-                    counted_content = 0
-
-        input_rate, output_rate = get_token_rates(model_name=model_name)
-        cost = input_rate * input_tokens + output_rate * output_tokens
-
-        # Award chat points equal to total tokens used. We await this (rather than fire-and-forget)
-        # so the resulting balance can land in the footer.
-        # On DB failure, it returns None and the footer falls back to the delta-only format.
-        total_tokens = input_tokens + output_tokens
-        avatar_url = await guild_avatar_url(
-            user=message.author, guild=getattr(message, "guild", None)
-        )
-        result = await credit_with_repayment(
-            user_id=message.author.id,
-            name=message.author.name,
-            avatar_url=avatar_url,
-            amount=total_tokens,
-        )
-
-        stored_content = _CODED_MENTION_RE.sub(r"\1", stored_content)
-        if result.new_balance is not None:
-            balance_text = f"{currency_text(amount=result.new_balance, compact=True)} ({currency_text(amount=total_tokens, signed=True, compact=True)})"
-        else:
-            balance_text = currency_text(amount=total_tokens, signed=True, compact=True)
-        usage_footer = f"\n\n-# {model_name} · ⬆ {input_tokens:,} ⬇ {output_tokens:,} · ${cost:.8f} · {balance_text}"
-
-        # Final update to ensure complete message is displayed.
-        await self._finalize_streaming_reply(
-            message=message, reply=reply, content=stored_content, footer=usage_footer
-        )
-        stored_content += usage_footer
-
-        if used_web_search:
-            await self._handle_reaction(message=message, emoji="🌐")
-
-        return stored_content
-
     async def _handle_message_reply(
         self, message: Message, system_prompt: str, history_limit: int
     ) -> None:
@@ -649,7 +315,7 @@ class ReplyGeneratorCogs(commands.Cog):
             extra_body={"mock_testing_fallbacks": False},
         )
 
-        await self._handle_streaming(responses=responses, message=message)
+        await self.discord_stream.handle_streaming(responses=responses, message=message)
 
     @commands.Cog.listener()
     async def on_message(self, message: Message) -> None:
@@ -671,43 +337,50 @@ class ReplyGeneratorCogs(commands.Cog):
         if not is_dm and (not self.bot.user or f"<@{self.bot.user.id}>" not in message.content):
             return
 
-        user_prompt = await self._get_user_prompt(content=message.content)
+        user_prompt = await self.discord_messages.get_user_prompt(content=message.content)
         has_attachment = bool(message.attachments or message.stickers)
 
         if not user_prompt and not has_attachment:
-            await self._handle_reaction(message=message, emoji="❓")
+            await self.discord_messages.handle_reaction(message=message, emoji="❓")
             await message.reply(content="?")
             return
 
         try:
-            await self._handle_reaction(message=message, emoji="🔀")
-            current_emoji = "🔀"
+            current_emoji = await self.discord_messages.handle_reaction(
+                message=message, emoji="🔀"
+            )
             route = await self._route_message(message=message)
             if route == "IMAGE":
-                await self._handle_reaction(message=message, emoji="🎨", previous=current_emoji)
-                current_emoji = "🎨"
+                current_emoji = await self.discord_messages.handle_reaction(
+                    message=message, emoji="🎨", previous=current_emoji
+                )
                 await self._handle_image_reply(message=message, user_prompt=user_prompt)
             elif route == "VIDEO":
-                await self._handle_reaction(message=message, emoji="🎬", previous=current_emoji)
-                current_emoji = "🎬"
+                current_emoji = await self.discord_messages.handle_reaction(
+                    message=message, emoji="🎬", previous=current_emoji
+                )
                 await self._handle_video_reply(message=message, user_prompt=user_prompt)
             elif route == "SUMMARY":
-                await self._handle_reaction(message=message, emoji="📖", previous=current_emoji)
-                current_emoji = "📖"
+                current_emoji = await self.discord_messages.handle_reaction(
+                    message=message, emoji="📖", previous=current_emoji
+                )
                 await self._handle_message_reply(
                     message=message, system_prompt=SUMMARY_PROMPT, history_limit=50
                 )
             else:
-                await self._handle_reaction(message=message, emoji="❓", previous=current_emoji)
-                current_emoji = "❓"
+                current_emoji = await self.discord_messages.handle_reaction(
+                    message=message, emoji="❓", previous=current_emoji
+                )
                 await self._handle_message_reply(
                     message=message, system_prompt=REPLY_PROMPT, history_limit=30
                 )
-            await self._handle_reaction(message=message, emoji="🆗", previous=current_emoji)
+            await self.discord_messages.handle_reaction(
+                message=message, emoji="🆗", previous=current_emoji
+            )
         except Exception as e:
             logfire.error("Failed to generate reply", user_id=message.author.name, _exc_info=True)
             with contextlib.suppress(Exception):
-                await self._handle_reaction(message=message, emoji="❌")
+                await self.discord_messages.handle_reaction(message=message, emoji="❌")
                 error_embed = Embed(
                     title="Something went wrong",
                     description=f"```\n{extract_friendly_error(exc=e)}\n```",

--- a/src/discordbot/cogs/parse_threads.py
+++ b/src/discordbot/cogs/parse_threads.py
@@ -9,6 +9,7 @@ from nextcord import File, Color, Embed, Message
 from nextcord.ext import commands
 
 from discordbot.utils.threads import ThreadsOutput, ThreadsDownloader
+from discordbot.utils.discord_ops import DiscordMessageOps
 
 URL_REGEX = re.compile(r"https?://(?:www\.)?threads\.(?:net|com)/@[^/]+/post/[^\s\"'<>)]+")
 
@@ -32,16 +33,7 @@ class ThreadsCogs(commands.Cog):
         self.output_folder = Path("./data/downloads")
         self.output_folder.mkdir(parents=True, exist_ok=True)
         self.downloader = ThreadsDownloader(output_folder=str(self.output_folder))
-
-    async def _handle_reaction(
-        self, message: Message, emoji: str, previous_emoji: str | None = None
-    ) -> None:
-        """Handles adding and removing reactions on a message."""
-        if previous_emoji and self.bot.user:
-            with contextlib.suppress(Exception):
-                await message.remove_reaction(emoji=previous_emoji, member=self.bot.user)
-        with contextlib.suppress(Exception):
-            await message.add_reaction(emoji=emoji)
+        self.discord_messages = DiscordMessageOps(bot=bot)
 
     @staticmethod
     def _gradient_color(index: int, total: int) -> Color:
@@ -138,14 +130,13 @@ class ThreadsCogs(commands.Cog):
             return
 
         url = match.group(0)
-        current_emoji = "🔗"
-        await self._handle_reaction(message=message, emoji=current_emoji)
+        current_emoji = await self.discord_messages.handle_reaction(message=message, emoji="🔗")
 
         try:
             with self.downloader.parse(url) as results:
                 if not results:
-                    await self._handle_reaction(
-                        message=message, emoji="⚠️", previous_emoji=current_emoji
+                    await self.discord_messages.handle_reaction(
+                        message=message, emoji="⚠️", previous=current_emoji
                     )
                     return
 
@@ -163,8 +154,8 @@ class ThreadsCogs(commands.Cog):
                     or len(target.video_paths) + len(target.image_urls) > 10
                     or len(target.text) > 4096
                 ):
-                    await self._handle_reaction(
-                        message=message, emoji="⚠️", previous_emoji=current_emoji
+                    await self.discord_messages.handle_reaction(
+                        message=message, emoji="⚠️", previous=current_emoji
                     )
                     return
 
@@ -180,14 +171,14 @@ class ThreadsCogs(commands.Cog):
                     await message.edit(suppress=True)
 
                 await message.reply(embeds=embeds, files=files, mention_author=False)
-                await self._handle_reaction(
-                    message=message, emoji="🆗", previous_emoji=current_emoji
+                await self.discord_messages.handle_reaction(
+                    message=message, emoji="🆗", previous=current_emoji
                 )
         except Exception:
             logfire.error("Failed to send Threads message", _exc_info=True)
             with contextlib.suppress(Exception):
-                await self._handle_reaction(
-                    message=message, emoji="❌", previous_emoji=current_emoji
+                await self.discord_messages.handle_reaction(
+                    message=message, emoji="❌", previous=current_emoji
                 )
 
 

--- a/src/discordbot/utils/discord_ops.py
+++ b/src/discordbot/utils/discord_ops.py
@@ -1,0 +1,407 @@
+"""Discord message ingestion and LLM streaming helpers.
+
+Two BaseModel-backed service classes own the Discord-side work that used to
+live as private helpers on ``ReplyGeneratorCogs``:
+
+- :class:`DiscordMessageOps` turns Discord messages, embeds, stickers, and
+  attachments into Responses API input parts, and manages the bot's
+  status-emoji reactions on a user's message.
+- :class:`DiscordStreamOps` consumes an OpenAI Responses stream, writes the
+  preview / final Discord messages, computes token cost, awards the chat
+  reward, and adds the web-search reaction when applicable.
+"""
+
+from io import BytesIO
+import re
+import base64
+import contextlib
+from typing import Literal
+from mimetypes import guess_type
+
+from PIL import Image
+import logfire
+from nextcord import Embed, Message, Attachment, StickerItem
+from pydantic import BaseModel, ConfigDict, SkipValidation
+from nextcord.ext import commands
+from openai import AsyncStream
+from openai.types.responses import ResponseStreamEvent
+from openai.types.responses.response_input_param import EasyInputMessageParam
+from openai.types.responses.response_input_file_param import ResponseInputFileParam
+from openai.types.responses.response_input_text_param import ResponseInputTextParam
+from openai.types.responses.response_input_image_param import ResponseInputImageParam
+
+from discordbot.utils.images import get_pil_image, convert_base64_to_data_uri
+from discordbot.utils.avatars import guild_avatar_url
+from discordbot.typings.models import RuntimeModelCatalog
+from discordbot.utils.model_pricing import get_token_rates, get_supported_modalities
+from discordbot.cogs._economy.database import credit_with_repayment
+from discordbot.cogs._economy.presentation import currency_text
+
+# Gemini occasionally wraps Discord mention syntax in backticks (inline code),
+# which stops Discord from rendering the actual mention. Strip those wrappers
+# before sending; matches user (<@id>, <@!id>), role (<@&id>) and channel (<#id>) mentions.
+_CODED_MENTION_RE = re.compile(r"`(<(?:@[!&]?|#)\d+>)`")
+
+# Strips the usage_footer appended by `DiscordStreamOps.handle_streaming` from
+# bot-authored messages before feeding them back as `role=assistant` history.
+# Without this, the model performs in-context learning on its own past footers
+# and starts hallucinating fake "-# model · ⬆ ... ⬇ ... · $... · ..." lines into
+# fresh replies. Anchored on the `\n\n-# ` separator plus the ⬆/⬇ token-count
+# icons, which never appear together in user-authored content.
+_USAGE_FOOTER_RE = re.compile(r"\n\n-#[^\n]*⬆[^\n]*⬇[^\n]*$")
+_DISCORD_MESSAGE_LIMIT = 2000
+
+
+class DiscordMessageOps(BaseModel):
+    """Converts Discord messages and attachments into Responses API inputs.
+
+    Attributes:
+        bot: Discord bot whose user identity feeds prompt cleanup and the
+            assistant role decision in ``process_single_message``.
+        runtime_models: Catalog used to gate attachment modalities against the
+            active slow model. Optional because callers that only need
+            reaction handling (e.g. ``parse_threads``) can omit it.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    bot: SkipValidation[commands.Bot]
+    runtime_models: RuntimeModelCatalog | None = None
+
+    async def handle_reaction(
+        self, message: Message, emoji: str, previous: str | None = None
+    ) -> str:
+        """Adds ``emoji`` to ``message`` and removes ``previous`` first if given.
+
+        Returns:
+            The emoji that was just applied, so callers can chain
+            ``current_emoji = await handle_reaction(...)``.
+        """
+        if previous and self.bot.user:
+            with contextlib.suppress(Exception):
+                await message.remove_reaction(emoji=previous, member=self.bot.user)
+        with contextlib.suppress(Exception):
+            await message.add_reaction(emoji=emoji)
+        return emoji
+
+    async def get_user_prompt(self, content: str) -> str:
+        """Removes the bot mention from the content and strips whitespace."""
+        if self.bot.user:
+            content = content.replace(f"<@{self.bot.user.id}>", "")
+        return content.strip()
+
+    @staticmethod
+    def extract_embed_text(embeds: list[Embed]) -> str:
+        """Joins author / title / description / fields / footer text from embeds."""
+        embed_parts: list[str] = []
+        for embed in embeds:
+            parts: list[str] = []
+            if embed.author and embed.author.name:
+                parts.append(f"Author: {embed.author.name}")
+            if embed.title:
+                parts.append(f"Title: {embed.title}")
+            if embed.description:
+                parts.append(embed.description)
+            for field in embed.fields:
+                parts.append(f"{field.name}: {field.value}")
+            if embed.footer and embed.footer.text:
+                parts.append(f"Footer: {embed.footer.text}")
+            if parts:
+                embed_parts.append("\n".join(parts))
+        return "\n\n".join(embed_parts)
+
+    async def get_cleaned_content(self, message: Message) -> str:
+        """Returns the textual content of a message without the author prefix."""
+        content = await self.get_user_prompt(content=message.content)
+        if content and self.bot.user and message.author.id == self.bot.user.id:
+            content = _USAGE_FOOTER_RE.sub("", content)
+        if not content and message.embeds:
+            content = self.extract_embed_text(embeds=list(message.embeds))
+        if not content and message.is_system():
+            content = message.system_content
+        return content
+
+    async def _image_to_part(
+        self, source: Attachment | StickerItem | str
+    ) -> ResponseInputImageParam | None:
+        """Converts an image source to a content part for the API."""
+        url = source if isinstance(source, str) else source.url
+        try:
+            if isinstance(source, str):
+                downloaded = get_pil_image(image_file=source)
+            else:
+                downloaded = Image.open(BytesIO(await source.read()))
+            downloaded.thumbnail(size=(1568, 1568))
+            if downloaded.mode != "RGB":
+                downloaded = downloaded.convert("RGB")
+            buffer = BytesIO()
+            downloaded.save(buffer, format="JPEG", quality=85, optimize=True)
+            b64 = base64.b64encode(buffer.getvalue()).decode("utf-8")
+            converted = convert_base64_to_data_uri(b64)
+            return ResponseInputImageParam(image_url=converted, detail="auto", type="input_image")
+        except Exception:
+            logfire.warn(f"Failed to convert this image: {url}")
+            return None
+
+    async def _attachment_to_part(self, attachment: Attachment) -> ResponseInputFileParam | None:
+        """Converts a file attachment to a content part for the API."""
+        try:
+            file_bytes = await attachment.read()
+            b64_data = base64.b64encode(file_bytes).decode()
+            content_type = attachment.content_type or guess_type(attachment.filename)[0] or ""
+            mime_type = content_type.split(";")[0].strip()
+            if not mime_type:
+                logfire.warn(
+                    f"Skipping attachment with unknown MIME type: {attachment.filename} ({attachment.url})"
+                )
+                return None
+            data_uri = f"data:{mime_type};base64,{b64_data}"
+            return ResponseInputFileParam(
+                filename=attachment.filename, file_data=data_uri, type="input_file"
+            )
+        except Exception:
+            logfire.warn(f"Failed to download this attachment: {attachment.url}")
+            return None
+
+    @staticmethod
+    def _required_modality(content_type: str) -> Literal["image", "video", "audio"]:
+        """Maps a MIME type to the input modality the model must accept.
+
+        Document-style files (PDF / text / json / ...) collapse to `image`
+        because LiteLLM's `supported_modalities` exposes no separate document
+        bucket, and every multimodal model that takes `input_image` also
+        accepts inline `input_file` payloads.
+        """
+        if content_type.startswith("video/"):
+            return "video"
+        if content_type.startswith("audio/"):
+            return "audio"
+        return "image"
+
+    async def get_attachment_parts(
+        self, message: Message
+    ) -> list[ResponseInputImageParam | ResponseInputFileParam]:
+        """Extracts attachment content parts from a message."""
+        if self.runtime_models is None:
+            raise ValueError("DiscordMessageOps.get_attachment_parts requires runtime_models")
+        slow_model = self.runtime_models.slow_model
+        modalities = get_supported_modalities(model_name=slow_model.name)
+        content_parts: list[ResponseInputImageParam | ResponseInputFileParam | None] = []
+
+        for attachment in message.attachments:
+            content_type = attachment.content_type or guess_type(attachment.filename)[0] or ""
+            required = self._required_modality(content_type=content_type)
+            if required in modalities:
+                if content_type.startswith("image/"):
+                    content_parts.append(await self._image_to_part(source=attachment))
+                else:
+                    content_parts.append(await self._attachment_to_part(attachment=attachment))
+            else:
+                logfire.warn(
+                    f"Skipping {required} attachment for {slow_model.name}: {attachment.filename}"
+                )
+
+        if "image" in modalities:
+            for sticker in message.stickers:
+                content_parts.append(await self._image_to_part(source=sticker))
+
+            # Prefer Discord's proxy_url (media.discordapp.net) over the original URL, since sources like Threads CDN expire and reject requests without specific headers.
+            for embed in message.embeds:
+                if embed.image and (url := embed.image.proxy_url or embed.image.url):
+                    content_parts.append(await self._image_to_part(source=url))
+                if embed.thumbnail and (url := embed.thumbnail.proxy_url or embed.thumbnail.url):
+                    content_parts.append(await self._image_to_part(source=url))
+
+        content_parts = [part for part in content_parts if part is not None]
+        return content_parts
+
+    async def process_single_message(self, message: Message) -> EasyInputMessageParam:
+        """Processes a single Discord message into a Responses API input message."""
+        try:
+            content = await self.get_cleaned_content(message=message)
+            attachment_parts = await self.get_attachment_parts(message=message)
+            is_bot = bool(self.bot.user and message.author.id == self.bot.user.id)
+
+            # Bot's own history without attachments → role=assistant carries identity,
+            # so the sender-prefix is dropped here. Without this, the model sees its
+            # own past replies prefixed with `Bot (bot) [id: ...]:` and learns to mimic
+            # that header, which leaks into output despite the prompt-level guard.
+            if is_bot and not attachment_parts:
+                return EasyInputMessageParam(role="assistant", content=content)
+
+            prefixed = (
+                f"{message.author.display_name} ({message.author.name}) "
+                f"[id: {message.author.id}]: {content}"
+            )
+
+            # No attachments → use EasyInputMessageParam's string-content shorthand.
+            # The SDK serializes it as `input_text` for role=user, which satisfies
+            # GPT-5.4's strict rule about content-part types per role.
+            if not attachment_parts:
+                return EasyInputMessageParam(role="user", content=prefixed)
+
+            # Has attachments → must use a content list with input_text/input_image.
+            # role=assistant cannot carry `input_image` (only output_text/refusal),
+            # so bot replies that include generated images (from _handle_image_reply)
+            # fall back to role=user; the author prefix above preserves bot identity.
+            return EasyInputMessageParam(
+                role="user",
+                content=[
+                    ResponseInputTextParam(text=prefixed, type="input_text"),
+                    *attachment_parts,
+                ],
+            )
+        except Exception:
+            logfire.warn(f"Failed to process message {message.id}", _exc_info=True)
+            return EasyInputMessageParam(role="user", content="")
+
+
+class DiscordStreamOps(BaseModel):
+    """Renders OpenAI Responses streams into Discord messages with economy footer.
+
+    Attributes:
+        bot: Discord bot, kept for symmetry with :class:`DiscordMessageOps` and
+            future expansion.
+        msg_ops: Sibling ops used to delegate the web-search reaction so the
+            reaction primitive lives in one place.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    bot: SkipValidation[commands.Bot]
+    msg_ops: DiscordMessageOps
+
+    @staticmethod
+    def _split_reply_for_discord(content: str, footer: str) -> tuple[str, list[str]]:
+        """Splits a completed reply into one parent message plus follow-up chunks."""
+        if len(f"{content}{footer}") <= _DISCORD_MESSAGE_LIMIT:
+            return f"{content}{footer}", []
+
+        tail_capacity = _DISCORD_MESSAGE_LIMIT - len(footer)
+        if tail_capacity <= 0:
+            raise ValueError("Usage footer is too long for Discord message content")
+
+        parent_content = content[:_DISCORD_MESSAGE_LIMIT]
+        remaining = content[_DISCORD_MESSAGE_LIMIT:]
+        follow_up_chunks: list[str] = []
+
+        while len(remaining) > _DISCORD_MESSAGE_LIMIT:
+            follow_up_chunks.append(remaining[:_DISCORD_MESSAGE_LIMIT])
+            remaining = remaining[_DISCORD_MESSAGE_LIMIT:]
+
+        if len(remaining) <= tail_capacity:
+            follow_up_chunks.append(f"{remaining}{footer}")
+        else:
+            follow_up_chunks.append(remaining[:tail_capacity])
+            follow_up_chunks.append(f"{remaining[tail_capacity:]}{footer}")
+        return parent_content, follow_up_chunks
+
+    async def _write_streaming_preview(
+        self, message: Message, reply: Message | None, content: str, displayed_content: str
+    ) -> tuple[Message | None, str]:
+        """Writes at most one Discord message worth of streaming preview text."""
+        preview = content[:_DISCORD_MESSAGE_LIMIT]
+        if preview == displayed_content:
+            return reply, displayed_content
+        if reply is None:
+            reply = await message.reply(content=preview)
+        else:
+            await reply.edit(content=preview)
+        return reply, preview
+
+    async def _finalize_streaming_reply(
+        self, message: Message, reply: Message | None, content: str, footer: str
+    ) -> Message:
+        """Writes the final reply, continuing overflow as follow-up replies in the same channel."""
+        parent_content, follow_up_chunks = self._split_reply_for_discord(
+            content=content, footer=footer
+        )
+        if reply is None:
+            reply = await message.reply(content=parent_content)
+        else:
+            await reply.edit(content=parent_content)
+        previous = reply
+        for chunk in follow_up_chunks:
+            previous = await previous.reply(content=chunk)
+        return reply
+
+    async def handle_streaming(  # noqa: C901 -- dispatches on multiple Responses API stream event types
+        self, responses: AsyncStream[ResponseStreamEvent], message: Message
+    ) -> str:
+        """Handles streaming responses from the API and updates the Discord message."""
+        stored_content = ""
+        counted_content = 0
+        reply: Message | None = None
+        displayed_content = ""
+        content_started = False
+        model_name = ""
+        input_tokens = 0
+        output_tokens = 0
+        used_web_search = False
+
+        async for response in responses:
+            if response.type == "response.completed":
+                model_name = response.response.model
+                if response.response.usage:
+                    input_tokens = response.response.usage.input_tokens
+                    output_tokens = response.response.usage.output_tokens
+            elif response.type in {
+                "response.web_search_call.in_progress",
+                "response.web_search_call.searching",
+                "response.web_search_call.completed",
+                "response.output_text.annotation.added",
+            }:
+                used_web_search = True
+            elif response.type == "response.output_text.delta":
+                delta = response.delta
+                if not content_started:
+                    delta = delta.lstrip("\n")
+                    if not delta:
+                        continue
+                    content_started = True
+                stored_content += delta
+                counted_content += len(delta)
+
+                if counted_content >= 30:
+                    reply, displayed_content = await self._write_streaming_preview(
+                        message=message,
+                        reply=reply,
+                        content=stored_content,
+                        displayed_content=displayed_content,
+                    )
+                    counted_content = 0
+
+        input_rate, output_rate = get_token_rates(model_name=model_name)
+        cost = input_rate * input_tokens + output_rate * output_tokens
+
+        # Award chat points equal to total tokens used. We await this (rather than fire-and-forget)
+        # so the resulting balance can land in the footer.
+        # On DB failure, it returns None and the footer falls back to the delta-only format.
+        total_tokens = input_tokens + output_tokens
+        avatar_url = await guild_avatar_url(
+            user=message.author, guild=getattr(message, "guild", None)
+        )
+        result = await credit_with_repayment(
+            user_id=message.author.id,
+            name=message.author.name,
+            avatar_url=avatar_url,
+            amount=total_tokens,
+        )
+
+        stored_content = _CODED_MENTION_RE.sub(r"\1", stored_content)
+        if result.new_balance is not None:
+            balance_text = f"{currency_text(amount=result.new_balance, compact=True)} ({currency_text(amount=total_tokens, signed=True, compact=True)})"
+        else:
+            balance_text = currency_text(amount=total_tokens, signed=True, compact=True)
+        usage_footer = f"\n\n-# {model_name} · ⬆ {input_tokens:,} ⬇ {output_tokens:,} · ${cost:.8f} · {balance_text}"
+
+        # Final update to ensure complete message is displayed.
+        await self._finalize_streaming_reply(
+            message=message, reply=reply, content=stored_content, footer=usage_footer
+        )
+        stored_content += usage_footer
+
+        if used_web_search:
+            await self.msg_ops.handle_reaction(message=message, emoji="🌐")
+
+        return stored_content

--- a/tests/test_discord_ops.py
+++ b/tests/test_discord_ops.py
@@ -1,0 +1,425 @@
+"""Tests for DiscordMessageOps and DiscordStreamOps in utils.discord_ops."""
+
+from __future__ import annotations
+
+from io import BytesIO
+from types import SimpleNamespace
+import base64
+from typing import TYPE_CHECKING
+
+from PIL import Image
+import pytest
+from nextcord import File, Embed
+
+from discordbot.typings.models import RuntimeModelCatalog
+from discordbot.utils.discord_ops import (
+    _USAGE_FOOTER_RE,
+    _DISCORD_MESSAGE_LIMIT,
+    DiscordMessageOps,
+    DiscordStreamOps,
+)
+
+TEST_LLM_MODEL = "test-llm-model"
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+class FakeGuild:
+    """Minimal guild stub with a stable ID."""
+
+    def __init__(self, guild_id: int = 1) -> None:
+        """Initializes the fake guild ID."""
+        self.id = guild_id
+
+
+class FakeReference:
+    """Minimal message reference stub."""
+
+    def __init__(self, resolved: FakeMessage) -> None:
+        """Initializes the resolved referenced message."""
+        self.resolved = resolved
+
+
+class FakeReply:
+    """Provides a fake reply object that records edited content and follow-up replies."""
+
+    def __init__(self) -> None:
+        """Initializes the fake reply with empty content and no follow-up chain."""
+        self.content: str | None = ""
+        self.file: File | None = None
+        self.embed: Embed | None = None
+        self.replies: list[FakeReply] = []
+
+    async def edit(self, content: str) -> None:
+        """Records the replacement content passed to edit."""
+        self.content = content
+
+    async def reply(self, content: str) -> FakeReply:
+        """Creates and records a follow-up reply in the chain."""
+        child = FakeReply()
+        child.content = content
+        self.replies.append(child)
+        return child
+
+
+class FakeAuthor:
+    """Minimal stand-in for `Message.author`."""
+
+    def __init__(self, bot: bool = False, user_id: int = 12345) -> None:
+        """Initializes the fake author with stable id and name fields."""
+        self.id = user_id
+        self.name = "tester"
+        self.display_name = "Tester"
+        self.mention = f"<@{user_id}>"
+        self.bot = bot
+        self.display_avatar = SimpleNamespace(url="https://example.test/avatar.png")
+
+
+class FakeMessage:
+    """Provides a fake message object that records created replies."""
+
+    def __init__(self, content: str = "", author: FakeAuthor | None = None) -> None:
+        """Initializes the fake message with no recorded replies."""
+        self.replies: list[FakeReply] = []
+        self.author = author or FakeAuthor()
+        self.content = content
+        self.embeds: list[Embed] = []
+        self.attachments: list[FakeAttachment] = []
+        self.stickers: list[FakeAttachment] = []
+        self.reference: FakeReference | None = None
+        self.guild: FakeGuild | None = FakeGuild()
+        self.channel = SimpleNamespace(history=self._history)
+        self.id = 987
+        self.system_content = ""
+        self.added_reactions: list[str] = []
+        self.removed_reactions: list[tuple[str, FakeAuthor]] = []
+
+    async def _history(
+        self, limit: int, before: FakeMessage, oldest_first: bool
+    ) -> AsyncIterator[FakeMessage]:
+        """Yields no history by default."""
+        if False:
+            yield self
+
+    async def reply(
+        self, content: str | None, file: File | None = None, embed: Embed | None = None
+    ) -> FakeReply:
+        """Creates and records a fake reply with the requested content."""
+        reply = FakeReply()
+        reply.content = content
+        reply.file = file
+        reply.embed = embed
+        self.replies.append(reply)
+        return reply
+
+    async def add_reaction(self, emoji: str) -> None:
+        """Records a reaction added to the fake message."""
+        self.added_reactions.append(emoji)
+
+    async def remove_reaction(self, emoji: str, member: FakeAuthor) -> None:
+        """Records a reaction removal from the fake message."""
+        self.removed_reactions.append((emoji, member))
+
+    def is_system(self) -> bool:
+        """Returns whether the fake message carries system content."""
+        return bool(self.system_content)
+
+
+class FakeAttachment:
+    """Minimal Discord attachment or sticker stub."""
+
+    def __init__(
+        self,
+        filename: str = "file.txt",
+        content_type: str | None = "text/plain",
+        payload: bytes = b"hello",
+        url: str = "https://example.test/file.txt",
+    ) -> None:
+        """Initializes attachment metadata and payload bytes."""
+        self.filename = filename
+        self.content_type = content_type
+        self._payload = payload
+        self.url = url
+
+    async def read(self) -> bytes:
+        """Returns the configured attachment bytes."""
+        return self._payload
+
+
+def _png_b64() -> str:
+    """Returns a base64-encoded one-pixel PNG."""
+    image = Image.new(mode="RGB", size=(1, 1), color=(255, 0, 0))
+    buffer = BytesIO()
+    image.save(fp=buffer, format="PNG")
+    return base64.b64encode(s=buffer.getvalue()).decode(encoding="utf-8")
+
+
+def _ops(bot_user_id: int = 999) -> tuple[DiscordMessageOps, DiscordStreamOps]:
+    """Builds DiscordMessageOps + DiscordStreamOps instances for tests."""
+    bot = SimpleNamespace(user=SimpleNamespace(id=bot_user_id, name="bot"))
+    msg_ops = DiscordMessageOps(bot=bot, runtime_models=RuntimeModelCatalog())
+    stream_ops = DiscordStreamOps(bot=bot, msg_ops=msg_ops)
+    return msg_ops, stream_ops
+
+
+async def _stream_events() -> AsyncIterator[SimpleNamespace]:
+    """Yields a minimal streaming completion with token usage."""
+    yield SimpleNamespace(type="response.output_text.delta", delta="hello from stream")
+    yield SimpleNamespace(
+        type="response.completed",
+        response=SimpleNamespace(
+            model=TEST_LLM_MODEL,
+            usage=SimpleNamespace(input_tokens=12, output_tokens=34, output_tokens_details=None),
+        ),
+    )
+
+
+async def _stream_events_from(events: list[SimpleNamespace]) -> AsyncIterator[SimpleNamespace]:
+    """Yields the provided fake streaming events in order."""
+    for event in events:
+        yield event
+
+
+async def test_handle_reaction_returns_emoji_for_chaining() -> None:
+    """Verifies handle_reaction returns the applied emoji so callers can chain."""
+    msg_ops, _stream_ops = _ops()
+    message = FakeMessage()
+
+    first = await msg_ops.handle_reaction(message=message, emoji="🔀")
+    assert first == "🔀"
+    assert message.added_reactions == ["🔀"]
+
+    second = await msg_ops.handle_reaction(message=message, emoji="🆗", previous=first)
+    assert second == "🆗"
+    assert message.added_reactions == ["🔀", "🆗"]
+    assert message.removed_reactions[0][0] == "🔀"
+
+
+async def test_handle_streaming_allows_missing_output_token_details(
+    economy_isolated_db: None,
+) -> None:
+    """Regression: LiteLLM may return usage with output_tokens_details=null."""
+    del economy_isolated_db
+    _msg_ops, stream_ops = _ops()
+    message = FakeMessage()
+
+    result = await stream_ops.handle_streaming(responses=_stream_events(), message=message)
+
+    expected = (
+        f"hello from stream\n\n-# {TEST_LLM_MODEL} · ⬆ 12 ⬇ 34 · $0.00000000"
+        " · 46 虛擬歡樂豆 (+46 虛擬歡樂豆)"
+    )
+    assert result == expected
+    assert message.replies[0].content == result
+
+
+async def test_handle_streaming_continues_long_reply_as_reply_chain(
+    economy_isolated_db: None,
+) -> None:
+    """Verifies replies over Discord's content limit continue as a reply chain."""
+    del economy_isolated_db
+    _msg_ops, stream_ops = _ops()
+    message = FakeMessage(content="<@999> explain how long Discord replies are handled")
+    body = "x" * 4500
+
+    result = await stream_ops.handle_streaming(
+        responses=_stream_events_from(
+            events=[
+                SimpleNamespace(type="response.output_text.delta", delta=body),
+                SimpleNamespace(
+                    type="response.completed",
+                    response=SimpleNamespace(
+                        model=TEST_LLM_MODEL,
+                        usage=SimpleNamespace(input_tokens=1, output_tokens=2),
+                    ),
+                ),
+            ]
+        ),
+        message=message,
+    )
+
+    usage_footer = (
+        f"\n\n-# {TEST_LLM_MODEL} · ⬆ 1 ⬇ 2 · $0.00000000 · 3 虛擬歡樂豆 (+3 虛擬歡樂豆)"
+    )
+    assert result == f"{body}{usage_footer}"
+
+    parent = message.replies[0]
+    assert parent.content == body[:_DISCORD_MESSAGE_LIMIT]
+
+    first_follow_up = parent.replies[0]
+    assert first_follow_up.content == body[_DISCORD_MESSAGE_LIMIT : _DISCORD_MESSAGE_LIMIT * 2]
+
+    second_follow_up = first_follow_up.replies[0]
+    assert second_follow_up.content == f"{body[_DISCORD_MESSAGE_LIMIT * 2 :]}{usage_footer}"
+    assert second_follow_up.replies == []
+
+    chain_chunks = [parent.content, first_follow_up.content, second_follow_up.content]
+    assert all(len(chunk) <= _DISCORD_MESSAGE_LIMIT for chunk in chain_chunks)
+
+
+async def test_handle_streaming_marks_web_search_from_call_event(
+    economy_isolated_db: None,
+) -> None:
+    """Verifies native web_search_call events trigger the web reaction."""
+    del economy_isolated_db
+    _msg_ops, stream_ops = _ops()
+    message = FakeMessage()
+
+    await stream_ops.handle_streaming(
+        responses=_stream_events_from(
+            events=[
+                SimpleNamespace(type="response.output_text.delta", delta="answer"),
+                SimpleNamespace(type="response.web_search_call.completed"),
+                SimpleNamespace(
+                    type="response.completed",
+                    response=SimpleNamespace(
+                        model=TEST_LLM_MODEL,
+                        usage=SimpleNamespace(input_tokens=12, output_tokens=34),
+                    ),
+                ),
+            ]
+        ),
+        message=message,
+    )
+
+    assert message.added_reactions == ["🌐"]
+
+
+async def test_handle_streaming_marks_web_search_from_annotation(
+    economy_isolated_db: None,
+) -> None:
+    """Verifies any annotation event also triggers the web reaction.
+
+    LiteLLM-proxied Gemini grounds via url_citation annotations without
+    emitting web_search_call.* events, so annotation alone is treated as
+    a search signal.
+    """
+    del economy_isolated_db
+    _msg_ops, stream_ops = _ops()
+    message = FakeMessage()
+
+    await stream_ops.handle_streaming(
+        responses=_stream_events_from(
+            events=[
+                SimpleNamespace(type="response.output_text.delta", delta="grounded answer"),
+                SimpleNamespace(
+                    type="response.output_text.annotation.added",
+                    annotation={"type": "url_citation", "url": "https://example.com/article"},
+                ),
+                SimpleNamespace(
+                    type="response.completed",
+                    response=SimpleNamespace(
+                        model=TEST_LLM_MODEL,
+                        usage=SimpleNamespace(input_tokens=12, output_tokens=34),
+                    ),
+                ),
+            ]
+        ),
+        message=message,
+    )
+
+    assert message.added_reactions == ["🌐"]
+
+
+async def test_message_content_and_attachment_helpers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verifies prompt cleanup, embed extraction, and attachment conversion."""
+    msg_ops, _stream_ops = _ops()
+    embed = Embed(title="Title", description="Body")
+    embed.set_author(name="Author")
+    embed.add_field(name="Field", value="Value")
+    embed.set_footer(text="Footer")
+
+    assert await msg_ops.get_user_prompt(content="hi <@999>") == "hi"
+    assert "Author" in msg_ops.extract_embed_text(embeds=[embed])
+
+    bot_message = FakeMessage(
+        content="answer\n\n-# model · ⬆ 1 ⬇ 2 · $0.0 · +3",
+        author=FakeAuthor(bot=True, user_id=999),
+    )
+    assert await msg_ops.get_cleaned_content(message=bot_message) == "answer"
+    assert _USAGE_FOOTER_RE.search(string=bot_message.content)
+
+    embed_message = FakeMessage()
+    embed_message.embeds = [embed]
+    assert "Title" in await msg_ops.get_cleaned_content(message=embed_message)
+
+    system_message = FakeMessage()
+    system_message.system_content = "joined"
+    assert await msg_ops.get_cleaned_content(message=system_message) == "joined"
+
+    assert msg_ops._required_modality(content_type="video/mp4") == "video"
+    assert msg_ops._required_modality(content_type="audio/mpeg") == "audio"
+    assert msg_ops._required_modality(content_type="application/pdf") == "image"
+
+    file_part = await msg_ops._attachment_to_part(
+        attachment=FakeAttachment(filename="note.txt", content_type="text/plain", payload=b"abc")
+    )
+    assert file_part is not None
+    assert file_part["file_data"] == "data:text/plain;base64,YWJj"
+
+    image_part = await msg_ops._image_to_part(
+        source=FakeAttachment(
+            filename="pixel.png", content_type="image/png", payload=base64.b64decode(_png_b64())
+        )
+    )
+    assert image_part is not None
+    assert image_part["type"] == "input_image"
+
+    monkeypatch.setattr(
+        "discordbot.utils.discord_ops.get_supported_modalities", lambda model_name: {"image"}
+    )
+    message = FakeMessage()
+    message.attachments = [
+        FakeAttachment(
+            filename="pixel.png", content_type="image/png", payload=base64.b64decode(_png_b64())
+        ),
+        FakeAttachment(filename="clip.mp4", content_type="video/mp4", payload=b"video"),
+    ]
+    message.stickers = [
+        FakeAttachment(
+            filename="sticker.png", content_type="image/png", payload=base64.b64decode(_png_b64())
+        )
+    ]
+    img_embed = Embed()
+    img_embed.set_image(url="https://example.test/image.png")
+    message.embeds = [img_embed]
+    monkeypatch.setattr(
+        "discordbot.utils.discord_ops.get_pil_image",
+        lambda image_file: Image.new(mode="RGB", size=(1, 1), color=(0, 0, 0)),
+    )
+    parts = await msg_ops.get_attachment_parts(message=message)
+    assert [part["type"] for part in parts] == ["input_image", "input_image", "input_image"]
+
+
+async def test_get_attachment_parts_requires_runtime_models() -> None:
+    """Verifies the runtime_models guard raises a clear ValueError."""
+    bot = SimpleNamespace(user=SimpleNamespace(id=999, name="bot"))
+    msg_ops = DiscordMessageOps(bot=bot)
+    with pytest.raises(ValueError, match="runtime_models"):
+        await msg_ops.get_attachment_parts(message=FakeMessage())
+
+
+async def test_process_single_message_role_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verifies role dispatch (assistant vs user) and attachment shape."""
+    msg_ops, _stream_ops = _ops()
+    monkeypatch.setattr(
+        "discordbot.utils.discord_ops.get_supported_modalities",
+        lambda model_name: {"text", "image"},
+    )
+    bot_msg = FakeMessage(content="bot answer", author=FakeAuthor(bot=True, user_id=999))
+    user_msg = FakeMessage(content="hello", author=FakeAuthor(user_id=1))
+    with_attachment = FakeMessage(content="see file", author=FakeAuthor(user_id=2))
+    with_attachment.attachments = [FakeAttachment(filename="note.txt", content_type="text/plain")]
+
+    bot_processed = await msg_ops.process_single_message(message=bot_msg)
+    user_processed = await msg_ops.process_single_message(message=user_msg)
+    attachment_processed = await msg_ops.process_single_message(message=with_attachment)
+    assert bot_processed["role"] == "assistant"
+    assert user_processed["role"] == "user"
+    assert attachment_processed["role"] == "user"
+    assert isinstance(attachment_processed["content"], list)

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -1,4 +1,4 @@
-"""Tests for AI reply routing, attachment handling, streaming, and regeneration."""
+"""Tests for AI reply routing, image/video handlers, and on_message dispatch."""
 
 from __future__ import annotations
 
@@ -10,10 +10,10 @@ from datetime import UTC, datetime
 
 from PIL import Image
 import pytest
-from nextcord import File, Embed
 
-from discordbot.cogs.gen_reply import _USAGE_FOOTER_RE, _DISCORD_MESSAGE_LIMIT, ReplyGeneratorCogs
+from discordbot.cogs.gen_reply import ReplyGeneratorCogs
 from discordbot.typings.models import ModelSettings, RouteDecision, RuntimeModelCatalog
+from discordbot.utils.discord_ops import DiscordStreamOps, DiscordMessageOps
 from discordbot.cogs._gen_reply.exceptions import extract_friendly_error
 
 TEST_LLM_MODEL = "test-llm-model"
@@ -21,6 +21,7 @@ TEST_LLM_MODEL = "test-llm-model"
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
+    from nextcord import File, Embed
     from openai.types.responses.response_input_param import ResponseInputParam
 
 
@@ -282,152 +283,9 @@ def _cog(bot_user_id: int = 999) -> ReplyGeneratorCogs:
     cog.bot = SimpleNamespace(user=SimpleNamespace(id=bot_user_id, name="bot"))
     cog.runtime_models = RuntimeModelCatalog()
     cog.__dict__["client"] = FakeClient()
+    cog.discord_messages = DiscordMessageOps(bot=cog.bot, runtime_models=cog.runtime_models)
+    cog.discord_stream = DiscordStreamOps(bot=cog.bot, msg_ops=cog.discord_messages)
     return cog
-
-
-async def _stream_events() -> AsyncIterator[SimpleNamespace]:
-    """Yields a minimal streaming completion with token usage."""
-    yield SimpleNamespace(type="response.output_text.delta", delta="hello from stream")
-    yield SimpleNamespace(
-        type="response.completed",
-        response=SimpleNamespace(
-            model=TEST_LLM_MODEL,
-            usage=SimpleNamespace(input_tokens=12, output_tokens=34, output_tokens_details=None),
-        ),
-    )
-
-
-async def _stream_events_from(events: list[SimpleNamespace]) -> AsyncIterator[SimpleNamespace]:
-    """Yields the provided fake streaming events in order."""
-    for event in events:
-        yield event
-
-
-async def test_handle_streaming_allows_missing_output_token_details(
-    economy_isolated_db: None,
-) -> None:
-    """Regression: LiteLLM may return usage with output_tokens_details=null."""
-    del economy_isolated_db
-    cog = ReplyGeneratorCogs.__new__(ReplyGeneratorCogs)
-    message = FakeMessage()
-
-    result = await cog._handle_streaming(responses=_stream_events(), message=message)
-
-    expected = (
-        f"hello from stream\n\n-# {TEST_LLM_MODEL} · ⬆ 12 ⬇ 34 · $0.00000000"
-        " · 46 虛擬歡樂豆 (+46 虛擬歡樂豆)"
-    )
-    assert result == expected
-    assert message.replies[0].content == result
-
-
-async def test_handle_streaming_continues_long_reply_as_reply_chain(
-    economy_isolated_db: None,
-) -> None:
-    """Verifies replies over Discord's content limit continue as a reply chain."""
-    del economy_isolated_db
-    cog = _cog()
-    message = FakeMessage(content="<@999> explain how long Discord replies are handled")
-    body = "x" * 4500
-
-    result = await cog._handle_streaming(
-        responses=_stream_events_from(
-            events=[
-                SimpleNamespace(type="response.output_text.delta", delta=body),
-                SimpleNamespace(
-                    type="response.completed",
-                    response=SimpleNamespace(
-                        model=TEST_LLM_MODEL,
-                        usage=SimpleNamespace(input_tokens=1, output_tokens=2),
-                    ),
-                ),
-            ]
-        ),
-        message=message,
-    )
-
-    usage_footer = (
-        f"\n\n-# {TEST_LLM_MODEL} · ⬆ 1 ⬇ 2 · $0.00000000 · 3 虛擬歡樂豆 (+3 虛擬歡樂豆)"
-    )
-    assert result == f"{body}{usage_footer}"
-
-    parent = message.replies[0]
-    assert parent.content == body[:_DISCORD_MESSAGE_LIMIT]
-
-    first_follow_up = parent.replies[0]
-    assert first_follow_up.content == body[_DISCORD_MESSAGE_LIMIT : _DISCORD_MESSAGE_LIMIT * 2]
-
-    second_follow_up = first_follow_up.replies[0]
-    assert second_follow_up.content == f"{body[_DISCORD_MESSAGE_LIMIT * 2 :]}{usage_footer}"
-    assert second_follow_up.replies == []
-
-    chain_chunks = [parent.content, first_follow_up.content, second_follow_up.content]
-    assert all(len(chunk) <= _DISCORD_MESSAGE_LIMIT for chunk in chain_chunks)
-    assert cog.client.responses.create_models == []
-
-
-async def test_handle_streaming_marks_web_search_from_call_event(
-    economy_isolated_db: None,
-) -> None:
-    """Verifies native web_search_call events trigger the web reaction."""
-    del economy_isolated_db
-    cog = _cog()
-    message = FakeMessage()
-
-    await cog._handle_streaming(
-        responses=_stream_events_from(
-            events=[
-                SimpleNamespace(type="response.output_text.delta", delta="answer"),
-                SimpleNamespace(type="response.web_search_call.completed"),
-                SimpleNamespace(
-                    type="response.completed",
-                    response=SimpleNamespace(
-                        model=TEST_LLM_MODEL,
-                        usage=SimpleNamespace(input_tokens=12, output_tokens=34),
-                    ),
-                ),
-            ]
-        ),
-        message=message,
-    )
-
-    assert message.added_reactions == ["🌐"]
-
-
-async def test_handle_streaming_marks_web_search_from_annotation(
-    economy_isolated_db: None,
-) -> None:
-    """Verifies any annotation event also triggers the web reaction.
-
-    LiteLLM-proxied Gemini grounds via url_citation annotations without
-    emitting web_search_call.* events, so annotation alone is treated as
-    a search signal.
-    """
-    del economy_isolated_db
-    cog = _cog()
-    message = FakeMessage()
-
-    await cog._handle_streaming(
-        responses=_stream_events_from(
-            events=[
-                SimpleNamespace(type="response.output_text.delta", delta="grounded answer"),
-                SimpleNamespace(
-                    type="response.output_text.annotation.added",
-                    annotation={"type": "url_citation", "url": "https://example.com/article"},
-                ),
-                SimpleNamespace(
-                    type="response.completed",
-                    response=SimpleNamespace(
-                        model=TEST_LLM_MODEL,
-                        usage=SimpleNamespace(input_tokens=12, output_tokens=34),
-                    ),
-                ),
-            ]
-        ),
-        message=message,
-    )
-
-    assert message.added_reactions == ["🌐"]
 
 
 def test_extract_friendly_error_prefers_nested_provider_message() -> None:
@@ -438,98 +296,17 @@ def test_extract_friendly_error_prefers_nested_provider_message() -> None:
     assert extract_friendly_error(exc=RuntimeError("bad b'not json'")) == "bad b'not json'"
 
 
-async def test_gen_reply_message_content_and_attachment_helpers(
+async def test_gen_reply_assembles_history_reference_and_current_messages(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Verifies prompt cleanup, embed extraction, and attachment conversion."""
-    cog = _cog()
-    embed = Embed(title="Title", description="Body")
-    embed.set_author(name="Author")
-    embed.add_field(name="Field", value="Value")
-    embed.set_footer(text="Footer")
-
-    assert await cog._get_user_prompt(content="hi <@999>") == "hi"
-    assert "Author" in cog._extract_embed_text(embeds=[embed])
-
-    bot_message = FakeMessage(
-        content="answer\n\n-# model · ⬆ 1 ⬇ 2 · $0.0 · +3",
-        author=FakeAuthor(bot=True, user_id=999),
-    )
-    assert await cog._get_cleaned_content(message=bot_message) == "answer"
-    assert _USAGE_FOOTER_RE.search(string=bot_message.content)
-
-    embed_message = FakeMessage()
-    embed_message.embeds = [embed]
-    assert "Title" in await cog._get_cleaned_content(message=embed_message)
-
-    system_message = FakeMessage()
-    system_message.system_content = "joined"
-    assert await cog._get_cleaned_content(message=system_message) == "joined"
-
-    assert cog._required_modality(content_type="video/mp4") == "video"
-    assert cog._required_modality(content_type="audio/mpeg") == "audio"
-    assert cog._required_modality(content_type="application/pdf") == "image"
-
-    file_part = await cog._attachment_to_part(
-        attachment=FakeAttachment(filename="note.txt", content_type="text/plain", payload=b"abc")
-    )
-    assert file_part is not None
-    assert file_part["file_data"] == "data:text/plain;base64,YWJj"
-
-    image_part = await cog._image_to_part(
-        source=FakeAttachment(
-            filename="pixel.png", content_type="image/png", payload=base64.b64decode(_png_b64())
-        )
-    )
-    assert image_part is not None
-    assert image_part["type"] == "input_image"
-
-    monkeypatch.setattr(
-        "discordbot.cogs.gen_reply.get_supported_modalities", lambda model_name: {"image"}
-    )
-    message = FakeMessage()
-    message.attachments = [
-        FakeAttachment(
-            filename="pixel.png", content_type="image/png", payload=base64.b64decode(_png_b64())
-        ),
-        FakeAttachment(filename="clip.mp4", content_type="video/mp4", payload=b"video"),
-    ]
-    message.stickers = [
-        FakeAttachment(
-            filename="sticker.png", content_type="image/png", payload=base64.b64decode(_png_b64())
-        )
-    ]
-    img_embed = Embed()
-    img_embed.set_image(url="https://example.test/image.png")
-    message.embeds = [img_embed]
-    monkeypatch.setattr(
-        "discordbot.cogs.gen_reply.get_pil_image",
-        lambda image_file: Image.new(mode="RGB", size=(1, 1), color=(0, 0, 0)),
-    )
-    parts = await cog._get_attachment_parts(message=message)
-    assert [part["type"] for part in parts] == ["input_image", "input_image", "input_image"]
-
-
-async def test_gen_reply_processes_history_reference_and_current_messages(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Verifies message processing for history, references, and current prompts."""
+    """Verifies history, reference chain, and current-message orchestration on the cog."""
     cog = _cog()
     monkeypatch.setattr(
-        "discordbot.cogs.gen_reply.get_supported_modalities", lambda model_name: {"text", "image"}
+        "discordbot.utils.discord_ops.get_supported_modalities",
+        lambda model_name: {"text", "image"},
     )
     bot_msg = FakeMessage(content="bot answer", author=FakeAuthor(bot=True, user_id=999))
     user_msg = FakeMessage(content="hello", author=FakeAuthor(user_id=1))
-    with_attachment = FakeMessage(content="see file", author=FakeAuthor(user_id=2))
-    with_attachment.attachments = [FakeAttachment(filename="note.txt", content_type="text/plain")]
-
-    bot_processed = await cog._process_single_message(message=bot_msg)
-    user_processed = await cog._process_single_message(message=user_msg)
-    attachment_processed = await cog._process_single_message(message=with_attachment)
-    assert bot_processed["role"] == "assistant"
-    assert user_processed["role"] == "user"
-    assert attachment_processed["role"] == "user"
-    assert isinstance(attachment_processed["content"], list)
 
     async def fake_history(
         limit: int, before: FakeMessage, oldest_first: bool
@@ -582,7 +359,7 @@ async def test_gen_reply_routes_and_handlers_without_api(monkeypatch: pytest.Mon
         return "done"
 
     streamed: list[FakeMessage] = []
-    monkeypatch.setattr(cog, "_handle_streaming", fake_streaming)
+    monkeypatch.setattr(cog, "discord_stream", SimpleNamespace(handle_streaming=fake_streaming))
     await cog._handle_message_reply(message=message, system_prompt="system", history_limit=2)
     assert cog.client.responses.create_streams[-1] is True
     assert streamed[-1] is message
@@ -608,9 +385,10 @@ async def test_gen_reply_on_message_dispatches_routes(
         """Returns the parametrized route."""
         return route
 
-    async def fake_reaction(message: FakeMessage, emoji: str, previous: str | None = None) -> None:
-        """Records reaction state transitions."""
+    async def fake_reaction(message: FakeMessage, emoji: str, previous: str | None = None) -> str:
+        """Records reaction state transitions and returns the emoji for chaining."""
         calls.append(f"reaction:{emoji}")
+        return emoji
 
     async def fake_image_handler(message: FakeMessage, user_prompt: str) -> None:
         """Records image handler dispatch."""
@@ -627,7 +405,14 @@ async def test_gen_reply_on_message_dispatches_routes(
         calls.append("_handle_message_reply")
 
     monkeypatch.setattr(cog, "_route_message", fake_route)
-    monkeypatch.setattr(cog, "_handle_reaction", fake_reaction)
+    monkeypatch.setattr(
+        cog,
+        "discord_messages",
+        SimpleNamespace(
+            get_user_prompt=cog.discord_messages.get_user_prompt,
+            handle_reaction=fake_reaction,
+        ),
+    )
     monkeypatch.setattr(cog, "_handle_image_reply", fake_image_handler)
     monkeypatch.setattr(cog, "_handle_video_reply", fake_video_handler)
     monkeypatch.setattr(cog, "_handle_message_reply", fake_message_handler)


### PR DESCRIPTION
## Summary
- Move message ingestion and streaming-render helpers from `ReplyGeneratorCogs` into `utils/discord_ops.py` as `DiscordMessageOps` and `DiscordStreamOps` (both `pydantic.BaseModel`).
- `handle_reaction` now returns the applied emoji so `on_message` no longer needs shadow `current_emoji` assignments.
- Share the reaction helper with `parse_threads.py`, removing the duplicated local implementation.

## Test plan
- [x] `uv run pre-commit run -a`
- [x] `uv run pytest` (467 passed, coverage 84%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)