### PR TITLE
feat(embeds): unify embed width with transparent spacer

### DIFF
--- a/src/discordbot/cli.py
+++ b/src/discordbot/cli.py
@@ -16,6 +16,7 @@ from discordbot import setup_logging
 from discordbot.utils.avatars import guild_avatar_url
 from discordbot.typings.config import DiscordConfig
 from discordbot.typings.economy import BASE_MESSAGE_REWARD_AMOUNT
+from discordbot.utils.discord_embeds import embed_spacer_payload
 from discordbot.cogs._economy.database import credit_with_repayment
 
 
@@ -186,10 +187,10 @@ class DiscordBot(commands.Bot):
                 description=f"**Please slow down** - You can use this command again in {f'{round(hours)} hours' if round(hours) > 0 else ''} {f'{round(minutes)} minutes' if round(minutes) > 0 else ''} {f'{round(seconds)} seconds' if round(seconds) > 0 else ''}.",
                 color=0xE02B2B,
             )
-            await context.send(embed=embed)
+            await context.send(embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False))
         elif isinstance(error, commands.NotOwner):
             embed = Embed(description="You are not the owner of the bot!", color=0xE02B2B)
-            await context.send(embed=embed)
+            await context.send(embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False))
             if context.guild:
                 logfire.warn(
                     f"{context.author} (ID: {context.author.id}) tried to execute an owner only command in the guild {context.guild.name} (ID: {context.guild.id}), but the user is not an owner of the bot."
@@ -205,7 +206,7 @@ class DiscordBot(commands.Bot):
                 + "` to execute this command!",
                 color=0xE02B2B,
             )
-            await context.send(embed=embed)
+            await context.send(embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False))
         elif isinstance(error, commands.BotMissingPermissions):
             embed = Embed(
                 description="I am missing the permission(s) `"
@@ -213,7 +214,7 @@ class DiscordBot(commands.Bot):
                 + "` to fully perform this command!",
                 color=0xE02B2B,
             )
-            await context.send(embed=embed)
+            await context.send(embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False))
         elif isinstance(error, commands.MissingRequiredArgument):
             embed = Embed(
                 title="Error!",
@@ -221,14 +222,14 @@ class DiscordBot(commands.Bot):
                 description=str(error).capitalize(),
                 color=0xE02B2B,
             )
-            await context.send(embed=embed)
+            await context.send(embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False))
         elif isinstance(error, commands.CommandNotFound):
             embed = Embed(
                 title="Error!",
                 description=f"Command {error.command_name} not found",
                 color=0xE02B2B,
             )
-            await context.send(embed=embed)
+            await context.send(embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False))
         else:
             pass
 

--- a/src/discordbot/cli.py
+++ b/src/discordbot/cli.py
@@ -187,10 +187,14 @@ class DiscordBot(commands.Bot):
                 description=f"**Please slow down** - You can use this command again in {f'{round(hours)} hours' if round(hours) > 0 else ''} {f'{round(minutes)} minutes' if round(minutes) > 0 else ''} {f'{round(seconds)} seconds' if round(seconds) > 0 else ''}.",
                 color=0xE02B2B,
             )
-            await context.send(embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False))
+            await context.send(
+                embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False, target=context)
+            )
         elif isinstance(error, commands.NotOwner):
             embed = Embed(description="You are not the owner of the bot!", color=0xE02B2B)
-            await context.send(embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False))
+            await context.send(
+                embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False, target=context)
+            )
             if context.guild:
                 logfire.warn(
                     f"{context.author} (ID: {context.author.id}) tried to execute an owner only command in the guild {context.guild.name} (ID: {context.guild.id}), but the user is not an owner of the bot."
@@ -206,7 +210,9 @@ class DiscordBot(commands.Bot):
                 + "` to execute this command!",
                 color=0xE02B2B,
             )
-            await context.send(embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False))
+            await context.send(
+                embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False, target=context)
+            )
         elif isinstance(error, commands.BotMissingPermissions):
             embed = Embed(
                 description="I am missing the permission(s) `"
@@ -214,7 +220,9 @@ class DiscordBot(commands.Bot):
                 + "` to fully perform this command!",
                 color=0xE02B2B,
             )
-            await context.send(embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False))
+            await context.send(
+                embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False, target=context)
+            )
         elif isinstance(error, commands.MissingRequiredArgument):
             embed = Embed(
                 title="Error!",
@@ -222,14 +230,18 @@ class DiscordBot(commands.Bot):
                 description=str(error).capitalize(),
                 color=0xE02B2B,
             )
-            await context.send(embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False))
+            await context.send(
+                embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False, target=context)
+            )
         elif isinstance(error, commands.CommandNotFound):
             embed = Embed(
                 title="Error!",
                 description=f"Command {error.command_name} not found",
                 color=0xE02B2B,
             )
-            await context.send(embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False))
+            await context.send(
+                embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False, target=context)
+            )
         else:
             pass
 

--- a/src/discordbot/cogs/_games/blackjack_views.py
+++ b/src/discordbot/cogs/_games/blackjack_views.py
@@ -98,9 +98,15 @@ BLACKJACK_SETTLEMENT_FALLBACK_LINES: Final[dict[SettleOutcome, str]] = {
 }
 
 
-def _blackjack_table_edit_kwargs(*, embeds: list[Embed], view: View | None) -> dict[str, Any]:
+def _blackjack_table_edit_kwargs(
+    *, embeds: list[Embed], view: View | None, target: object | None = None
+) -> dict[str, Any]:
     """Builds the shared edit payload for Blackjack table renders."""
-    return {"embeds": embeds, "view": view, **embed_spacer_payload(embeds=embeds, is_edit=True)}
+    return {
+        "embeds": embeds,
+        "view": view,
+        **embed_spacer_payload(embeds=embeds, is_edit=True, target=target),
+    }
 
 
 def _hand_summary_line(cards: list[Card], suffix: str = "") -> str:
@@ -665,7 +671,9 @@ class BlackjackLobbyView(BaseGameLobbyView):
         )
         await edit_message_with_retry(
             message=message,
-            **_blackjack_table_edit_kwargs(embeds=[talk_embed, *seat_embeds], view=view),
+            **_blackjack_table_edit_kwargs(
+                embeds=[talk_embed, *seat_embeds], view=view, target=message
+            ),
         )
         await view.maybe_play_bot_turn(message=message)
         return True
@@ -1348,7 +1356,9 @@ class BlackjackView(View):
             bot_reasons=self._bot_reasons,
         )
         await message.edit(
-            **_blackjack_table_edit_kwargs(embeds=[talk_embed, *seat_embeds], view=self)
+            **_blackjack_table_edit_kwargs(
+                embeds=[talk_embed, *seat_embeds], view=self, target=message
+            )
         )
 
     async def _reject_stale_action_locked(
@@ -1422,7 +1432,9 @@ class BlackjackView(View):
         with contextlib.suppress(Exception):
             await asyncio.wait_for(
                 message.edit(
-                    **_blackjack_table_edit_kwargs(embeds=[talk_embed, *seat_embeds], view=None)
+                    **_blackjack_table_edit_kwargs(
+                        embeds=[talk_embed, *seat_embeds], view=None, target=message
+                    )
                 ),
                 timeout=FINAL_EDIT_TIMEOUT_SECONDS,
             )
@@ -1465,7 +1477,9 @@ class BlackjackView(View):
         with contextlib.suppress(Exception):
             await asyncio.wait_for(
                 message.edit(
-                    **_blackjack_table_edit_kwargs(embeds=[intro_talk, *body_hidden], view=self)
+                    **_blackjack_table_edit_kwargs(
+                        embeds=[intro_talk, *body_hidden], view=self, target=message
+                    )
                 ),
                 timeout=FINAL_EDIT_TIMEOUT_SECONDS,
             )
@@ -1488,7 +1502,9 @@ class BlackjackView(View):
         with contextlib.suppress(Exception):
             await asyncio.wait_for(
                 message.edit(
-                    **_blackjack_table_edit_kwargs(embeds=[reveal_talk, *reveal_body], view=self)
+                    **_blackjack_table_edit_kwargs(
+                        embeds=[reveal_talk, *reveal_body], view=self, target=message
+                    )
                 ),
                 timeout=FINAL_EDIT_TIMEOUT_SECONDS,
             )
@@ -1630,7 +1646,7 @@ class BlackjackView(View):
                 await asyncio.wait_for(
                     message.edit(
                         **_blackjack_table_edit_kwargs(
-                            embeds=[talk_embed, *seat_embeds], view=None
+                            embeds=[talk_embed, *seat_embeds], view=None, target=message
                         )
                     ),
                     timeout=FINAL_EDIT_TIMEOUT_SECONDS,

--- a/src/discordbot/cogs/_games/blackjack_views.py
+++ b/src/discordbot/cogs/_games/blackjack_views.py
@@ -669,10 +669,11 @@ class BlackjackLobbyView(BaseGameLobbyView):
             bot_user_id=self.bot_user_id,
             bot_reasons={},
         )
+        embeds = [talk_embed, *seat_embeds]
         await edit_message_with_retry(
             message=message,
-            **_blackjack_table_edit_kwargs(
-                embeds=[talk_embed, *seat_embeds], view=view, target=message
+            kwargs_factory=lambda: _blackjack_table_edit_kwargs(
+                embeds=embeds, view=view, target=message
             ),
         )
         await view.maybe_play_bot_turn(message=message)

--- a/src/discordbot/cogs/_games/blackjack_views.py
+++ b/src/discordbot/cogs/_games/blackjack_views.py
@@ -24,7 +24,7 @@ from discordbot.typings.games import (
     BlackjackPlayerSettlement,
 )
 from discordbot.cogs._games.lobby import BaseGameLobbyView, PrepareParticipant, RefreshParticipants
-from discordbot.utils.discord_embeds import build_embed_spacer_file, apply_embed_spacer_image
+from discordbot.utils.discord_embeds import embed_spacer_payload
 from discordbot.cogs._games.blackjack import (
     BlackjackRound,
     BlackjackHandState,
@@ -100,12 +100,7 @@ BLACKJACK_SETTLEMENT_FALLBACK_LINES: Final[dict[SettleOutcome, str]] = {
 
 def _blackjack_table_edit_kwargs(*, embeds: list[Embed], view: View | None) -> dict[str, Any]:
     """Builds the shared edit payload for Blackjack table renders."""
-    return {
-        "embeds": apply_embed_spacer_image(embeds=embeds),
-        "view": view,
-        "file": build_embed_spacer_file(),
-        "attachments": [],
-    }
+    return {"embeds": embeds, "view": view, **embed_spacer_payload(embeds=embeds, is_edit=True)}
 
 
 def _hand_summary_line(cards: list[Card], suffix: str = "") -> str:

--- a/src/discordbot/cogs/_games/dragon_gate_views.py
+++ b/src/discordbot/cogs/_games/dragon_gate_views.py
@@ -428,10 +428,11 @@ class DragonGateLobbyView(BaseJackpotLobbyView):
         )
         view.message = message
         view.sync_controls()
+        embeds = view.in_progress_embeds()
         await edit_message_with_retry(
             message=message,
-            **_dragon_gate_table_edit_kwargs(
-                embeds=view.in_progress_embeds(), view=view, target=message
+            kwargs_factory=lambda: _dragon_gate_table_edit_kwargs(
+                embeds=embeds, view=view, target=message
             ),
         )
 

--- a/src/discordbot/cogs/_games/dragon_gate_views.py
+++ b/src/discordbot/cogs/_games/dragon_gate_views.py
@@ -75,9 +75,15 @@ DRAGON_GATE_VISIBLE_PLAYER_LINES = 20
 DRAGON_GATE_FINAL_EDIT_TIMEOUT_SECONDS: Final[float] = 8.0
 
 
-def _dragon_gate_table_edit_kwargs(*, embeds: list[Embed], view: View | None) -> dict[str, Any]:
+def _dragon_gate_table_edit_kwargs(
+    *, embeds: list[Embed], view: View | None, target: object | None = None
+) -> dict[str, Any]:
     """Builds the shared edit payload for 射龍門 table renders."""
-    return {"embeds": embeds, "view": view, **embed_spacer_payload(embeds=embeds, is_edit=True)}
+    return {
+        "embeds": embeds,
+        "view": view,
+        **embed_spacer_payload(embeds=embeds, is_edit=True, target=target),
+    }
 
 
 def _participant_lines(participants: list[GameParticipant]) -> str:
@@ -424,7 +430,9 @@ class DragonGateLobbyView(BaseJackpotLobbyView):
         view.sync_controls()
         await edit_message_with_retry(
             message=message,
-            **_dragon_gate_table_edit_kwargs(embeds=view.in_progress_embeds(), view=view),
+            **_dragon_gate_table_edit_kwargs(
+                embeds=view.in_progress_embeds(), view=view, target=message
+            ),
         )
 
 
@@ -652,7 +660,9 @@ class DragonGateView(View):
                 return
             self.sync_controls()
             await interaction.message.edit(
-                **_dragon_gate_table_edit_kwargs(embeds=self.in_progress_embeds(), view=self)
+                **_dragon_gate_table_edit_kwargs(
+                    embeds=self.in_progress_embeds(), view=self, target=interaction.message
+                )
             )
 
     async def _place_select_bet(self, interaction: Interaction, amount: int) -> None:
@@ -720,7 +730,9 @@ class DragonGateView(View):
                     return
             self.sync_controls()
             await message.edit(
-                **_dragon_gate_table_edit_kwargs(embeds=self.in_progress_embeds(), view=self)
+                **_dragon_gate_table_edit_kwargs(
+                    embeds=self.in_progress_embeds(), view=self, target=message
+                )
             )
 
     async def _handle_leave(self, interaction: Interaction) -> None:
@@ -759,7 +771,9 @@ class DragonGateView(View):
                 return
             self.sync_controls()
             await message.edit(
-                **_dragon_gate_table_edit_kwargs(embeds=self.in_progress_embeds(), view=self)
+                **_dragon_gate_table_edit_kwargs(
+                    embeds=self.in_progress_embeds(), view=self, target=message
+                )
             )
 
     def in_progress_embeds(self) -> list[Embed]:
@@ -845,7 +859,9 @@ class DragonGateView(View):
         self.stop()
         with contextlib.suppress(Exception):
             await asyncio.wait_for(
-                message.edit(**_dragon_gate_table_edit_kwargs(embeds=embeds, view=None)),
+                message.edit(
+                    **_dragon_gate_table_edit_kwargs(embeds=embeds, view=None, target=message)
+                ),
                 timeout=DRAGON_GATE_FINAL_EDIT_TIMEOUT_SECONDS,
             )
         self._track_background_task(
@@ -892,7 +908,9 @@ class DragonGateView(View):
                 embeds.append(history_embed)
             with contextlib.suppress(Exception):
                 await asyncio.wait_for(
-                    message.edit(**_dragon_gate_table_edit_kwargs(embeds=embeds, view=None)),
+                    message.edit(
+                        **_dragon_gate_table_edit_kwargs(embeds=embeds, view=None, target=message)
+                    ),
                     timeout=DRAGON_GATE_FINAL_EDIT_TIMEOUT_SECONDS,
                 )
 

--- a/src/discordbot/cogs/_games/dragon_gate_views.py
+++ b/src/discordbot/cogs/_games/dragon_gate_views.py
@@ -19,6 +19,7 @@ from discordbot.cogs._games.lobby import (
 )
 from discordbot.utils.number_text import compact_amount
 from discordbot.cogs._games.wagers import parse_wager_amount
+from discordbot.utils.discord_embeds import embed_spacer_payload
 from discordbot.utils.message_cleanup import schedule_public_message_delete
 from discordbot.cogs._economy.database import (
     get_balance,
@@ -72,6 +73,11 @@ if TYPE_CHECKING:
 DRAGON_GATE_ACTION_TIMEOUT_SECONDS = 180
 DRAGON_GATE_VISIBLE_PLAYER_LINES = 20
 DRAGON_GATE_FINAL_EDIT_TIMEOUT_SECONDS: Final[float] = 8.0
+
+
+def _dragon_gate_table_edit_kwargs(*, embeds: list[Embed], view: View | None) -> dict[str, Any]:
+    """Builds the shared edit payload for 射龍門 table renders."""
+    return {"embeds": embeds, "view": view, **embed_spacer_payload(embeds=embeds, is_edit=True)}
 
 
 def _participant_lines(participants: list[GameParticipant]) -> str:
@@ -416,7 +422,10 @@ class DragonGateLobbyView(BaseJackpotLobbyView):
         )
         view.message = message
         view.sync_controls()
-        await edit_message_with_retry(message=message, embeds=view.in_progress_embeds(), view=view)
+        await edit_message_with_retry(
+            message=message,
+            **_dragon_gate_table_edit_kwargs(embeds=view.in_progress_embeds(), view=view),
+        )
 
 
 class DragonGateView(View):
@@ -642,7 +651,9 @@ class DragonGateView(View):
                 await self._send_notice(interaction=interaction, content="這手不需要猜大小")
                 return
             self.sync_controls()
-            await interaction.message.edit(embeds=self.in_progress_embeds(), view=self)
+            await interaction.message.edit(
+                **_dragon_gate_table_edit_kwargs(embeds=self.in_progress_embeds(), view=self)
+            )
 
     async def _place_select_bet(self, interaction: Interaction, amount: int) -> None:
         """Defers a select interaction and places the chosen fixed bet."""
@@ -708,7 +719,9 @@ class DragonGateView(View):
                     await self._finalize_locked(message=message, reason="所有玩家已離桌或餘額歸零")
                     return
             self.sync_controls()
-            await message.edit(embeds=self.in_progress_embeds(), view=self)
+            await message.edit(
+                **_dragon_gate_table_edit_kwargs(embeds=self.in_progress_embeds(), view=self)
+            )
 
     async def _handle_leave(self, interaction: Interaction) -> None:
         """Withdraws a seated player and refunds positive table delta to the jackpot."""
@@ -745,7 +758,9 @@ class DragonGateView(View):
                 await self._finalize_locked(message=message, reason="所有玩家已離桌")
                 return
             self.sync_controls()
-            await message.edit(embeds=self.in_progress_embeds(), view=self)
+            await message.edit(
+                **_dragon_gate_table_edit_kwargs(embeds=self.in_progress_embeds(), view=self)
+            )
 
     def in_progress_embeds(self) -> list[Embed]:
         """Builds the current narrator, table, and optional history embeds."""
@@ -830,7 +845,7 @@ class DragonGateView(View):
         self.stop()
         with contextlib.suppress(Exception):
             await asyncio.wait_for(
-                message.edit(embeds=embeds, view=None),
+                message.edit(**_dragon_gate_table_edit_kwargs(embeds=embeds, view=None)),
                 timeout=DRAGON_GATE_FINAL_EDIT_TIMEOUT_SECONDS,
             )
         self._track_background_task(

--- a/src/discordbot/cogs/_games/dragon_gate_views.py
+++ b/src/discordbot/cogs/_games/dragon_gate_views.py
@@ -892,7 +892,7 @@ class DragonGateView(View):
                 embeds.append(history_embed)
             with contextlib.suppress(Exception):
                 await asyncio.wait_for(
-                    message.edit(embeds=embeds, view=None),
+                    message.edit(**_dragon_gate_table_edit_kwargs(embeds=embeds, view=None)),
                     timeout=DRAGON_GATE_FINAL_EDIT_TIMEOUT_SECONDS,
                 )
 

--- a/src/discordbot/cogs/_games/interactions.py
+++ b/src/discordbot/cogs/_games/interactions.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 import asyncio
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 
 import logfire
 from nextcord import Message, Interaction
@@ -41,6 +41,7 @@ def set_view_item_visible(view: View, item: Item, visible: bool) -> None:
 async def edit_message_with_retry(
     message: Message,
     attempts: int = 3,
+    kwargs_factory: Callable[[], dict[str, Any]] | None = None,
     **kwargs: Any,  # noqa: ANN401 -- transparent forwarder to Message.edit's heterogeneous kwargs
 ) -> Message:
     """Edits `message` retrying transient Discord 5xx errors with backoff.
@@ -50,9 +51,13 @@ async def edit_message_with_retry(
     stopped with antes already charged. Backoff grows 0.5s, 1.0s, ... so the
     final attempt covers ~1.5s of upstream flakiness before propagating.
     """
+
+    def edit_kwargs() -> dict[str, Any]:
+        return kwargs_factory() if kwargs_factory is not None else kwargs
+
     for attempt in range(attempts - 1):
         try:
-            return await message.edit(**kwargs)
+            return await message.edit(**edit_kwargs())
         except DiscordServerError as error:
             logfire.warn(
                 "Discord 5xx on message.edit, retrying",
@@ -61,4 +66,4 @@ async def edit_message_with_retry(
                 message_id=message.id,
             )
             await asyncio.sleep(0.5 * (attempt + 1))
-    return await message.edit(**kwargs)
+    return await message.edit(**edit_kwargs())

--- a/src/discordbot/cogs/_games/lobby.py
+++ b/src/discordbot/cogs/_games/lobby.py
@@ -103,7 +103,9 @@ class BaseGameLobbyView(View):
         embed = self._build_lobby_embed(status="Lobby 已逾時")
         with contextlib.suppress(Exception):
             await self.message.edit(
-                embed=embed, view=self, **embed_spacer_payload(embeds=[embed], is_edit=True)
+                embed=embed,
+                view=self,
+                **embed_spacer_payload(embeds=[embed], is_edit=True, target=self.message),
             )
         schedule_public_message_delete(message=self.message, user_name=self.owner.account_name)
 
@@ -188,7 +190,9 @@ class BaseGameLobbyView(View):
         self.message = message
         embed = self._build_lobby_embed(status=status)
         await message.edit(
-            embed=embed, view=self, **embed_spacer_payload(embeds=[embed], is_edit=True)
+            embed=embed,
+            view=self,
+            **embed_spacer_payload(embeds=[embed], is_edit=True, target=message),
         )
 
     async def _send_notice(self, interaction: Interaction, content: str) -> None:

--- a/src/discordbot/cogs/_games/lobby.py
+++ b/src/discordbot/cogs/_games/lobby.py
@@ -12,6 +12,7 @@ from nextcord import Embed, Message, ButtonStyle, Interaction
 from nextcord.ui import Item, View, Button
 
 from discordbot.typings.economy import JackpotSettlementRequest, JackpotSettlementBatchResult
+from discordbot.utils.discord_embeds import embed_spacer_payload
 from discordbot.utils.message_cleanup import schedule_public_message_delete
 from discordbot.cogs._economy.database import apply_jackpot_settlement_batch
 from discordbot.cogs._games.interactions import send_ephemeral_notice, disable_view_components
@@ -101,7 +102,9 @@ class BaseGameLobbyView(View):
         self.stop()
         embed = self._build_lobby_embed(status="Lobby 已逾時")
         with contextlib.suppress(Exception):
-            await self.message.edit(embed=embed, view=self)
+            await self.message.edit(
+                embed=embed, view=self, **embed_spacer_payload(embeds=[embed], is_edit=True)
+            )
         schedule_public_message_delete(message=self.message, user_name=self.owner.account_name)
 
     @nextcord.ui.button(label="加入", emoji="✅", style=ButtonStyle.success)
@@ -183,7 +186,10 @@ class BaseGameLobbyView(View):
         if message is None:
             return
         self.message = message
-        await message.edit(embed=self._build_lobby_embed(status=status), view=self)
+        embed = self._build_lobby_embed(status=status)
+        await message.edit(
+            embed=embed, view=self, **embed_spacer_payload(embeds=[embed], is_edit=True)
+        )
 
     async def _send_notice(self, interaction: Interaction, content: str) -> None:
         """Sends a private lobby notice to the interacting user."""

--- a/src/discordbot/cogs/_maplestory/views.py
+++ b/src/discordbot/cogs/_maplestory/views.py
@@ -154,7 +154,7 @@ class MapleDropSearchView(View):
                 message_id=interaction.message.id,
                 embed=embed,
                 view=None,
-                **embed_spacer_payload(embeds=[embed], is_edit=True),
+                **embed_spacer_payload(embeds=[embed], is_edit=True, target=interaction),
             )
 
     def set_options(self, options: list[SelectOption]) -> None:

--- a/src/discordbot/cogs/_maplestory/views.py
+++ b/src/discordbot/cogs/_maplestory/views.py
@@ -12,6 +12,8 @@ import nextcord
 from nextcord import Embed, Interaction, SelectOption
 from nextcord.ui import View, Select
 
+from discordbot.utils.discord_embeds import embed_spacer_payload
+
 from .embeds import (
     TranslateFn,
     create_map_embed,
@@ -149,7 +151,10 @@ class MapleDropSearchView(View):
 
         if embed:
             await interaction.followup.edit_message(
-                message_id=interaction.message.id, embed=embed, view=None
+                message_id=interaction.message.id,
+                embed=embed,
+                view=None,
+                **embed_spacer_payload(embeds=[embed], is_edit=True),
             )
 
     def set_options(self, options: list[SelectOption]) -> None:

--- a/src/discordbot/cogs/_stock/views.py
+++ b/src/discordbot/cogs/_stock/views.py
@@ -557,7 +557,12 @@ async def edit_stock_message(
     kwargs: dict[str, object] = {
         "embed": embed,
         "view": view,
-        **embed_spacer_payload(embeds=[embed], is_edit=True, extra_files=extra_files),
+        **embed_spacer_payload(
+            embeds=[embed],
+            is_edit=True,
+            target=target_message or interaction,
+            extra_files=extra_files,
+        ),
     }
     if not interaction.response.is_done():
         edited = await interaction.response.edit_message(**kwargs)
@@ -576,7 +581,9 @@ async def edit_stock_message(
         "embed": embed,
         "view": view,
         "wait": True,
-        **embed_spacer_payload(embeds=[embed], is_edit=False, extra_files=extra_files),
+        **embed_spacer_payload(
+            embeds=[embed], is_edit=False, target=interaction, extra_files=extra_files
+        ),
     }
     sent_message = await interaction.followup.send(**followup_kwargs)
     if view is not None:

--- a/src/discordbot/cogs/_stock/views.py
+++ b/src/discordbot/cogs/_stock/views.py
@@ -2,6 +2,7 @@
 
 from io import BytesIO
 from typing import cast
+from collections.abc import Callable
 
 import nextcord
 from nextcord import File, User, Member, Message, ButtonStyle, Interaction, SelectOption
@@ -74,6 +75,29 @@ def build_market_message_payload(
         quotes=quotes, page_index=page_index, page_size=MARKET_PAGE_SIZE
     )
     return embed, File(fp=BytesIO(board), filename=filename)
+
+
+def _fresh_file_factory(file: File | None) -> Callable[[], File] | None:
+    """Returns a factory that creates fresh uploads for retry or fallback paths."""
+    if file is None:
+        return None
+    file.reset()
+    payload = file.fp.read()
+    file.reset()
+    filename = file.filename
+    description = file.description
+
+    def build_file() -> File:
+        return File(fp=BytesIO(payload), filename=filename, description=description)
+
+    return build_file
+
+
+def _fresh_extra_files(file_factory: Callable[[], File] | None) -> list[File] | None:
+    """Builds a fresh extra file list for one Discord request."""
+    if file_factory is None:
+        return None
+    return [file_factory()]
 
 
 class StockPublicView(View):
@@ -553,7 +577,7 @@ async def edit_stock_message(
     target_message = message or interaction.message
     if view is not None:
         view.bind_message(message=target_message)
-    extra_files = [file] if file is not None else None
+    file_factory = _fresh_file_factory(file=file)
     kwargs: dict[str, object] = {
         "embed": embed,
         "view": view,
@@ -561,7 +585,7 @@ async def edit_stock_message(
             embeds=[embed],
             is_edit=True,
             target=target_message or interaction,
-            extra_files=extra_files,
+            extra_files=_fresh_extra_files(file_factory=file_factory),
         ),
     }
     if not interaction.response.is_done():
@@ -582,7 +606,10 @@ async def edit_stock_message(
         "view": view,
         "wait": True,
         **embed_spacer_payload(
-            embeds=[embed], is_edit=False, target=interaction, extra_files=extra_files
+            embeds=[embed],
+            is_edit=False,
+            target=interaction,
+            extra_files=_fresh_extra_files(file_factory=file_factory),
         ),
     }
     sent_message = await interaction.followup.send(**followup_kwargs)

--- a/src/discordbot/cogs/_stock/views.py
+++ b/src/discordbot/cogs/_stock/views.py
@@ -17,6 +17,7 @@ from discordbot.cogs._stock.database import (
     list_market_quotes,
     settle_stock_operation,
 )
+from discordbot.utils.discord_embeds import embed_spacer_payload
 from discordbot.utils.message_cleanup import (
     track_public_message,
     delete_public_message,
@@ -552,9 +553,12 @@ async def edit_stock_message(
     target_message = message or interaction.message
     if view is not None:
         view.bind_message(message=target_message)
-    kwargs: dict[str, object] = {"embed": embed, "view": view, "attachments": []}
-    if file is not None:
-        kwargs["file"] = file
+    extra_files = [file] if file is not None else None
+    kwargs: dict[str, object] = {
+        "embed": embed,
+        "view": view,
+        **embed_spacer_payload(embeds=[embed], is_edit=True, extra_files=extra_files),
+    }
     if not interaction.response.is_done():
         edited = await interaction.response.edit_message(**kwargs)
         if isinstance(edited, Message) and view is not None:
@@ -568,9 +572,12 @@ async def edit_stock_message(
             message_id = getattr(target_message, "id", None)
             if isinstance(message_id, int):
                 await forget_public_message(message_id=message_id)
-    followup_kwargs: dict[str, object] = {"embed": embed, "view": view, "wait": True}
-    if file is not None:
-        followup_kwargs["file"] = file
+    followup_kwargs: dict[str, object] = {
+        "embed": embed,
+        "view": view,
+        "wait": True,
+        **embed_spacer_payload(embeds=[embed], is_edit=False, extra_files=extra_files),
+    }
     sent_message = await interaction.followup.send(**followup_kwargs)
     if view is not None:
         view.bind_message(message=sent_message)

--- a/src/discordbot/cogs/economy.py
+++ b/src/discordbot/cogs/economy.py
@@ -193,7 +193,9 @@ async def _send_expiring_followup(
     kwargs: dict[str, object] = {
         "embed": embed,
         "wait": True,
-        **embed_spacer_payload(embeds=[embed], is_edit=False, extra_files=extra_files),
+        **embed_spacer_payload(
+            embeds=[embed], is_edit=False, target=interaction, extra_files=extra_files
+        ),
     }
     if view is not None:
         kwargs["view"] = view
@@ -205,7 +207,10 @@ async def _send_expiring_followup(
 async def _send_loan_request_followup(interaction: Interaction, embed: Embed, view: View) -> None:
     """Sends a loan request message that owns its cleanup after a terminal state."""
     message = await interaction.followup.send(
-        embed=embed, view=view, wait=True, **embed_spacer_payload(embeds=[embed], is_edit=False)
+        embed=embed,
+        view=view,
+        wait=True,
+        **embed_spacer_payload(embeds=[embed], is_edit=False, target=interaction),
     )
     view.message = message
 
@@ -213,21 +218,27 @@ async def _send_loan_request_followup(interaction: Interaction, embed: Embed, vi
 async def _send_private_followup(interaction: Interaction, embed: Embed) -> None:
     """Sends a personal economy embed visible only to the caller."""
     await interaction.followup.send(
-        embed=embed, ephemeral=True, **embed_spacer_payload(embeds=[embed], is_edit=False)
+        embed=embed,
+        ephemeral=True,
+        **embed_spacer_payload(embeds=[embed], is_edit=False, target=interaction),
     )
 
 
 async def _send_ephemeral_response(interaction: Interaction, embed: Embed) -> None:
     """Sends an ephemeral economy embed as the initial interaction response."""
     await interaction.response.send_message(
-        embed=embed, ephemeral=True, **embed_spacer_payload(embeds=[embed], is_edit=False)
+        embed=embed,
+        ephemeral=True,
+        **embed_spacer_payload(embeds=[embed], is_edit=False, target=interaction),
     )
 
 
 async def _edit_response_embed(interaction: Interaction, embed: Embed) -> None:
     """Edits the interaction's public message embed and clears its controls."""
     await interaction.response.edit_message(
-        embed=embed, view=None, **embed_spacer_payload(embeds=[embed], is_edit=True)
+        embed=embed,
+        view=None,
+        **embed_spacer_payload(embeds=[embed], is_edit=True, target=interaction),
     )
 
 
@@ -318,7 +329,9 @@ class CentralBankLoanDecisionView(View):
         )
         with contextlib.suppress(Exception):
             await self.message.edit(
-                embed=embed, view=None, **embed_spacer_payload(embeds=[embed], is_edit=True)
+                embed=embed,
+                view=None,
+                **embed_spacer_payload(embeds=[embed], is_edit=True, target=self.message),
             )
         self._schedule_cleanup()
 
@@ -500,7 +513,9 @@ class CreditLoanDecisionView(View):
         )
         with contextlib.suppress(Exception):
             await self.message.edit(
-                embed=embed, view=None, **embed_spacer_payload(embeds=[embed], is_edit=True)
+                embed=embed,
+                view=None,
+                **embed_spacer_payload(embeds=[embed], is_edit=True, target=self.message),
             )
         self._schedule_cleanup()
 

--- a/src/discordbot/cogs/economy.py
+++ b/src/discordbot/cogs/economy.py
@@ -28,6 +28,7 @@ from discordbot.cogs._economy.boards import (
     build_balance_leaderboard_board_image,
 )
 from discordbot.cogs._stock.database import get_stock_portfolio
+from discordbot.utils.discord_embeds import embed_spacer_payload
 from discordbot.utils.message_cleanup import schedule_public_message_delete
 from discordbot.cogs._economy.database import (
     top_n,
@@ -188,11 +189,14 @@ async def _send_expiring_followup(
     file: nextcord.File | None = None,
 ) -> None:
     """Sends a game-related economy embed and schedules its cleanup."""
-    kwargs: dict[str, object] = {"embed": embed, "wait": True}
+    extra_files = [file] if file is not None else None
+    kwargs: dict[str, object] = {
+        "embed": embed,
+        "wait": True,
+        **embed_spacer_payload(embeds=[embed], is_edit=False, extra_files=extra_files),
+    }
     if view is not None:
         kwargs["view"] = view
-    if file is not None:
-        kwargs["file"] = file
     message = await interaction.followup.send(**kwargs)
     user_name = interaction.user.name if interaction.user is not None else None
     schedule_public_message_delete(message=message, user_name=user_name)
@@ -200,13 +204,31 @@ async def _send_expiring_followup(
 
 async def _send_loan_request_followup(interaction: Interaction, embed: Embed, view: View) -> None:
     """Sends a loan request message that owns its cleanup after a terminal state."""
-    message = await interaction.followup.send(embed=embed, view=view, wait=True)
+    message = await interaction.followup.send(
+        embed=embed, view=view, wait=True, **embed_spacer_payload(embeds=[embed], is_edit=False)
+    )
     view.message = message
 
 
 async def _send_private_followup(interaction: Interaction, embed: Embed) -> None:
     """Sends a personal economy embed visible only to the caller."""
-    await interaction.followup.send(embed=embed, ephemeral=True)
+    await interaction.followup.send(
+        embed=embed, ephemeral=True, **embed_spacer_payload(embeds=[embed], is_edit=False)
+    )
+
+
+async def _send_ephemeral_response(interaction: Interaction, embed: Embed) -> None:
+    """Sends an ephemeral economy embed as the initial interaction response."""
+    await interaction.response.send_message(
+        embed=embed, ephemeral=True, **embed_spacer_payload(embeds=[embed], is_edit=False)
+    )
+
+
+async def _edit_response_embed(interaction: Interaction, embed: Embed) -> None:
+    """Edits the interaction's public message embed and clears its controls."""
+    await interaction.response.edit_message(
+        embed=embed, view=None, **embed_spacer_payload(embeds=[embed], is_edit=True)
+    )
 
 
 def _rate_text(monthly_rate_bps: int) -> str:
@@ -295,7 +317,9 @@ class CentralBankLoanDecisionView(View):
             color=_CENTRAL_BANK_COLOR,
         )
         with contextlib.suppress(Exception):
-            await self.message.edit(embed=embed, view=None)
+            await self.message.edit(
+                embed=embed, view=None, **embed_spacer_payload(embeds=[embed], is_edit=True)
+            )
         self._schedule_cleanup()
 
     async def _send_permission_denied(self, interaction: Interaction) -> None:
@@ -305,7 +329,7 @@ class CentralBankLoanDecisionView(View):
             description="### 只有央行成員可以處理央行借款申請",
             color=_ERROR_COLOR,
         )
-        await interaction.response.send_message(embed=embed, ephemeral=True)
+        await _send_ephemeral_response(interaction=interaction, embed=embed)
 
     async def _is_central_banker(self, interaction: Interaction) -> bool:
         """Returns whether the clicking user can decide central-bank proposals."""
@@ -350,7 +374,7 @@ class CentralBankLoanDecisionView(View):
                 description="### 申請不存在、已處理、自我批准未開放，或央行額度不足",
                 color=_ERROR_COLOR,
             )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            await _send_ephemeral_response(interaction=interaction, embed=embed)
             return
 
         embed = Embed(
@@ -367,7 +391,7 @@ class CentralBankLoanDecisionView(View):
             inline=True,
         )
         self.stop()
-        await interaction.response.edit_message(embed=embed, view=None)
+        await _edit_response_embed(interaction=interaction, embed=embed)
         self._schedule_cleanup(interaction=interaction)
 
     @nextcord.ui.button(
@@ -390,7 +414,7 @@ class CentralBankLoanDecisionView(View):
                 description="### 申請不存在、已處理，或你沒有權限拒絕",
                 color=_ERROR_COLOR,
             )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            await _send_ephemeral_response(interaction=interaction, embed=embed)
             return
 
         embed = Embed(
@@ -399,7 +423,7 @@ class CentralBankLoanDecisionView(View):
             color=_CENTRAL_BANK_COLOR,
         )
         self.stop()
-        await interaction.response.edit_message(embed=embed, view=None)
+        await _edit_response_embed(interaction=interaction, embed=embed)
         self._schedule_cleanup(interaction=interaction)
 
     @nextcord.ui.button(
@@ -419,7 +443,7 @@ class CentralBankLoanDecisionView(View):
                 description="### 只有申請發起者可以取消央行借款申請",
                 color=_ERROR_COLOR,
             )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            await _send_ephemeral_response(interaction=interaction, embed=embed)
             return
 
         proposal = await cancel_loan_proposal(
@@ -431,7 +455,7 @@ class CentralBankLoanDecisionView(View):
                 description="### 申請不存在、已處理，或你不是發起者",
                 color=_ERROR_COLOR,
             )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            await _send_ephemeral_response(interaction=interaction, embed=embed)
             return
 
         embed = Embed(
@@ -440,7 +464,7 @@ class CentralBankLoanDecisionView(View):
             color=_CENTRAL_BANK_COLOR,
         )
         self.stop()
-        await interaction.response.edit_message(embed=embed, view=None)
+        await _edit_response_embed(interaction=interaction, embed=embed)
         self._schedule_cleanup(interaction=interaction)
 
 
@@ -475,13 +499,15 @@ class CreditLoanDecisionView(View):
             title="信貸申請已逾時", description="### 申請已逾時，自動拒絕", color=_REPAY_COLOR
         )
         with contextlib.suppress(Exception):
-            await self.message.edit(embed=embed, view=None)
+            await self.message.edit(
+                embed=embed, view=None, **embed_spacer_payload(embeds=[embed], is_edit=True)
+            )
         self._schedule_cleanup()
 
     async def _send_permission_denied(self, interaction: Interaction, description: str) -> None:
         """Replies privately when a user clicks a button they cannot use."""
         embed = Embed(title="權限不足", description=description, color=_ERROR_COLOR)
-        await interaction.response.send_message(embed=embed, ephemeral=True)
+        await _send_ephemeral_response(interaction=interaction, embed=embed)
 
     async def _require_lender(self, interaction: Interaction) -> bool:
         """Returns whether the clicking user is the requested lender."""
@@ -517,7 +543,7 @@ class CreditLoanDecisionView(View):
                 description="### 申請不存在、已處理、不是指定貸方，或貸方餘額不足",
                 color=_ERROR_COLOR,
             )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            await _send_ephemeral_response(interaction=interaction, embed=embed)
             return
 
         embed = Embed(
@@ -532,7 +558,7 @@ class CreditLoanDecisionView(View):
             inline=True,
         )
         self.stop()
-        await interaction.response.edit_message(embed=embed, view=None)
+        await _edit_response_embed(interaction=interaction, embed=embed)
         self._schedule_cleanup(interaction=interaction)
 
     @nextcord.ui.button(
@@ -552,7 +578,7 @@ class CreditLoanDecisionView(View):
                 description="### 申請不存在、已處理，或你不是指定貸方",
                 color=_ERROR_COLOR,
             )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            await _send_ephemeral_response(interaction=interaction, embed=embed)
             return
 
         embed = Embed(
@@ -561,7 +587,7 @@ class CreditLoanDecisionView(View):
             color=_REPAY_COLOR,
         )
         self.stop()
-        await interaction.response.edit_message(embed=embed, view=None)
+        await _edit_response_embed(interaction=interaction, embed=embed)
         self._schedule_cleanup(interaction=interaction)
 
     @nextcord.ui.button(
@@ -586,7 +612,7 @@ class CreditLoanDecisionView(View):
                 description="### 申請不存在、已處理，或你不是發起者",
                 color=_ERROR_COLOR,
             )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            await _send_ephemeral_response(interaction=interaction, embed=embed)
             return
 
         embed = Embed(
@@ -595,7 +621,7 @@ class CreditLoanDecisionView(View):
             color=_REPAY_COLOR,
         )
         self.stop()
-        await interaction.response.edit_message(embed=embed, view=None)
+        await _edit_response_embed(interaction=interaction, embed=embed)
         self._schedule_cleanup(interaction=interaction)
 
 
@@ -664,8 +690,8 @@ class EconomyCogs(commands.Cog):
         """Credits points to a member through the manual-adjustment audit path."""
         parsed_amount = _parse_positive_amount(raw_amount=amount)
         if parsed_amount is None:
-            await interaction.response.send_message(
-                embed=self._invalid_admin_amount_embed(title="退稅失敗"), ephemeral=True
+            await _send_ephemeral_response(
+                interaction=interaction, embed=self._invalid_admin_amount_embed(title="退稅失敗")
             )
             return
         await self._run_admin_adjustment(
@@ -713,8 +739,8 @@ class EconomyCogs(commands.Cog):
         """Debits points from a member through the manual-adjustment audit path."""
         parsed_amount = _parse_positive_amount(raw_amount=amount)
         if parsed_amount is None:
-            await interaction.response.send_message(
-                embed=self._invalid_admin_amount_embed(title="收稅失敗"), ephemeral=True
+            await _send_ephemeral_response(
+                interaction=interaction, embed=self._invalid_admin_amount_embed(title="收稅失敗")
             )
             return
         await self._run_admin_adjustment(
@@ -1797,7 +1823,7 @@ class EconomyCogs(commands.Cog):
                 color=_ERROR_COLOR,
             )
             embed.set_author(name=user.display_name, icon_url=user_avatar_url)
-            await interaction.followup.send(embed=embed, ephemeral=True)
+            await _send_private_followup(interaction=interaction, embed=embed)
             return
 
         vip_badge = " · 👑 VIP 2x" if result.is_vip else ""
@@ -1825,7 +1851,7 @@ class EconomyCogs(commands.Cog):
                 inline=False,
             )
         embed.set_footer(text=f"連續 7 天為一個 cycle | 每天 0:00 (Asia/Taipei) 重置{vip_badge}")
-        await interaction.followup.send(embed=embed, ephemeral=True)
+        await _send_private_followup(interaction=interaction, embed=embed)
 
     @nextcord.slash_command(
         name="vip",

--- a/src/discordbot/cogs/games.py
+++ b/src/discordbot/cogs/games.py
@@ -20,10 +20,10 @@ from discordbot.typings.games import (
     ParticipantPreparationResult,
 )
 from discordbot.utils.avatars import guild_avatar_url
-from discordbot.utils.discord_embeds import embed_spacer_payload
 from discordbot.typings.models import RuntimeModelCatalog
 from discordbot.cogs._games.dealer import SystemNarrator
 from discordbot.cogs._games.wagers import WagerMode, parse_wager_amount, build_wager_participant
+from discordbot.utils.discord_embeds import embed_spacer_payload
 from discordbot.utils.message_cleanup import (
     track_public_message,
     delete_tracked_public_messages,

--- a/src/discordbot/cogs/games.py
+++ b/src/discordbot/cogs/games.py
@@ -434,11 +434,13 @@ class GamesCogs(commands.Cog):
         )
         owner = participant_result.participant
         if owner is None:
+            embed = self._dragon_gate_insufficient_balance_embed(
+                balance=participant_result.balance
+            )
             message = await interaction.followup.send(
-                embed=self._dragon_gate_insufficient_balance_embed(
-                    balance=participant_result.balance
-                ),
+                embed=embed,
                 wait=True,
+                **embed_spacer_payload(embeds=[embed], is_edit=False, target=interaction),
             )
             schedule_public_message_delete(message=message, user_name=interaction.user.name)
             return

--- a/src/discordbot/cogs/games.py
+++ b/src/discordbot/cogs/games.py
@@ -397,7 +397,7 @@ class GamesCogs(commands.Cog):
             embed=embed,
             view=view,
             wait=True,
-            **embed_spacer_payload(embeds=[embed], is_edit=False),
+            **embed_spacer_payload(embeds=[embed], is_edit=False, target=interaction),
         )
         await track_public_message(message=message, user_name=owner.account_name)
         view.message = message
@@ -463,7 +463,7 @@ class GamesCogs(commands.Cog):
             embed=embed,
             view=view,
             wait=True,
-            **embed_spacer_payload(embeds=[embed], is_edit=False),
+            **embed_spacer_payload(embeds=[embed], is_edit=False, target=interaction),
         )
         await track_public_message(message=message, user_name=owner.account_name)
         view.message = message

--- a/src/discordbot/cogs/games.py
+++ b/src/discordbot/cogs/games.py
@@ -336,8 +336,11 @@ class GamesCogs(commands.Cog):
             return
         wager = parse_wager_amount(raw_amount=bet)
         if wager is None:
+            embed = self._invalid_bet_embed()
             await interaction.response.send_message(
-                embed=self._invalid_bet_embed(), ephemeral=True
+                embed=embed,
+                ephemeral=True,
+                **embed_spacer_payload(embeds=[embed], is_edit=False, target=interaction),
             )
             return
 
@@ -354,9 +357,11 @@ class GamesCogs(commands.Cog):
             )
         owner = participant_result.participant
         if owner is None:
+            embed = self._insufficient_balance_embed(balance=participant_result.balance)
             message = await interaction.followup.send(
-                embed=self._insufficient_balance_embed(balance=participant_result.balance),
+                embed=embed,
                 wait=True,
+                **embed_spacer_payload(embeds=[embed], is_edit=False, target=interaction),
             )
             schedule_public_message_delete(message=message, user_name=interaction.user.name)
             return

--- a/src/discordbot/cogs/games.py
+++ b/src/discordbot/cogs/games.py
@@ -20,6 +20,7 @@ from discordbot.typings.games import (
     ParticipantPreparationResult,
 )
 from discordbot.utils.avatars import guild_avatar_url
+from discordbot.utils.discord_embeds import embed_spacer_payload
 from discordbot.typings.models import RuntimeModelCatalog
 from discordbot.cogs._games.dealer import SystemNarrator
 from discordbot.cogs._games.wagers import WagerMode, parse_wager_amount, build_wager_participant
@@ -392,7 +393,12 @@ class GamesCogs(commands.Cog):
             requested_bet=table_bet,
             max_players=MAX_BLACKJACK_PLAYERS,
         )
-        message = await interaction.followup.send(embed=embed, view=view, wait=True)
+        message = await interaction.followup.send(
+            embed=embed,
+            view=view,
+            wait=True,
+            **embed_spacer_payload(embeds=[embed], is_edit=False),
+        )
         await track_public_message(message=message, user_name=owner.account_name)
         view.message = message
 
@@ -453,7 +459,12 @@ class GamesCogs(commands.Cog):
         embed = build_dragon_gate_lobby_embed(
             owner=owner, participants=view.participants, jackpot=initial_jackpot.balance
         )
-        message = await interaction.followup.send(embed=embed, view=view, wait=True)
+        message = await interaction.followup.send(
+            embed=embed,
+            view=view,
+            wait=True,
+            **embed_spacer_payload(embeds=[embed], is_edit=False),
+        )
         await track_public_message(message=message, user_name=owner.account_name)
         view.message = message
 

--- a/src/discordbot/cogs/gen_reply.py
+++ b/src/discordbot/cogs/gen_reply.py
@@ -25,6 +25,7 @@ from discordbot.utils.images import get_image_data, convert_base64_to_data_uri
 from discordbot.utils.avatars import guild_avatar_url
 from discordbot.typings.models import RouteDecision, RuntimeModelCatalog
 from discordbot.utils.model_pricing import get_token_rates, get_supported_modalities
+from discordbot.utils.discord_embeds import embed_spacer_payload
 from discordbot.cogs._economy.database import credit_with_repayment
 from discordbot.cogs._gen_reply.prompts import (
     IMAGE_PROMPT,
@@ -744,7 +745,11 @@ class ReplyGeneratorCogs(commands.Cog):
                     color=0xED4245,
                 )
                 error_embed.set_footer(text=type(e).__name__)
-                await message.reply(content=None, embed=error_embed)
+                await message.reply(
+                    content=None,
+                    embed=error_embed,
+                    **embed_spacer_payload(embeds=[error_embed], is_edit=False),
+                )
 
 
 def setup(bot: commands.Bot) -> None:

--- a/src/discordbot/cogs/gen_reply.py
+++ b/src/discordbot/cogs/gen_reply.py
@@ -748,7 +748,7 @@ class ReplyGeneratorCogs(commands.Cog):
                 await message.reply(
                     content=None,
                     embed=error_embed,
-                    **embed_spacer_payload(embeds=[error_embed], is_edit=False),
+                    **embed_spacer_payload(embeds=[error_embed], is_edit=False, target=message),
                 )
 
 

--- a/src/discordbot/cogs/help.py
+++ b/src/discordbot/cogs/help.py
@@ -6,6 +6,7 @@ import nextcord
 from nextcord import Embed, Locale, Interaction
 from nextcord.ext import commands
 
+from discordbot.utils.discord_embeds import embed_spacer_payload
 from discordbot.cogs._economy.presentation import CURRENCY_NAME
 
 _EMBED_FIELD_VALUE_LIMIT = 1024
@@ -263,8 +264,9 @@ class HelpCogs(commands.Cog):
         )
 
         for index in range(0, len(embeds), _MESSAGE_EMBED_COUNT_LIMIT):
+            batch = embeds[index : index + _MESSAGE_EMBED_COUNT_LIMIT]
             await interaction.followup.send(
-                embeds=embeds[index : index + _MESSAGE_EMBED_COUNT_LIMIT], ephemeral=True
+                embeds=batch, ephemeral=True, **embed_spacer_payload(embeds=batch, is_edit=False)
             )
 
 

--- a/src/discordbot/cogs/help.py
+++ b/src/discordbot/cogs/help.py
@@ -266,7 +266,9 @@ class HelpCogs(commands.Cog):
         for index in range(0, len(embeds), _MESSAGE_EMBED_COUNT_LIMIT):
             batch = embeds[index : index + _MESSAGE_EMBED_COUNT_LIMIT]
             await interaction.followup.send(
-                embeds=batch, ephemeral=True, **embed_spacer_payload(embeds=batch, is_edit=False)
+                embeds=batch,
+                ephemeral=True,
+                **embed_spacer_payload(embeds=batch, is_edit=False, target=interaction),
             )
 
 

--- a/src/discordbot/cogs/maplestory.py
+++ b/src/discordbot/cogs/maplestory.py
@@ -30,7 +30,7 @@ async def _send_maple_followup(
     interaction: Interaction, embed: Embed, view: nextcord.ui.View | None = None
 ) -> None:
     """Sends a MapleStory result embed at a uniform width."""
-    payload = embed_spacer_payload(embeds=[embed], is_edit=False)
+    payload = embed_spacer_payload(embeds=[embed], is_edit=False, target=interaction)
     if view is not None:
         await interaction.followup.send(embed=embed, view=view, **payload)
     else:

--- a/src/discordbot/cogs/maplestory.py
+++ b/src/discordbot/cogs/maplestory.py
@@ -6,6 +6,8 @@ import nextcord
 from nextcord import Embed, Locale, Interaction, SlashOption, SelectOption
 from nextcord.ext import commands
 
+from discordbot.utils.discord_embeds import embed_spacer_payload
+
 from ._maplestory.views import MapleDropSearchView
 from ._maplestory.embeds import (
     create_map_embed,
@@ -22,6 +24,17 @@ from ._maplestory.service import DEFAULT_DATA_DIR, MapleStoryService
 _NOT_FOUND_COLOR = 0xFFAA00
 _MULTI_COLOR = 0x00AAFF
 _ERROR_COLOR = 0xFF0000
+
+
+async def _send_maple_followup(
+    interaction: Interaction, embed: Embed, view: nextcord.ui.View | None = None
+) -> None:
+    """Sends a MapleStory result embed at a uniform width."""
+    payload = embed_spacer_payload(embeds=[embed], is_edit=False)
+    if view is not None:
+        await interaction.followup.send(embed=embed, view=view, **payload)
+    else:
+        await interaction.followup.send(embed=embed, **payload)
 
 
 class MapleStoryCogs(commands.Cog):
@@ -54,7 +67,7 @@ class MapleStoryCogs(commands.Cog):
         embed = Embed(
             title=":x: 錯誤", description="無法載入資料，請聯絡管理員", color=_ERROR_COLOR
         )
-        await interaction.followup.send(embed=embed)
+        await _send_maple_followup(interaction=interaction, embed=embed)
 
     async def _send_not_found(self, interaction: Interaction, kind: str, query: str) -> None:
         """Sends a 'not found' message to the user."""
@@ -63,7 +76,7 @@ class MapleStoryCogs(commands.Cog):
             description=f"找不到名稱包含「{query}」的{kind}",
             color=_NOT_FOUND_COLOR,
         )
-        await interaction.followup.send(embed=embed)
+        await _send_maple_followup(interaction=interaction, embed=embed)
 
     @nextcord.slash_command(
         name="maplestory",
@@ -118,7 +131,7 @@ class MapleStoryCogs(commands.Cog):
 
         if len(results) == 1:
             embed = create_monster_embed(monster=results[0], translate=self._translate)
-            return await interaction.followup.send(embed=embed)
+            return await _send_maple_followup(interaction=interaction, embed=embed)
 
         embed = Embed(
             title=":mag: 搜尋結果",
@@ -130,7 +143,7 @@ class MapleStoryCogs(commands.Cog):
             SelectOption(label=m.display_name, description=f"Lv.{m.level}", value=m.name)
             for m in results
         ])
-        await interaction.followup.send(embed=embed, view=view)
+        await _send_maple_followup(interaction=interaction, embed=embed, view=view)
         return None
 
     # ── /maplestory equip ───────────────────────────────────────────
@@ -174,7 +187,7 @@ class MapleStoryCogs(commands.Cog):
 
         if len(results) == 1:
             embed = create_equipment_embed(equip=results[0], translate=self._translate)
-            return await interaction.followup.send(embed=embed)
+            return await _send_maple_followup(interaction=interaction, embed=embed)
 
         embed = Embed(
             title=":mag: 搜尋結果",
@@ -190,7 +203,7 @@ class MapleStoryCogs(commands.Cog):
             )
             for e in results
         ])
-        await interaction.followup.send(embed=embed, view=view)
+        await _send_maple_followup(interaction=interaction, embed=embed, view=view)
         return None
 
     # ── /maplestory scroll ──────────────────────────────────────────
@@ -234,7 +247,7 @@ class MapleStoryCogs(commands.Cog):
 
         if len(results) == 1:
             embed = create_scroll_embed(scroll=results[0], translate=self._translate)
-            return await interaction.followup.send(embed=embed)
+            return await _send_maple_followup(interaction=interaction, embed=embed)
 
         embed = Embed(
             title=":mag: 搜尋結果",
@@ -250,7 +263,7 @@ class MapleStoryCogs(commands.Cog):
             )
             for s in results
         ])
-        await interaction.followup.send(embed=embed, view=view)
+        await _send_maple_followup(interaction=interaction, embed=embed, view=view)
         return None
 
     # ── /maplestory npc ─────────────────────────────────────────────
@@ -294,7 +307,7 @@ class MapleStoryCogs(commands.Cog):
 
         if len(results) == 1:
             embed = create_npc_embed(npc=results[0], translate=self._translate)
-            return await interaction.followup.send(embed=embed)
+            return await _send_maple_followup(interaction=interaction, embed=embed)
 
         embed = Embed(
             title=":mag: 搜尋結果",
@@ -305,7 +318,7 @@ class MapleStoryCogs(commands.Cog):
         view.set_options([
             SelectOption(label=n.display_name, description=n.type, value=n.name) for n in results
         ])
-        await interaction.followup.send(embed=embed, view=view)
+        await _send_maple_followup(interaction=interaction, embed=embed, view=view)
         return None
 
     # ── /maplestory quest ───────────────────────────────────────────
@@ -349,7 +362,7 @@ class MapleStoryCogs(commands.Cog):
 
         if len(results) == 1:
             embed = create_quest_embed(quest=results[0], translate=self._translate)
-            return await interaction.followup.send(embed=embed)
+            return await _send_maple_followup(interaction=interaction, embed=embed)
 
         embed = Embed(
             title=":mag: 搜尋結果",
@@ -363,7 +376,7 @@ class MapleStoryCogs(commands.Cog):
             )
             for q in results
         ])
-        await interaction.followup.send(embed=embed, view=view)
+        await _send_maple_followup(interaction=interaction, embed=embed, view=view)
         return None
 
     # ── /maplestory map ─────────────────────────────────────────────
@@ -407,7 +420,7 @@ class MapleStoryCogs(commands.Cog):
 
         if len(results) == 1:
             embed = create_map_embed(map_entry=results[0], translate=self._translate)
-            return await interaction.followup.send(embed=embed)
+            return await _send_maple_followup(interaction=interaction, embed=embed)
 
         embed = Embed(
             title=":mag: 搜尋結果",
@@ -423,7 +436,7 @@ class MapleStoryCogs(commands.Cog):
             )
             for m in results
         ])
-        await interaction.followup.send(embed=embed, view=view)
+        await _send_maple_followup(interaction=interaction, embed=embed, view=view)
         return None
 
     # ── /maplestory item ────────────────────────────────────────────
@@ -471,7 +484,7 @@ class MapleStoryCogs(commands.Cog):
             embed = create_item_source_embed(
                 item_name=item, monsters=monsters, translate=self._translate
             )
-            return await interaction.followup.send(embed=embed)
+            return await _send_maple_followup(interaction=interaction, embed=embed)
 
         embed = Embed(
             title=":mag: 搜尋結果",
@@ -489,7 +502,7 @@ class MapleStoryCogs(commands.Cog):
             )
             for item in items_found
         ])
-        await interaction.followup.send(embed=embed, view=view)
+        await _send_maple_followup(interaction=interaction, embed=embed, view=view)
         return None
 
     # ── /maplestory stats ───────────────────────────────────────────
@@ -515,7 +528,7 @@ class MapleStoryCogs(commands.Cog):
 
         stats = self.service.get_stats()
         embed = build_stats_embed(stats)
-        await interaction.followup.send(embed=embed)
+        await _send_maple_followup(interaction=interaction, embed=embed)
         return None
 
 

--- a/src/discordbot/cogs/parse_threads.py
+++ b/src/discordbot/cogs/parse_threads.py
@@ -183,7 +183,9 @@ class ThreadsCogs(commands.Cog):
                 await message.reply(
                     embeds=embeds,
                     mention_author=False,
-                    **embed_spacer_payload(embeds=embeds, is_edit=False, extra_files=files),
+                    **embed_spacer_payload(
+                        embeds=embeds, is_edit=False, target=message, extra_files=files
+                    ),
                 )
                 await self._handle_reaction(
                     message=message, emoji="🆗", previous_emoji=current_emoji

--- a/src/discordbot/cogs/parse_threads.py
+++ b/src/discordbot/cogs/parse_threads.py
@@ -9,6 +9,7 @@ from nextcord import File, Color, Embed, Message
 from nextcord.ext import commands
 
 from discordbot.utils.threads import ThreadsOutput, ThreadsDownloader
+from discordbot.utils.discord_embeds import embed_spacer_payload
 
 URL_REGEX = re.compile(r"https?://(?:www\.)?threads\.(?:net|com)/@[^/]+/post/[^\s\"'<>)]+")
 
@@ -179,7 +180,11 @@ class ThreadsCogs(commands.Cog):
                 with contextlib.suppress(Exception):
                     await message.edit(suppress=True)
 
-                await message.reply(embeds=embeds, files=files, mention_author=False)
+                await message.reply(
+                    embeds=embeds,
+                    mention_author=False,
+                    **embed_spacer_payload(embeds=embeds, is_edit=False, extra_files=files),
+                )
                 await self._handle_reaction(
                     message=message, emoji="🆗", previous_emoji=current_emoji
                 )

--- a/src/discordbot/cogs/stock.py
+++ b/src/discordbot/cogs/stock.py
@@ -70,7 +70,9 @@ class StockCogs(commands.Cog):
             embed=embed,
             view=view,
             wait=True,
-            **embed_spacer_payload(embeds=[embed], is_edit=False, extra_files=[file]),
+            **embed_spacer_payload(
+                embeds=[embed], is_edit=False, target=interaction, extra_files=[file]
+            ),
         )
         view.bind_message(message=message)
         await track_public_message(message=message, user_name=user.name)

--- a/src/discordbot/cogs/stock.py
+++ b/src/discordbot/cogs/stock.py
@@ -19,6 +19,7 @@ from discordbot.cogs._stock.views import (
     build_market_message_payload,
 )
 from discordbot.cogs._stock.database import list_market_quotes, ensure_due_stock_news
+from discordbot.utils.discord_embeds import embed_spacer_payload
 from discordbot.utils.message_cleanup import track_public_message
 
 _stock_news_refresh_task: asyncio.Task[None] | None = None
@@ -65,7 +66,12 @@ class StockCogs(commands.Cog):
         quotes = await list_market_quotes(refresh_news=news_ai is None)
         view = StockMarketView(quotes=quotes, owner_id=user.id)
         embed, file = build_market_message_payload(quotes=quotes)
-        message = await interaction.followup.send(embed=embed, file=file, view=view, wait=True)
+        message = await interaction.followup.send(
+            embed=embed,
+            view=view,
+            wait=True,
+            **embed_spacer_payload(embeds=[embed], is_edit=False, extra_files=[file]),
+        )
         view.bind_message(message=message)
         await track_public_message(message=message, user_name=user.name)
 

--- a/src/discordbot/cogs/template.py
+++ b/src/discordbot/cogs/template.py
@@ -4,6 +4,8 @@ import nextcord
 from nextcord import Embed, Locale, Message, Interaction
 from nextcord.ext import commands
 
+from discordbot.utils.discord_embeds import embed_spacer_payload
+
 
 class TemplateCogs(commands.Cog):
     """Provides simple message reactions and the ping slash command.
@@ -69,7 +71,9 @@ class TemplateCogs(commands.Cog):
             icon_url=interaction.user.display_avatar.url,
         )
 
-        await interaction.followup.send(embed=embed)
+        await interaction.followup.send(
+            embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False)
+        )
 
 
 # 註冊 Cog

--- a/src/discordbot/cogs/template.py
+++ b/src/discordbot/cogs/template.py
@@ -72,7 +72,7 @@ class TemplateCogs(commands.Cog):
         )
 
         await interaction.followup.send(
-            embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False)
+            embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False, target=interaction)
         )
 
 

--- a/src/discordbot/utils/discord_embeds.py
+++ b/src/discordbot/utils/discord_embeds.py
@@ -56,7 +56,6 @@ def embed_spacer_payload(
     filename: str = DEFAULT_EMBED_SPACER_FILENAME,
 ) -> dict[str, Any]:
     """Returns the spacer files/attachments increment to merge into a send or edit."""
-    spacer_url = embed_spacer_url(filename=filename)
     needs_spacer = any(not _embed_has_image(embed=embed) for embed in embeds)
     files: list[File] = list(extra_files or [])
     if needs_spacer and len(files) < DISCORD_MAX_FILES_PER_MESSAGE:

--- a/src/discordbot/utils/discord_embeds.py
+++ b/src/discordbot/utils/discord_embeds.py
@@ -32,9 +32,10 @@ def build_embed_spacer_file(
     )
 
 
-def _embed_has_image(embed: Embed) -> bool:
+def _embed_has_real_image(*, embed: Embed, spacer_url: str) -> bool:
     """Returns True when an embed already shows a real image via set_image."""
-    return bool(embed.image and embed.image.url)
+    image_url = embed.image.url if embed.image else None
+    return bool(image_url and image_url != spacer_url)
 
 
 def apply_embed_spacer_image(
@@ -43,7 +44,7 @@ def apply_embed_spacer_image(
     """Sets a transparent spacer only on embeds without an image of their own."""
     spacer_url = embed_spacer_url(filename=filename)
     for embed in embeds:
-        if not _embed_has_image(embed=embed):
+        if not _embed_has_real_image(embed=embed, spacer_url=spacer_url):
             embed.set_image(url=spacer_url)
     return embeds
 
@@ -56,11 +57,18 @@ def embed_spacer_payload(
     filename: str = DEFAULT_EMBED_SPACER_FILENAME,
 ) -> dict[str, Any]:
     """Returns the spacer files/attachments increment to merge into a send or edit."""
-    needs_spacer = any(not _embed_has_image(embed=embed) for embed in embeds)
+    spacer_url = embed_spacer_url(filename=filename)
+    needs_spacer = any(
+        not _embed_has_real_image(embed=embed, spacer_url=spacer_url) for embed in embeds
+    )
     files: list[File] = list(extra_files or [])
     if needs_spacer and len(files) < DISCORD_MAX_FILES_PER_MESSAGE:
         apply_embed_spacer_image(embeds=embeds, filename=filename)
         files.append(build_embed_spacer_file(filename=filename))
+    elif needs_spacer:
+        for embed in embeds:
+            if embed.image and embed.image.url == spacer_url:
+                embed.set_image(url=None)
     payload: dict[str, Any] = {}
     if files:
         payload["files"] = files

--- a/src/discordbot/utils/discord_embeds.py
+++ b/src/discordbot/utils/discord_embeds.py
@@ -38,6 +38,29 @@ def _embed_has_real_image(*, embed: Embed, spacer_url: str) -> bool:
     return bool(image_url and image_url != spacer_url)
 
 
+def _target_allows_file_uploads(*, target: object | None) -> bool:
+    """Returns False only when the current channel clearly denies file uploads."""
+    if target is None:
+        return True
+    channel = getattr(target, "channel", None)
+    guild = getattr(target, "guild", None) or getattr(channel, "guild", None)
+    if guild is None:
+        return True
+    member = getattr(target, "me", None) or getattr(guild, "me", None)
+    if member is None:
+        client = getattr(target, "client", None) or getattr(target, "bot", None)
+        user = getattr(client, "user", None)
+        user_id = getattr(user, "id", None)
+        get_member = getattr(guild, "get_member", None)
+        if isinstance(user_id, int) and callable(get_member):
+            member = get_member(user_id)
+    permissions_for = getattr(channel, "permissions_for", None)
+    if member is None or not callable(permissions_for):
+        return True
+    permissions = permissions_for(member)
+    return bool(getattr(permissions, "attach_files", True))
+
+
 def apply_embed_spacer_image(
     *, embeds: list[Embed], filename: str = DEFAULT_EMBED_SPACER_FILENAME
 ) -> list[Embed]:
@@ -53,6 +76,7 @@ def embed_spacer_payload(
     *,
     embeds: list[Embed],
     is_edit: bool,
+    target: object | None = None,
     extra_files: list[File] | None = None,
     filename: str = DEFAULT_EMBED_SPACER_FILENAME,
 ) -> dict[str, Any]:
@@ -62,7 +86,8 @@ def embed_spacer_payload(
         not _embed_has_real_image(embed=embed, spacer_url=spacer_url) for embed in embeds
     )
     files: list[File] = list(extra_files or [])
-    if needs_spacer and len(files) < DISCORD_MAX_FILES_PER_MESSAGE:
+    can_upload_spacer = _target_allows_file_uploads(target=target)
+    if needs_spacer and can_upload_spacer and len(files) < DISCORD_MAX_FILES_PER_MESSAGE:
         apply_embed_spacer_image(embeds=embeds, filename=filename)
         files.append(build_embed_spacer_file(filename=filename))
     elif needs_spacer:

--- a/src/discordbot/utils/discord_embeds.py
+++ b/src/discordbot/utils/discord_embeds.py
@@ -10,6 +10,7 @@ from nextcord import File, Embed
 DEFAULT_EMBED_SPACER_FILENAME: Final[str] = "embed_spacer.png"
 DEFAULT_EMBED_SPACER_WIDTH: Final[int] = 640
 DEFAULT_EMBED_SPACER_HEIGHT: Final[int] = 1
+DISCORD_MAX_FILES_PER_MESSAGE: Final[int] = 10
 _TRANSPARENT_RGBA: Final[tuple[int, int, int, int]] = (0, 0, 0, 0)
 
 
@@ -55,11 +56,11 @@ def embed_spacer_payload(
     filename: str = DEFAULT_EMBED_SPACER_FILENAME,
 ) -> dict[str, Any]:
     """Returns the spacer files/attachments increment to merge into a send or edit."""
-    apply_embed_spacer_image(embeds=embeds, filename=filename)
     spacer_url = embed_spacer_url(filename=filename)
-    needs_spacer = any(embed.image.url == spacer_url for embed in embeds)
+    needs_spacer = any(not _embed_has_image(embed=embed) for embed in embeds)
     files: list[File] = list(extra_files or [])
-    if needs_spacer:
+    if needs_spacer and len(files) < DISCORD_MAX_FILES_PER_MESSAGE:
+        apply_embed_spacer_image(embeds=embeds, filename=filename)
         files.append(build_embed_spacer_file(filename=filename))
     payload: dict[str, Any] = {}
     if files:

--- a/src/discordbot/utils/discord_embeds.py
+++ b/src/discordbot/utils/discord_embeds.py
@@ -1,7 +1,7 @@
 """Helpers for Discord embed rendering quirks."""
 
 from io import BytesIO
-from typing import Final
+from typing import Any, Final
 from functools import cache
 
 from PIL import Image
@@ -31,14 +31,42 @@ def build_embed_spacer_file(
     )
 
 
+def _embed_has_image(embed: Embed) -> bool:
+    """Returns True when an embed already shows a real image via set_image."""
+    return bool(embed.image and embed.image.url)
+
+
 def apply_embed_spacer_image(
     *, embeds: list[Embed], filename: str = DEFAULT_EMBED_SPACER_FILENAME
 ) -> list[Embed]:
-    """Sets a transparent spacer image on embeds so Discord renders aligned widths."""
+    """Sets a transparent spacer only on embeds without an image of their own."""
     spacer_url = embed_spacer_url(filename=filename)
     for embed in embeds:
-        embed.set_image(url=spacer_url)
+        if not _embed_has_image(embed=embed):
+            embed.set_image(url=spacer_url)
     return embeds
+
+
+def embed_spacer_payload(
+    *,
+    embeds: list[Embed],
+    is_edit: bool,
+    extra_files: list[File] | None = None,
+    filename: str = DEFAULT_EMBED_SPACER_FILENAME,
+) -> dict[str, Any]:
+    """Returns the spacer files/attachments increment to merge into a send or edit."""
+    apply_embed_spacer_image(embeds=embeds, filename=filename)
+    spacer_url = embed_spacer_url(filename=filename)
+    needs_spacer = any(embed.image.url == spacer_url for embed in embeds)
+    files: list[File] = list(extra_files or [])
+    if needs_spacer:
+        files.append(build_embed_spacer_file(filename=filename))
+    payload: dict[str, Any] = {}
+    if files:
+        payload["files"] = files
+    if is_edit:
+        payload["attachments"] = []
+    return payload
 
 
 @cache

--- a/tests/test_blackjack_view_buttons.py
+++ b/tests/test_blackjack_view_buttons.py
@@ -329,7 +329,7 @@ def test_blackjack_table_edit_payload_adds_width_spacer() -> None:
     )
 
     assert payload["attachments"] == []
-    assert payload["file"].filename == DEFAULT_EMBED_SPACER_FILENAME
+    assert payload["files"][0].filename == DEFAULT_EMBED_SPACER_FILENAME
     for embed in payload["embeds"]:
         assert embed.image.url == embed_spacer_url()
 

--- a/tests/test_cogs_smoke.py
+++ b/tests/test_cogs_smoke.py
@@ -20,6 +20,7 @@ from discordbot.cogs.template import TemplateCogs
 from discordbot.typings.games import GameParticipant
 from discordbot.typings.stock import StockPortfolioView, StockPortfolioHolding
 from discordbot.utils.threads import ThreadsOutput
+from discordbot.utils.discord_embeds import DEFAULT_EMBED_SPACER_FILENAME, embed_spacer_url
 from discordbot.typings.models import ModelSettings
 from discordbot.typings.economy import (
     PortfolioView,
@@ -1516,6 +1517,8 @@ async def test_games_commands_run_with_patched_settlement(
     await GamesCogs.blackjack.callback(cog, blackjack_interaction, bet="10")
     assert blackjack_interaction.followup.sent[0]["wait"] is True
     assert isinstance(blackjack_interaction.followup.sent[0]["view"], BlackjackLobbyView)
+    assert blackjack_interaction.followup.sent[0]["files"][0].filename == DEFAULT_EMBED_SPACER_FILENAME
+    assert blackjack_interaction.followup.sent[0]["embed"].image.url == embed_spacer_url()
 
     monkeypatch.setattr(
         games, "fetch_dragon_gate_jackpot_snapshot", fake_dragon_gate_jackpot_snapshot
@@ -1525,6 +1528,8 @@ async def test_games_commands_run_with_patched_settlement(
     await GamesCogs.dragon_gate.callback(cog, dragon_gate_interaction)
     assert dragon_gate_interaction.followup.sent[-1]["wait"] is True
     assert isinstance(dragon_gate_interaction.followup.sent[-1]["view"], DragonGateLobbyView)
+    assert dragon_gate_interaction.followup.sent[-1]["files"][0].filename == DEFAULT_EMBED_SPACER_FILENAME
+    assert dragon_gate_interaction.followup.sent[-1]["embed"].image.url == embed_spacer_url()
 
 
 async def test_blackjack_lobby_start_is_owner_only(

--- a/tests/test_cogs_smoke.py
+++ b/tests/test_cogs_smoke.py
@@ -668,8 +668,8 @@ async def test_economy_commands_use_database_facade(  # noqa: PLR0915 -- command
     assert len(scheduled) == 12
     assert interaction.followup.sent[0].get("ephemeral") is True
     assert "view" not in interaction.followup.sent[1]
-    assert interaction.followup.sent[1]["file"].filename == "economy_leaderboard.png"
-    assert interaction.followup.sent[2]["file"].filename == "economy_loss_leaderboard.png"
+    assert interaction.followup.sent[1]["files"][0].filename == "economy_leaderboard.png"
+    assert interaction.followup.sent[2]["files"][0].filename == "economy_loss_leaderboard.png"
     assert "view" not in interaction.followup.sent[3]
     assert "view" not in interaction.followup.sent[4]
     assert interaction.followup.sent[5].get("ephemeral") is not True
@@ -1150,7 +1150,7 @@ async def test_loss_leaderboard_uses_daily_loss_copy(monkeypatch: pytest.MonkeyP
     embed = interaction.followup.sent[0]["embed"]
     assert "今日輸局累計" in embed.title
     assert "累計輸" in embed.description
-    assert interaction.followup.sent[0]["file"].filename == "economy_loss_leaderboard.png"
+    assert interaction.followup.sent[0]["files"][0].filename == "economy_loss_leaderboard.png"
     assert "贏回來不抵扣" in embed.footer.text
     assert len(scheduled) == 1
 

--- a/tests/test_cogs_smoke.py
+++ b/tests/test_cogs_smoke.py
@@ -20,7 +20,6 @@ from discordbot.cogs.template import TemplateCogs
 from discordbot.typings.games import GameParticipant
 from discordbot.typings.stock import StockPortfolioView, StockPortfolioHolding
 from discordbot.utils.threads import ThreadsOutput
-from discordbot.utils.discord_embeds import DEFAULT_EMBED_SPACER_FILENAME, embed_spacer_url
 from discordbot.typings.models import ModelSettings
 from discordbot.typings.economy import (
     PortfolioView,
@@ -43,6 +42,7 @@ from discordbot.cogs.auto_unmute import AutoUnmuteCogs
 from discordbot.cogs._games.dealer import SystemNarrator
 from discordbot.cogs._games.wagers import parse_wager_amount
 from discordbot.cogs.parse_threads import ThreadsCogs
+from discordbot.utils.discord_embeds import DEFAULT_EMBED_SPACER_FILENAME, embed_spacer_url
 from discordbot.cogs._economy.database import (
     VIP_PURCHASE_COST,
     CreditResult,
@@ -1517,7 +1517,10 @@ async def test_games_commands_run_with_patched_settlement(
     await GamesCogs.blackjack.callback(cog, blackjack_interaction, bet="10")
     assert blackjack_interaction.followup.sent[0]["wait"] is True
     assert isinstance(blackjack_interaction.followup.sent[0]["view"], BlackjackLobbyView)
-    assert blackjack_interaction.followup.sent[0]["files"][0].filename == DEFAULT_EMBED_SPACER_FILENAME
+    assert (
+        blackjack_interaction.followup.sent[0]["files"][0].filename
+        == DEFAULT_EMBED_SPACER_FILENAME
+    )
     assert blackjack_interaction.followup.sent[0]["embed"].image.url == embed_spacer_url()
 
     monkeypatch.setattr(
@@ -1528,7 +1531,10 @@ async def test_games_commands_run_with_patched_settlement(
     await GamesCogs.dragon_gate.callback(cog, dragon_gate_interaction)
     assert dragon_gate_interaction.followup.sent[-1]["wait"] is True
     assert isinstance(dragon_gate_interaction.followup.sent[-1]["view"], DragonGateLobbyView)
-    assert dragon_gate_interaction.followup.sent[-1]["files"][0].filename == DEFAULT_EMBED_SPACER_FILENAME
+    assert (
+        dragon_gate_interaction.followup.sent[-1]["files"][0].filename
+        == DEFAULT_EMBED_SPACER_FILENAME
+    )
     assert dragon_gate_interaction.followup.sent[-1]["embed"].image.url == embed_spacer_url()
 
 

--- a/tests/test_cogs_smoke.py
+++ b/tests/test_cogs_smoke.py
@@ -1674,6 +1674,8 @@ async def test_blackjack_string_bet_rejects_invalid_text() -> None:
 
     assert owner_interaction.response.sent[0]["ephemeral"] is True
     assert owner_interaction.response.sent[0]["embed"].title == "下注格式錯誤"
+    assert owner_interaction.response.sent[0]["files"][0].filename == DEFAULT_EMBED_SPACER_FILENAME
+    assert owner_interaction.response.sent[0]["embed"].image.url == embed_spacer_url()
     assert owner_interaction.followup.sent == []
     assert owner_interaction.response.deferred is False
 
@@ -1719,6 +1721,8 @@ async def test_blackjack_zero_bet_rejects_empty_balance(monkeypatch: pytest.Monk
     assert owner_interaction.followup.sent[0]["wait"] is True
     assert "view" not in owner_interaction.followup.sent[0]
     assert owner_interaction.followup.sent[0]["embed"].title == "餘額不足"
+    assert owner_interaction.followup.sent[0]["files"][0].filename == DEFAULT_EMBED_SPACER_FILENAME
+    assert owner_interaction.followup.sent[0]["embed"].image.url == embed_spacer_url()
 
 
 async def test_dragon_gate_lobby_start_is_owner_only(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_cogs_smoke.py
+++ b/tests/test_cogs_smoke.py
@@ -1725,6 +1725,27 @@ async def test_blackjack_zero_bet_rejects_empty_balance(monkeypatch: pytest.Monk
     assert owner_interaction.followup.sent[0]["embed"].image.url == embed_spacer_url()
 
 
+async def test_dragon_gate_rejects_empty_balance_with_spacer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verifies the Dragon Gate insufficient-balance response keeps uniform width."""
+    monkeypatch.setenv(name="OPENAI_BASE_URL", value="https://example.test/v1")
+    monkeypatch.setenv(name="OPENAI_API_KEY", value="test-key")
+    monkeypatch.setattr(games, "schedule_public_message_delete", ignore_scheduled_public_message)
+    monkeypatch.setattr(games, "get_balance", _empty_game_balance)
+
+    cog = GamesCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+
+    owner_interaction = FakeInteraction(user=FakeUser(user_id=1))
+    await GamesCogs.dragon_gate.callback(cog, owner_interaction)
+
+    assert owner_interaction.followup.sent[0]["wait"] is True
+    assert "view" not in owner_interaction.followup.sent[0]
+    assert owner_interaction.followup.sent[0]["embed"].title == "餘額不足"
+    assert owner_interaction.followup.sent[0]["files"][0].filename == DEFAULT_EMBED_SPACER_FILENAME
+    assert owner_interaction.followup.sent[0]["embed"].image.url == embed_spacer_url()
+
+
 async def test_dragon_gate_lobby_start_is_owner_only(monkeypatch: pytest.MonkeyPatch) -> None:
     """Verifies only the Dragon Gate lobby owner can press Start."""
     monkeypatch.setenv(name="OPENAI_BASE_URL", value="https://example.test/v1")

--- a/tests/test_discord_embed_utils.py
+++ b/tests/test_discord_embed_utils.py
@@ -109,3 +109,14 @@ def test_embed_spacer_payload_merges_extra_files_with_spacer() -> None:
     assert payload["files"][1].filename == DEFAULT_EMBED_SPACER_FILENAME
     assert with_image.image.url == "https://cdn.test/photo.png"
     assert text_only.image.url == embed_spacer_url()
+
+
+def test_embed_spacer_payload_skips_spacer_when_extra_files_fill_discord_limit() -> None:
+    """A full file payload keeps the real files and leaves text embeds unmodified."""
+    files = [build_embed_spacer_file(filename=f"video-{index}.mp4") for index in range(10)]
+    embed = Embed(description="video-only post")
+
+    payload = embed_spacer_payload(embeds=[embed], is_edit=False, extra_files=files)
+
+    assert payload["files"] == files
+    assert not embed.image.url

--- a/tests/test_discord_embed_utils.py
+++ b/tests/test_discord_embed_utils.py
@@ -74,6 +74,18 @@ def test_embed_spacer_payload_send_omits_attachments() -> None:
     assert payload["files"][0].filename == DEFAULT_EMBED_SPACER_FILENAME
 
 
+def test_embed_spacer_payload_reuploads_existing_spacer_image() -> None:
+    """A reused spacer embed still gets a fresh upload for the new message."""
+    embed = Embed(description="text")
+    embed_spacer_payload(embeds=[embed], is_edit=True)
+
+    payload = embed_spacer_payload(embeds=[embed], is_edit=False)
+
+    assert "attachments" not in payload
+    assert payload["files"][0].filename == DEFAULT_EMBED_SPACER_FILENAME
+    assert embed.image.url == embed_spacer_url()
+
+
 def test_embed_spacer_payload_real_image_keeps_only_extra_files() -> None:
     """A real-image embed adds no spacer upload but preserves the caller's file."""
     embed = Embed(description="board")
@@ -115,6 +127,18 @@ def test_embed_spacer_payload_skips_spacer_when_extra_files_fill_discord_limit()
     """A full file payload keeps the real files and leaves text embeds unmodified."""
     files = [build_embed_spacer_file(filename=f"video-{index}.mp4") for index in range(10)]
     embed = Embed(description="video-only post")
+
+    payload = embed_spacer_payload(embeds=[embed], is_edit=False, extra_files=files)
+
+    assert payload["files"] == files
+    assert not embed.image.url
+
+
+def test_embed_spacer_payload_removes_stale_spacer_when_file_limit_is_full() -> None:
+    """A reused spacer embed drops the missing attachment reference when upload is full."""
+    files = [build_embed_spacer_file(filename=f"video-{index}.mp4") for index in range(10)]
+    embed = Embed(description="video-only post")
+    embed.set_image(url=embed_spacer_url())
 
     payload = embed_spacer_payload(embeds=[embed], is_edit=False, extra_files=files)
 

--- a/tests/test_discord_embed_utils.py
+++ b/tests/test_discord_embed_utils.py
@@ -5,6 +5,7 @@ from nextcord import Embed
 from discordbot.utils.discord_embeds import (
     DEFAULT_EMBED_SPACER_FILENAME,
     embed_spacer_url,
+    embed_spacer_payload,
     build_embed_spacer_file,
     apply_embed_spacer_image,
 )
@@ -28,3 +29,83 @@ def test_build_embed_spacer_file_returns_fresh_png_upload() -> None:
     assert first is not second
     assert first.filename == DEFAULT_EMBED_SPACER_FILENAME
     assert first.fp.read(8) == b"\x89PNG\r\n\x1a\n"
+
+
+def test_apply_embed_spacer_image_skips_embeds_with_real_image() -> None:
+    """Embeds that already show a real image are never overwritten by the spacer."""
+    with_image = Embed(description="has image")
+    with_image.set_image(url="https://cdn.test/board.png")
+    text_only = Embed(description="text only")
+
+    apply_embed_spacer_image(embeds=[with_image, text_only])
+
+    assert with_image.image.url == "https://cdn.test/board.png"
+    assert text_only.image.url == embed_spacer_url()
+
+
+def test_apply_embed_spacer_image_treats_thumbnail_as_image_less() -> None:
+    """A thumbnail is not an image, so the embed still receives a spacer."""
+    embed = Embed(description="thumb only")
+    embed.set_thumbnail(url="https://cdn.test/avatar.png")
+
+    apply_embed_spacer_image(embeds=[embed])
+
+    assert embed.image.url == embed_spacer_url()
+
+
+def test_embed_spacer_payload_edit_adds_spacer_file_and_clears_attachments() -> None:
+    """An edit payload uploads a fresh spacer and clears stale attachments."""
+    embed = Embed(description="text")
+
+    payload = embed_spacer_payload(embeds=[embed], is_edit=True)
+
+    assert payload["attachments"] == []
+    assert payload["files"][0].filename == DEFAULT_EMBED_SPACER_FILENAME
+    assert embed.image.url == embed_spacer_url()
+
+
+def test_embed_spacer_payload_send_omits_attachments() -> None:
+    """A send payload never carries attachments, which send methods reject."""
+    embed = Embed(description="text")
+
+    payload = embed_spacer_payload(embeds=[embed], is_edit=False)
+
+    assert "attachments" not in payload
+    assert payload["files"][0].filename == DEFAULT_EMBED_SPACER_FILENAME
+
+
+def test_embed_spacer_payload_real_image_keeps_only_extra_files() -> None:
+    """A real-image embed adds no spacer upload but preserves the caller's file."""
+    embed = Embed(description="board")
+    embed.set_image(url="https://cdn.test/board.png")
+    real_file = build_embed_spacer_file(filename="board.png")
+
+    payload = embed_spacer_payload(embeds=[embed], is_edit=False, extra_files=[real_file])
+
+    assert payload["files"] == [real_file]
+    assert embed.image.url == "https://cdn.test/board.png"
+
+
+def test_embed_spacer_payload_is_empty_when_nothing_needed() -> None:
+    """A real-image send with no extra files produces an empty payload."""
+    embed = Embed(description="board")
+    embed.set_image(url="https://cdn.test/board.png")
+
+    assert embed_spacer_payload(embeds=[embed], is_edit=False) == {}
+
+
+def test_embed_spacer_payload_merges_extra_files_with_spacer() -> None:
+    """Mixed embeds keep the real upload first and append a single spacer upload."""
+    real_file = build_embed_spacer_file(filename="video.mp4")
+    with_image = Embed(description="image")
+    with_image.set_image(url="https://cdn.test/photo.png")
+    text_only = Embed(description="text")
+
+    payload = embed_spacer_payload(
+        embeds=[with_image, text_only], is_edit=False, extra_files=[real_file]
+    )
+
+    assert payload["files"][0] is real_file
+    assert payload["files"][1].filename == DEFAULT_EMBED_SPACER_FILENAME
+    assert with_image.image.url == "https://cdn.test/photo.png"
+    assert text_only.image.url == embed_spacer_url()

--- a/tests/test_discord_embed_utils.py
+++ b/tests/test_discord_embed_utils.py
@@ -1,5 +1,7 @@
 """Tests for shared Discord embed helpers."""
 
+from types import SimpleNamespace
+
 from nextcord import Embed
 
 from discordbot.utils.discord_embeds import (
@@ -9,6 +11,23 @@ from discordbot.utils.discord_embeds import (
     build_embed_spacer_file,
     apply_embed_spacer_image,
 )
+
+
+def _permission_target(*, attach_files: bool) -> SimpleNamespace:
+    """Builds a Discord target stub with channel permissions."""
+    member = object()
+    guild = SimpleNamespace(me=member)
+
+    class _Channel:
+        def __init__(self) -> None:
+            self.guild = guild
+
+        @staticmethod
+        def permissions_for(target_member: object) -> SimpleNamespace:
+            assert target_member is member
+            return SimpleNamespace(attach_files=attach_files)
+
+    return SimpleNamespace(guild=guild, channel=_Channel())
 
 
 def test_apply_embed_spacer_image_sets_attachment_url() -> None:
@@ -72,6 +91,31 @@ def test_embed_spacer_payload_send_omits_attachments() -> None:
 
     assert "attachments" not in payload
     assert payload["files"][0].filename == DEFAULT_EMBED_SPACER_FILENAME
+
+
+def test_embed_spacer_payload_skips_spacer_without_attach_files_permission() -> None:
+    """A text-only send stays usable when the bot cannot upload attachments."""
+    embed = Embed(description="text")
+
+    payload = embed_spacer_payload(
+        embeds=[embed], is_edit=False, target=_permission_target(attach_files=False)
+    )
+
+    assert payload == {}
+    assert not embed.image.url
+
+
+def test_embed_spacer_payload_removes_stale_spacer_without_attach_files_permission() -> None:
+    """An edit without upload permission drops stale spacer attachment references."""
+    embed = Embed(description="text")
+    embed.set_image(url=embed_spacer_url())
+
+    payload = embed_spacer_payload(
+        embeds=[embed], is_edit=True, target=_permission_target(attach_files=False)
+    )
+
+    assert payload == {"attachments": []}
+    assert not embed.image.url
 
 
 def test_embed_spacer_payload_reuploads_existing_spacer_image() -> None:

--- a/tests/test_dragon_gate.py
+++ b/tests/test_dragon_gate.py
@@ -12,7 +12,6 @@ import pytest
 from nextcord import Embed
 from nextcord.ui import Button, StringSelect
 
-from discordbot.utils.discord_embeds import DEFAULT_EMBED_SPACER_FILENAME, embed_spacer_url
 from discordbot.typings.games import (
     Card,
     GameParticipant,
@@ -24,6 +23,7 @@ from discordbot.typings.economy import (
     JackpotSettlementRequest,
     JackpotSettlementBatchResult,
 )
+from discordbot.utils.discord_embeds import DEFAULT_EMBED_SPACER_FILENAME, embed_spacer_url
 from discordbot.cogs._games.dragon_gate import (
     ANTE,
     GAME_ID,

--- a/tests/test_dragon_gate.py
+++ b/tests/test_dragon_gate.py
@@ -12,6 +12,7 @@ import pytest
 from nextcord import Embed
 from nextcord.ui import Button, StringSelect
 
+from discordbot.utils.discord_embeds import DEFAULT_EMBED_SPACER_FILENAME, embed_spacer_url
 from discordbot.typings.games import (
     Card,
     GameParticipant,
@@ -848,11 +849,14 @@ async def test_dragon_gate_final_settlement_does_not_wait_for_dealer_banter(
 
     assert len(dealer.table_settle_calls) == 1
     assert message.edits[-1]["view"] is None
+    assert message.edits[-1]["attachments"] == []
+    assert message.edits[-1]["files"][0].filename == DEFAULT_EMBED_SPACER_FILENAME
     refreshed_embeds = message.edits[-1]["embeds"]
     assert isinstance(refreshed_embeds, list)
     assert isinstance(refreshed_embeds[0], Embed)
     assert isinstance(refreshed_embeds[0].description, str)
     assert "background settled" in refreshed_embeds[0].description
+    assert refreshed_embeds[0].image.url == embed_spacer_url()
 
 
 async def test_dragon_gate_view_uses_capped_jackpot_settlement_delta(

--- a/tests/test_dragon_gate.py
+++ b/tests/test_dragon_gate.py
@@ -12,6 +12,7 @@ import pytest
 from nextcord import Embed
 from nextcord.ui import Button, StringSelect
 
+from discordbot.cogs._games import interactions as game_interactions
 from discordbot.typings.games import (
     Card,
     GameParticipant,
@@ -32,6 +33,7 @@ from discordbot.cogs._games.dragon_gate import (
     card_value,
     has_open_gate,
 )
+from discordbot.cogs._games.interactions import edit_message_with_retry
 from discordbot.cogs._games.dragon_gate_views import (
     DragonGateView,
     DragonGateBetModal,
@@ -60,6 +62,28 @@ class MessageStub:
     async def edit(self, **kwargs: Any) -> None:  # noqa: ANN401 -- test double accepts heterogeneous kwargs
         """Records a message edit payload."""
         self.edits.append(kwargs)
+
+
+class RetryMessageStub:
+    """Message stub that fails once with a transient Discord error."""
+
+    def __init__(self) -> None:
+        """Initializes retry records."""
+        self.id = 123
+        self.edits: list[dict[str, Any]] = []
+
+    async def edit(self, **kwargs: Any) -> RetryMessageStub:  # noqa: ANN401 -- Discord kwargs
+        """Records an edit and fails the first attempt."""
+        self.edits.append(kwargs)
+        if len(self.edits) == 1:
+            raise _TransientEditError
+        return self
+
+
+class _TransientEditError(Exception):
+    """Fake Discord 5xx error for retry tests."""
+
+    status = 503
 
 
 class ResponseStub:
@@ -537,6 +561,35 @@ def test_dragon_gate_embeds_show_lobby_progress_and_final_state() -> None:
     assert isinstance(final, Embed)
     assert isinstance(final.title, str)
     assert final.title
+
+
+async def test_edit_message_with_retry_rebuilds_payload_between_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Retries rebuild file-backed edit kwargs instead of reusing consumed streams."""
+    sleep_delays: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        """Records backoff without slowing the test."""
+        sleep_delays.append(delay)
+
+    monkeypatch.setattr(game_interactions, "DiscordServerError", _TransientEditError)
+    monkeypatch.setattr(game_interactions.asyncio, "sleep", fake_sleep)
+    message = RetryMessageStub()
+    payloads: list[object] = []
+
+    def kwargs_factory() -> dict[str, Any]:
+        file_marker = object()
+        payloads.append(file_marker)
+        return {"files": [file_marker]}
+
+    result = await edit_message_with_retry(message=message, kwargs_factory=kwargs_factory)
+
+    assert result is message
+    assert sleep_delays == [0.5]
+    assert len(payloads) == 2
+    assert message.edits[0]["files"][0] is payloads[0]
+    assert message.edits[1]["files"][0] is payloads[1]
 
 
 async def test_dragon_gate_controls_hide_unavailable_actions() -> None:

--- a/tests/test_game_cleanup.py
+++ b/tests/test_game_cleanup.py
@@ -172,6 +172,7 @@ class _FollowupStub:
         self.sent_ephemeral: bool | None = None
         self.sent_embed: nextcord.Embed | None = None
         self.sent_view: nextcord.ui.View | None = None
+        self.sent_files: list[nextcord.File] | None = None
 
     async def send(
         self,
@@ -179,12 +180,14 @@ class _FollowupStub:
         wait: bool = False,
         ephemeral: bool = False,
         view: nextcord.ui.View | None = None,
+        files: list[nextcord.File] | None = None,
     ) -> _SentFollowupMessageStub:
         """Records the embed send and returns the message object."""
         self.sent_embed = embed
         self.sent_wait = wait
         self.sent_ephemeral = ephemeral
         self.sent_view = view
+        self.sent_files = files
         return self.message
 
 

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -47,6 +47,7 @@ class FakeReply:
         """Initializes the fake reply with empty content and no follow-up chain."""
         self.content: str | None = ""
         self.file: File | None = None
+        self.files: list[File] | None = None
         self.embed: Embed | None = None
         self.replies: list[FakeReply] = []
 
@@ -102,12 +103,17 @@ class FakeMessage:
             yield self
 
     async def reply(
-        self, content: str | None, file: File | None = None, embed: Embed | None = None
+        self,
+        content: str | None,
+        file: File | None = None,
+        embed: Embed | None = None,
+        files: list[File] | None = None,
     ) -> FakeReply:
         """Creates and records a fake reply with the requested content."""
         reply = FakeReply()
         reply.content = content
         reply.file = file
+        reply.files = files
         reply.embed = embed
         self.replies.append(reply)
         return reply

--- a/tests/test_maplestory.py
+++ b/tests/test_maplestory.py
@@ -7,11 +7,12 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING, Unpack, TypedDict
 
 import pytest
-from nextcord import File, Embed, Locale, SelectOption
+from nextcord import File, Embed, Locale, Attachment, SelectOption
 
 from discordbot.cogs import maplestory
 from discordbot.cogs.maplestory import MapleStoryCogs
 from discordbot.cogs._maplestory.views import _RESOLVERS, MapleDropSearchView
+from discordbot.utils.discord_embeds import DEFAULT_EMBED_SPACER_FILENAME, embed_spacer_url
 from discordbot.cogs._maplestory.embeds import (
     _truncate,
     create_map_embed,
@@ -69,6 +70,7 @@ class InteractionPayload(TypedDict, total=False):
     message_id: int
     ephemeral: bool
     files: list[File]
+    attachments: list[Attachment]
 
 
 class _FakeResponse:
@@ -602,6 +604,12 @@ async def test_maplestory_view_select_result_handles_loading_and_valid_choice(
     assert valid_interaction.followup.edited[0]["message_id"] == 777
     assert isinstance(valid_interaction.followup.edited[0]["embed"], Embed)
     assert valid_interaction.followup.edited[0]["view"] is None
+    assert valid_interaction.followup.edited[0]["attachments"] == []
+    assert (
+        valid_interaction.followup.edited[0]["files"][0].filename
+        == DEFAULT_EMBED_SPACER_FILENAME
+    )
+    assert valid_interaction.followup.edited[0]["embed"].image.url == embed_spacer_url()
 
 
 @pytest.fixture
@@ -667,6 +675,8 @@ async def test_maplestory_commands_send_multi_result_view(maple_cog: MapleStoryC
     assert isinstance(payload["embed"], Embed)
     assert "找到 2 個相關怪物" in payload["embed"].description
     assert isinstance(payload["view"], MapleDropSearchView)
+    assert payload["files"][0].filename == DEFAULT_EMBED_SPACER_FILENAME
+    assert payload["embed"].image.url == embed_spacer_url()
 
 
 async def test_maplestory_commands_send_not_found_and_stats(maple_cog: MapleStoryCogs) -> None:

--- a/tests/test_maplestory.py
+++ b/tests/test_maplestory.py
@@ -11,8 +11,8 @@ from nextcord import File, Embed, Locale, Attachment, SelectOption
 
 from discordbot.cogs import maplestory
 from discordbot.cogs.maplestory import MapleStoryCogs
-from discordbot.cogs._maplestory.views import _RESOLVERS, MapleDropSearchView
 from discordbot.utils.discord_embeds import DEFAULT_EMBED_SPACER_FILENAME, embed_spacer_url
+from discordbot.cogs._maplestory.views import _RESOLVERS, MapleDropSearchView
 from discordbot.cogs._maplestory.embeds import (
     _truncate,
     create_map_embed,
@@ -606,8 +606,7 @@ async def test_maplestory_view_select_result_handles_loading_and_valid_choice(
     assert valid_interaction.followup.edited[0]["view"] is None
     assert valid_interaction.followup.edited[0]["attachments"] == []
     assert (
-        valid_interaction.followup.edited[0]["files"][0].filename
-        == DEFAULT_EMBED_SPACER_FILENAME
+        valid_interaction.followup.edited[0]["files"][0].filename == DEFAULT_EMBED_SPACER_FILENAME
     )
     assert valid_interaction.followup.edited[0]["embed"].image.url == embed_spacer_url()
 

--- a/tests/test_maplestory.py
+++ b/tests/test_maplestory.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING, Unpack, TypedDict
 
 import pytest
-from nextcord import Embed, Locale, SelectOption
+from nextcord import File, Embed, Locale, SelectOption
 
 from discordbot.cogs import maplestory
 from discordbot.cogs.maplestory import MapleStoryCogs
@@ -68,6 +68,7 @@ class InteractionPayload(TypedDict, total=False):
     view: MapleDropSearchView | None
     message_id: int
     ephemeral: bool
+    files: list[File]
 
 
 class _FakeResponse:
@@ -101,6 +102,7 @@ class _FakeFollowup:
         embed: Embed | None = None,
         view: MapleDropSearchView | None = None,
         ephemeral: bool | None = None,
+        files: list[File] | None = None,
     ) -> None:
         """Records a followup send payload."""
         payload = InteractionPayload()
@@ -112,6 +114,8 @@ class _FakeFollowup:
             payload["view"] = view
         if ephemeral is not None:
             payload["ephemeral"] = ephemeral
+        if files is not None:
+            payload["files"] = files
         self.sent.append(payload)
 
     async def edit_message(self, **kwargs: Unpack[InteractionPayload]) -> None:

--- a/tests/test_stock_views.py
+++ b/tests/test_stock_views.py
@@ -10,7 +10,7 @@ from datetime import datetime
 
 from PIL import Image
 import pytest
-from nextcord import Embed, Locale
+from nextcord import File, Embed, Locale
 
 from discordbot.cogs import stock
 from discordbot.cogs.stock import StockCogs
@@ -790,16 +790,21 @@ async def test_edit_stock_message_publicly_recovers_when_target_was_deleted(
     interaction.response.deferred = True
     interaction.message = DeletedMessageStub()
     view = StockPostTradeView(symbol=BCAT_SYMBOL, owner_id=1)
+    chart_file = File(fp=BytesIO(b"chart-bytes"), filename="chart.png")
 
     await stock_views.edit_stock_message(
         interaction=interaction,
         embed=Embed(title="股票交易完成"),
         view=view,
+        file=chart_file,
         message=interaction.message,
     )
 
     assert interaction.followup.sent[0].get("ephemeral") is not True
     assert interaction.followup.sent[0]["view"] is view
+    assert interaction.followup.sent[0]["files"][0] is not chart_file
+    assert interaction.followup.sent[0]["files"][0].filename == "chart.png"
+    assert interaction.followup.sent[0]["files"][0].fp.read() == b"chart-bytes"
     assert view.message is not interaction.message
     assert forgotten == [interaction.message.id]
     assert tracked == [view.message]

--- a/tests/test_stock_views.py
+++ b/tests/test_stock_views.py
@@ -285,7 +285,7 @@ async def test_stock_command_sends_public_market_and_schedules_cleanup(
     assert interaction.user is not None
     assert interaction.followup.sent[0].get("ephemeral") is not True
     assert isinstance(interaction.followup.sent[0]["view"], StockMarketView)
-    assert interaction.followup.sent[0]["file"].filename == "stock_market_1.png"
+    assert interaction.followup.sent[0]["files"][0].filename == "stock_market_1.png"
     assert interaction.followup.sent[0]["view"].message is scheduled[0]
     assert interaction.followup.sent[0]["view"].owner_id == interaction.user.id
     assert scheduled


### PR DESCRIPTION
## Summary

Reuse the transparent spacer-image trick (previously only in Blackjack) across the whole bot so every embed renders at Discord's maximum width. Embeds that already show a real image (leaderboard / stock board / 7D chart / threads photos) keep their image and are never overwritten by the spacer.

## Approach

- `utils/discord_embeds.py`: new `embed_spacer_payload(...)` returns the `files` (+ `attachments=[]` on edits) increment to merge into any send/edit; `apply_embed_spacer_image` now skips embeds that already carry an image.
- Call sites keep their own `embed=`/`embeds=`/`view=` shape and just merge the payload. Send paths never receive `attachments` (those methods reject it).
- Real-image uploads (stock board/chart PNG, threads videos) pass through `extra_files=` and merge with the spacer under a single `files=`.

## Progress

- [x] Core helper (`embed_spacer_payload`, skip-real-image)
- [x] Pattern A: games (blackjack / dragon_gate / lobby)
- [x] Pattern B: stock (`edit_stock_message`, market init)
- [x] Pattern C: economy / maplestory / template
- [x] Pattern D/E: gen_reply / threads / cli / help
- [x] Tests updated + added (coverage >= 80%)
- [x] `uv run pytest` + `uv run pre-commit run -a` green

## Test plan

- [x] `uv run pytest` — 488 passed, coverage gate 80% satisfied
- [x] `uv run pre-commit run -a` — ruff / mypy / codespell all pass
- [ ] Discord visual (manual, needs live bot): /help, /games, /stock, /balance, /leaderboard, /maplestory, threads link — widths aligned, real images intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
