### PR TITLE
fix(embeds): unify width on game lobby insufficient-balance reply

### DIFF
--- a/src/discordbot/cogs/games.py
+++ b/src/discordbot/cogs/games.py
@@ -229,8 +229,11 @@ class GamesCogs(commands.Cog):
             guild=getattr(interaction, "guild", None),
         )
         if result.participant is None:
+            embed = insufficient_embed_builder(result.balance)
             await interaction.followup.send(
-                embed=insufficient_embed_builder(result.balance), ephemeral=True
+                embed=embed,
+                ephemeral=True,
+                **embed_spacer_payload(embeds=[embed], is_edit=False, target=interaction),
             )
         return result.participant
 

--- a/tests/test_dragon_gate.py
+++ b/tests/test_dragon_gate.py
@@ -12,6 +12,7 @@ import pytest
 from nextcord import Embed
 from nextcord.ui import Button, StringSelect
 
+from discordbot.cogs.games import GamesCogs
 from discordbot.cogs._games import interactions as game_interactions
 from discordbot.typings.games import (
     Card,
@@ -634,6 +635,33 @@ async def test_dragon_gate_controls_hide_unavailable_actions() -> None:
     assert _component_ids(view=pair_view) == {"dg:bet", "dg:leave"}
     assert _component_rows(view=pair_view) == {"dg:leave": 0, "dg:bet": 2}
     assert _attached_select(view=pair_view, custom_id="dg:bet").disabled is False
+
+
+async def test_prepare_participant_insufficient_balance_applies_embed_spacer() -> None:
+    """Insufficient-balance lobby join reply carries the shared embed spacer."""
+    interaction = InteractionStub(user_id=7)
+
+    async def fake_participant_from_user(**_kwargs: Any) -> SimpleNamespace:  # noqa: ANN401 -- test double accepts heterogeneous kwargs
+        """Stands in for a balance check that rejects the wager."""
+        return SimpleNamespace(participant=None, balance=0)
+
+    stub_self = SimpleNamespace(_participant_from_user=fake_participant_from_user)
+
+    await GamesCogs._prepare_participant(
+        cast("Any", stub_self),
+        interaction=cast("Any", interaction),
+        wager=100,
+        mode="clamp",
+        insufficient_embed_builder=lambda balance: Embed(
+            title="餘額不足", description=str(balance)
+        ),
+    )
+
+    assert len(interaction.followup.sent) == 1
+    sent = interaction.followup.sent[0]
+    assert sent["ephemeral"] is True
+    assert sent["embed"].image.url == embed_spacer_url()
+    assert sent["files"][0].filename == DEFAULT_EMBED_SPACER_FILENAME
 
 
 async def test_dragon_gate_lobby_join_leave_and_owner_start(


### PR DESCRIPTION
## Summary

Closing out the embed-width unification started in #215. A full audit of every `Embed` send/edit site across the codebase found it already nearly complete: every site routes through `embed_spacer_payload(...)` directly or via a wrapper (`_blackjack_table_edit_kwargs`, `_dragon_gate_table_edit_kwargs`, `edit_stock_message`, maplestory `payload`), **except one**.

- Add the transparent spacer to the only embed send still missing it: the insufficient-balance ephemeral reply sent when a player presses a game lobby Join button (`GamesCogs._prepare_participant`). Without it, that embed rendered at the narrow text-content width instead of the unified maximum width used everywhere else.
- Add a regression test that drives the insufficient-balance branch and asserts the reply carries the spacer attachment.

### Audit notes (no change needed)

- **Max width:** Discord does not publish an exact pixel value; the desktop embed content container tops out around 520–600px and cannot be forced wider. The 640px spacer deliberately exceeds that so every plain embed saturates to the maximum width.
- **Real-image embeds stay uniform:** the Pillow PNGs already exceed the container cap and scale down to the same maximum width — leaderboard board (960px), stock market board (1120px), 7D chart (900px). The spacer helper correctly skips these.
- **Thumbnails** (avatars, MapleStory icons) sit in the corner and do not affect body width; those embeds still receive the spacer.

## Test plan

- [x] `uv run pytest` — 496 passed, coverage 83.06% (gate 80%)
- [x] `uv run pre-commit run -a` — ruff, format, mypy all green
- [x] New regression test fails on the pre-fix code and passes after the fix
- [ ] Manual: trigger a lobby Join with insufficient balance and confirm the ephemeral embed width matches other embeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)