### PR TITLE
refactor(gen_reply): extract message input and streaming helpers

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,7 +37,9 @@ nav:
                   - wagers: Reference/discordbot/cogs/_games/wagers.md
               - _gen_reply:
                   - exceptions: Reference/discordbot/cogs/_gen_reply/exceptions.md
+                  - input: Reference/discordbot/cogs/_gen_reply/input.md
                   - prompts: Reference/discordbot/cogs/_gen_reply/prompts.md
+                  - streaming: Reference/discordbot/cogs/_gen_reply/streaming.md
               - _maplestory:
                   - constants: Reference/discordbot/cogs/_maplestory/constants.md
                   - embeds: Reference/discordbot/cogs/_maplestory/embeds.md
@@ -72,11 +74,13 @@ nav:
               - stock: Reference/discordbot/typings/stock.md
           - utils:
               - avatars: Reference/discordbot/utils/avatars.md
+              - discord_embeds: Reference/discordbot/utils/discord_embeds.md
               - downloader: Reference/discordbot/utils/downloader.md
               - images: Reference/discordbot/utils/images.md
               - message_cleanup: Reference/discordbot/utils/message_cleanup.md
               - model_pricing: Reference/discordbot/utils/model_pricing.md
               - number_text: Reference/discordbot/utils/number_text.md
+              - reactions: Reference/discordbot/utils/reactions.md
               - stored_integer: Reference/discordbot/utils/stored_integer.md
               - threads: Reference/discordbot/utils/threads.md
           - cli: Reference/discordbot/cli.md

--- a/src/discordbot/cogs/_gen_reply/input.py
+++ b/src/discordbot/cogs/_gen_reply/input.py
@@ -1,0 +1,237 @@
+"""Builds Responses API input messages from Discord messages."""
+
+import re
+import base64
+from typing import Literal
+from mimetypes import guess_type
+
+import logfire
+from nextcord import Embed, Message, Attachment, StickerItem
+from pydantic import BaseModel, ConfigDict, SkipValidation
+from nextcord.ext import commands
+from openai.types.responses.response_input_param import EasyInputMessageParam
+from openai.types.responses.response_input_file_param import ResponseInputFileParam
+from openai.types.responses.response_input_text_param import ResponseInputTextParam
+from openai.types.responses.response_input_image_param import ResponseInputImageParam
+
+from discordbot.utils.images import get_image_data, convert_base64_to_data_uri
+from discordbot.typings.models import RuntimeModelCatalog
+from discordbot.utils.model_pricing import get_supported_modalities
+
+# Strips the usage_footer appended by `streaming.ResponseStreamer.stream` from
+# bot-authored messages before feeding them back as `role=assistant` history.
+# Without this, the model performs in-context learning on its own past footers
+# and starts hallucinating fake "-# model · ⬆ ... ⬇ ... · $... · ..." lines into
+# fresh replies. Anchored on the `\n\n-# ` separator plus the ⬆/⬇ token-count
+# icons, which never appear together in user-authored content.
+USAGE_FOOTER_RE = re.compile(r"\n\n-#[^\n]*⬆[^\n]*⬇[^\n]*$")
+
+
+class MessageInputBuilder(BaseModel):
+    """Converts Discord messages into Responses API input parts.
+
+    Attributes:
+        bot: The Discord bot instance, used to detect the bot's own messages.
+        runtime_models: Catalog whose slow model gates attachment modalities.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    bot: SkipValidation[commands.Bot]
+    runtime_models: RuntimeModelCatalog
+
+    async def get_user_prompt(self, content: str) -> str:
+        """Removes the bot mention from the content and strips whitespace."""
+        if self.bot.user:
+            content = content.replace(f"<@{self.bot.user.id}>", "")
+        return content.strip()
+
+    @staticmethod
+    def extract_embed_text(embeds: list[Embed]) -> str:
+        """Joins author / title / description / fields / footer text from embeds."""
+        embed_parts: list[str] = []
+        for embed in embeds:
+            parts: list[str] = []
+            if embed.author and embed.author.name:
+                parts.append(f"Author: {embed.author.name}")
+            if embed.title:
+                parts.append(f"Title: {embed.title}")
+            if embed.description:
+                parts.append(embed.description)
+            for field in embed.fields:
+                parts.append(f"{field.name}: {field.value}")
+            if embed.footer and embed.footer.text:
+                parts.append(f"Footer: {embed.footer.text}")
+            if parts:
+                embed_parts.append("\n".join(parts))
+        return "\n\n".join(embed_parts)
+
+    async def get_cleaned_content(self, message: Message) -> str:
+        """Returns the textual content of a message without the author prefix."""
+        content = await self.get_user_prompt(content=message.content)
+        if content and self.bot.user and message.author.id == self.bot.user.id:
+            content = USAGE_FOOTER_RE.sub("", content)
+        if not content and message.embeds:
+            content = self.extract_embed_text(embeds=list(message.embeds))
+        if not content and message.is_system():
+            content = message.system_content
+        return content
+
+    async def image_to_part(
+        self, source: Attachment | StickerItem | str
+    ) -> ResponseInputImageParam | None:
+        """Converts an image source to a content part for the API."""
+        try:
+            if isinstance(source, str):
+                b64_data = get_image_data(image_file=source)
+                data_uri = convert_base64_to_data_uri(base64_image=b64_data)
+                return ResponseInputImageParam(
+                    image_url=data_uri, detail="low", type="input_image"
+                )
+            if isinstance(source, Attachment):
+                content_type = source.content_type or guess_type(source.filename)[0] or "image/png"
+            else:
+                content_type = guess_type(source.url)[0] or "image/png"
+            file_bytes = await source.read()
+            b64_data = base64.b64encode(file_bytes).decode("utf-8")
+            data_uri = f"data:{content_type};base64,{b64_data}"
+            return ResponseInputImageParam(image_url=data_uri, detail="low", type="input_image")
+        except Exception:
+            logfire.warn("Failed to convert this image")
+            return None
+
+    async def attachment_to_part(self, attachment: Attachment) -> ResponseInputFileParam | None:
+        """Converts a file attachment to a content part for the API."""
+        try:
+            content_type = attachment.content_type or guess_type(attachment.filename)[0] or ""
+            file_bytes = await attachment.read()
+            b64_data = base64.b64encode(file_bytes).decode()
+            mime_type = content_type.split(";")[0].strip()
+            if not mime_type:
+                logfire.warn(
+                    f"Skipping attachment with unknown MIME type: {attachment.filename} ({attachment.url})"
+                )
+                return None
+            data_uri = f"data:{mime_type};base64,{b64_data}"
+            return ResponseInputFileParam(
+                filename=attachment.filename, file_data=data_uri, type="input_file"
+            )
+        except Exception:
+            logfire.warn(f"Failed to download this attachment: {attachment.url}")
+            return None
+
+    @staticmethod
+    def required_modality(content_type: str) -> Literal["image", "video", "audio", "unknown"]:
+        """Maps a MIME type to the input modality the model must accept.
+
+        Documents (PDF / Office / text / code) fall through to `image` as a
+        proxy: LiteLLM only reports text/image/audio/video, and image-capable
+        models in practice also accept `input_file`. Known binaries (archives,
+        executables, octet-stream) are checked first and return `unknown` so
+        they are dropped before reaching the API.
+        """
+        unsupported_binary_mimes = frozenset({
+            "application/octet-stream",
+            "application/zip",
+            "application/x-zip-compressed",
+            "application/x-rar-compressed",
+            "application/vnd.rar",
+            "application/x-7z-compressed",
+            "application/x-tar",
+            "application/gzip",
+            "application/x-gzip",
+            "application/x-bzip",
+            "application/x-bzip2",
+            "application/x-xz",
+            "application/java-archive",
+            "application/x-msdownload",
+            "application/x-dosexec",
+            "application/x-executable",
+            "application/x-mach-binary",
+            "application/x-sharedlib",
+            "application/wasm",
+        })
+        if content_type in unsupported_binary_mimes:
+            return "unknown"
+        if content_type.startswith("video/"):
+            return "video"
+        if content_type.startswith("audio/"):
+            return "audio"
+        if content_type.startswith("image/"):
+            return "image"
+        return "image"
+
+    async def get_attachment_parts(
+        self, message: Message
+    ) -> list[ResponseInputImageParam | ResponseInputFileParam]:
+        """Extracts attachment content parts from a message."""
+        slow_model = self.runtime_models.slow_model
+        modalities = get_supported_modalities(model_name=slow_model.name)
+        content_parts: list[ResponseInputImageParam | ResponseInputFileParam | None] = []
+
+        for attachment in message.attachments:
+            content_type = attachment.content_type or guess_type(attachment.filename)[0] or ""
+            required = self.required_modality(content_type=content_type)
+            if required in modalities:
+                if content_type.startswith("image/"):
+                    content_parts.append(await self.image_to_part(source=attachment))
+                else:
+                    content_parts.append(await self.attachment_to_part(attachment=attachment))
+            else:
+                logfire.warn(
+                    f"Skipping {required} attachment for {slow_model.name}: {attachment.filename}"
+                )
+
+        if "image" in modalities:
+            for sticker in message.stickers:
+                content_parts.append(await self.image_to_part(source=sticker))
+
+            # Prefer Discord's proxy_url (media.discordapp.net) over the original URL, since sources like Threads CDN expire and reject requests without specific headers.
+            for embed in message.embeds:
+                if embed.image and (url := embed.image.proxy_url or embed.image.url):
+                    content_parts.append(await self.image_to_part(source=url))
+                if embed.thumbnail and (url := embed.thumbnail.proxy_url or embed.thumbnail.url):
+                    content_parts.append(await self.image_to_part(source=url))
+
+        content_parts = [part for part in content_parts if part is not None]
+        return content_parts
+
+    async def process_single_message(self, message: Message) -> EasyInputMessageParam:
+        """Processes a single Discord message into a Responses API input message."""
+        try:
+            content = await self.get_cleaned_content(message=message)
+            attachment_parts = await self.get_attachment_parts(message=message)
+            is_bot = bool(self.bot.user and message.author.id == self.bot.user.id)
+
+            # Bot's own history without attachments → role=assistant carries identity,
+            # so the sender-prefix is dropped here. Without this, the model sees its
+            # own past replies prefixed with `Bot (bot) [id: ...]:` and learns to mimic
+            # that header, which leaks into output despite the prompt-level guard.
+            if is_bot and not attachment_parts:
+                return EasyInputMessageParam(role="assistant", content=content)
+
+            prefixed = (
+                f"{message.author.display_name} ({message.author.name}) "
+                f"[id: {message.author.id}]: {content}"
+            )
+
+            # No attachments → use EasyInputMessageParam's string-content shorthand.
+            # The SDK serializes it as `input_text` for role=user, which satisfies
+            # GPT-5.4's strict rule about content-part types per role.
+            if not attachment_parts:
+                return EasyInputMessageParam(role="user", content=prefixed)
+
+            # Has attachments → must use a content list with input_text/input_image.
+            # role=assistant cannot carry `input_image` (only output_text/refusal),
+            # so bot replies that include generated images (from _handle_image_reply)
+            # fall back to role=user; the author prefix above preserves bot identity.
+            return EasyInputMessageParam(
+                role="user",
+                content=[
+                    ResponseInputTextParam(text=prefixed, type="input_text"),
+                    *attachment_parts,
+                ],
+            )
+        except Exception:
+            logfire.warn(f"Failed to process message {message.id}", _exc_info=True)
+            return EasyInputMessageParam(role="user", content="")

--- a/src/discordbot/cogs/_gen_reply/streaming.py
+++ b/src/discordbot/cogs/_gen_reply/streaming.py
@@ -1,0 +1,161 @@
+"""Streams a Responses API reply onto a Discord message."""
+
+import re
+
+from openai import AsyncStream
+from nextcord import Message
+from pydantic import BaseModel, ConfigDict, SkipValidation
+from openai.types.responses import ResponseStreamEvent
+
+from discordbot.utils.avatars import guild_avatar_url
+from discordbot.utils.reactions import update_reaction
+from discordbot.utils.model_pricing import get_token_rates
+from discordbot.cogs._economy.database import credit_with_repayment
+from discordbot.cogs._economy.presentation import currency_text
+
+# Gemini occasionally wraps Discord mention syntax in backticks (inline code),
+# which stops Discord from rendering the actual mention. Strip those wrappers
+# before sending; matches user (<@id>, <@!id>), role (<@&id>) and channel (<#id>) mentions.
+CODED_MENTION_RE = re.compile(r"`(<(?:@[!&]?|#)\d+>)`")
+DISCORD_MESSAGE_LIMIT = 2000
+
+
+class ResponseStreamer(BaseModel):
+    """Renders a streaming Responses API reply onto the originating message.
+
+    Attributes:
+        message: The Discord message being answered and replied to.
+        responses: The streaming Responses API events to render.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    message: SkipValidation[Message]
+    responses: SkipValidation[AsyncStream[ResponseStreamEvent]]
+
+    @staticmethod
+    def _split_reply_for_discord(content: str, footer: str) -> tuple[str, list[str]]:
+        """Splits a completed reply into one parent message plus follow-up chunks."""
+        if len(f"{content}{footer}") <= DISCORD_MESSAGE_LIMIT:
+            return f"{content}{footer}", []
+
+        tail_capacity = DISCORD_MESSAGE_LIMIT - len(footer)
+        if tail_capacity <= 0:
+            raise ValueError("Usage footer is too long for Discord message content")
+
+        parent_content = content[:DISCORD_MESSAGE_LIMIT]
+        remaining = content[DISCORD_MESSAGE_LIMIT:]
+        follow_up_chunks: list[str] = []
+
+        while len(remaining) > DISCORD_MESSAGE_LIMIT:
+            follow_up_chunks.append(remaining[:DISCORD_MESSAGE_LIMIT])
+            remaining = remaining[DISCORD_MESSAGE_LIMIT:]
+
+        if len(remaining) <= tail_capacity:
+            follow_up_chunks.append(f"{remaining}{footer}")
+        else:
+            follow_up_chunks.append(remaining[:tail_capacity])
+            follow_up_chunks.append(f"{remaining[tail_capacity:]}{footer}")
+        return parent_content, follow_up_chunks
+
+    async def _write_preview(
+        self, reply: Message | None, content: str, displayed_content: str
+    ) -> tuple[Message | None, str]:
+        """Writes at most one Discord message worth of streaming preview text."""
+        preview = content[:DISCORD_MESSAGE_LIMIT]
+        if preview == displayed_content:
+            return reply, displayed_content
+        if reply is None:
+            reply = await self.message.reply(content=preview)
+        else:
+            await reply.edit(content=preview)
+        return reply, preview
+
+    async def _finalize(self, reply: Message | None, content: str, footer: str) -> Message:
+        """Writes the final reply, continuing overflow as follow-up replies in the same channel."""
+        parent_content, follow_up_chunks = self._split_reply_for_discord(
+            content=content, footer=footer
+        )
+        if reply is None:
+            reply = await self.message.reply(content=parent_content)
+        else:
+            await reply.edit(content=parent_content)
+        previous = reply
+        for chunk in follow_up_chunks:
+            previous = await previous.reply(content=chunk)
+        return reply
+
+    async def stream(self) -> str:  # noqa: C901 -- dispatches on multiple Responses API stream event types
+        """Renders the streamed reply and returns the full content with usage footer."""
+        stored_content = ""
+        counted_content = 0
+        reply: Message | None = None
+        displayed_content = ""
+        content_started = False
+        model_name = ""
+        input_tokens = 0
+        output_tokens = 0
+        used_web_search = False
+
+        async for response in self.responses:
+            if response.type == "response.completed":
+                model_name = response.response.model
+                if response.response.usage:
+                    input_tokens = response.response.usage.input_tokens
+                    output_tokens = response.response.usage.output_tokens
+            elif response.type in {
+                "response.web_search_call.in_progress",
+                "response.web_search_call.searching",
+                "response.web_search_call.completed",
+                "response.output_text.annotation.added",
+            }:
+                used_web_search = True
+            elif response.type == "response.output_text.delta":
+                delta = response.delta
+                if not content_started:
+                    delta = delta.lstrip("\n")
+                    if not delta:
+                        continue
+                    content_started = True
+                stored_content += delta
+                counted_content += len(delta)
+
+                if counted_content >= 30:
+                    reply, displayed_content = await self._write_preview(
+                        reply=reply, content=stored_content, displayed_content=displayed_content
+                    )
+                    counted_content = 0
+
+        input_rate, output_rate = get_token_rates(model_name=model_name)
+        cost = input_rate * input_tokens + output_rate * output_tokens
+
+        # Award chat points equal to total tokens used. We await this (rather than fire-and-forget)
+        # so the resulting balance can land in the footer.
+        # On DB failure, it returns None and the footer falls back to the delta-only format.
+        total_tokens = input_tokens + output_tokens
+        avatar_url = await guild_avatar_url(
+            user=self.message.author, guild=getattr(self.message, "guild", None)
+        )
+        result = await credit_with_repayment(
+            user_id=self.message.author.id,
+            name=self.message.author.name,
+            avatar_url=avatar_url,
+            amount=total_tokens,
+        )
+
+        stored_content = CODED_MENTION_RE.sub(r"\1", stored_content)
+        if result.new_balance is not None:
+            balance_text = f"{currency_text(amount=result.new_balance, compact=True)} ({currency_text(amount=total_tokens, signed=True, compact=True)})"
+        else:
+            balance_text = currency_text(amount=total_tokens, signed=True, compact=True)
+        # Footer format must stay matchable by `input.USAGE_FOOTER_RE`; the ⬆/⬇ icons are its anchor.
+        usage_footer = f"\n\n-# {model_name} · ⬆ {input_tokens:,} ⬇ {output_tokens:,} · ${cost:.8f} · {balance_text}"
+
+        # Final update to ensure complete message is displayed.
+        await self._finalize(reply=reply, content=stored_content, footer=usage_footer)
+        stored_content += usage_footer
+
+        if used_web_search:
+            await update_reaction(message=self.message, bot_user=None, emoji="🌐")
+
+        return stored_content

--- a/src/discordbot/cogs/gen_reply.py
+++ b/src/discordbot/cogs/gen_reply.py
@@ -1,57 +1,38 @@
 """Cog that routes Discord messages through the AI reply pipeline."""
 
 from io import BytesIO
-import re
 import base64
 from typing import TYPE_CHECKING, Literal, cast
 import asyncio
 from functools import cached_property
-from mimetypes import guess_type
 import contextlib
 
-from openai import AsyncOpenAI, AsyncStream
+from openai import AsyncOpenAI
 import logfire
-from nextcord import File, Embed, Message, Attachment, StickerItem
+from nextcord import File, Embed, Message
 from pydantic import ValidationError
 from nextcord.ext import commands
-from openai.types.responses import ResponseStreamEvent
 from openai.types.responses.response_input_param import ResponseInputParam, EasyInputMessageParam
-from openai.types.responses.response_input_file_param import ResponseInputFileParam
 from openai.types.responses.response_input_text_param import ResponseInputTextParam
 from openai.types.responses.response_input_image_param import ResponseInputImageParam
 
 from discordbot.typings.llm import LLMConfig
 from discordbot.utils.images import get_image_data, convert_base64_to_data_uri
-from discordbot.utils.avatars import guild_avatar_url
 from discordbot.typings.models import RouteDecision, RuntimeModelCatalog
-from discordbot.utils.model_pricing import get_token_rates, get_supported_modalities
+from discordbot.utils.reactions import update_reaction
 from discordbot.utils.discord_embeds import embed_spacer_payload
-from discordbot.cogs._economy.database import credit_with_repayment
+from discordbot.cogs._gen_reply.input import MessageInputBuilder
 from discordbot.cogs._gen_reply.prompts import (
     IMAGE_PROMPT,
     REPLY_PROMPT,
     ROUTE_PROMPT,
     SUMMARY_PROMPT,
 )
-from discordbot.cogs._economy.presentation import currency_text
+from discordbot.cogs._gen_reply.streaming import ResponseStreamer
 from discordbot.cogs._gen_reply.exceptions import extract_friendly_error
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable
-
-# Gemini occasionally wraps Discord mention syntax in backticks (inline code),
-# which stops Discord from rendering the actual mention. Strip those wrappers
-# before sending; matches user (<@id>, <@!id>), role (<@&id>) and channel (<#id>) mentions.
-_CODED_MENTION_RE = re.compile(r"`(<(?:@[!&]?|#)\d+>)`")
-
-# Strips the usage_footer appended by `_handle_streaming` from bot-authored
-# messages before feeding them back as `role=assistant` history. Without this,
-# the model performs in-context learning on its own past footers and starts
-# hallucinating fake "-# model · ⬆ ... ⬇ ... · $... · ..." lines into fresh
-# replies. Anchored on the `\n\n-# ` separator plus the ⬆/⬇ token-count icons,
-# which never appear together in user-authored content.
-_USAGE_FOOTER_RE = re.compile(r"\n\n-#[^\n]*⬆[^\n]*⬇[^\n]*$")
-_DISCORD_MESSAGE_LIMIT = 2000
 
 
 class ReplyGeneratorCogs(commands.Cog):
@@ -82,201 +63,14 @@ class ReplyGeneratorCogs(commands.Cog):
         client = AsyncOpenAI(base_url=self.config.base_url, api_key=self.config.api_key)
         return client
 
-    async def _get_user_prompt(self, content: str) -> str:
-        """Removes the bot mention from the content and strips whitespace."""
-        if self.bot.user:
-            content = content.replace(f"<@{self.bot.user.id}>", "")
-        return content.strip()
+    @cached_property
+    def input_builder(self) -> MessageInputBuilder:
+        """The cached Discord-message-to-Responses-API input builder.
 
-    @staticmethod
-    def _extract_embed_text(embeds: list[Embed]) -> str:
-        """Joins author / title / description / fields / footer text from embeds."""
-        embed_parts: list[str] = []
-        for embed in embeds:
-            parts: list[str] = []
-            if embed.author and embed.author.name:
-                parts.append(f"Author: {embed.author.name}")
-            if embed.title:
-                parts.append(f"Title: {embed.title}")
-            if embed.description:
-                parts.append(embed.description)
-            for field in embed.fields:
-                parts.append(f"{field.name}: {field.value}")
-            if embed.footer and embed.footer.text:
-                parts.append(f"Footer: {embed.footer.text}")
-            if parts:
-                embed_parts.append("\n".join(parts))
-        return "\n\n".join(embed_parts)
-
-    async def _get_cleaned_content(self, message: Message) -> str:
-        """Returns the textual content of a message without the author prefix."""
-        content = await self._get_user_prompt(content=message.content)
-        if content and self.bot.user and message.author.id == self.bot.user.id:
-            content = _USAGE_FOOTER_RE.sub("", content)
-        if not content and message.embeds:
-            content = self._extract_embed_text(embeds=list(message.embeds))
-        if not content and message.is_system():
-            content = message.system_content
-        return content
-
-    async def _image_to_part(
-        self, source: Attachment | StickerItem | str
-    ) -> ResponseInputImageParam | None:
-        """Converts an image source to a content part for the API."""
-        try:
-            if isinstance(source, str):
-                b64_data = get_image_data(image_file=source)
-                data_uri = convert_base64_to_data_uri(base64_image=b64_data)
-                return ResponseInputImageParam(
-                    image_url=data_uri, detail="low", type="input_image"
-                )
-            if isinstance(source, Attachment):
-                content_type = source.content_type or guess_type(source.filename)[0] or "image/png"
-            else:
-                content_type = guess_type(source.url)[0] or "image/png"
-            file_bytes = await source.read()
-            b64_data = base64.b64encode(file_bytes).decode("utf-8")
-            data_uri = f"data:{content_type};base64,{b64_data}"
-            return ResponseInputImageParam(image_url=data_uri, detail="low", type="input_image")
-        except Exception:
-            logfire.warn("Failed to convert this image")
-            return None
-
-    async def _attachment_to_part(self, attachment: Attachment) -> ResponseInputFileParam | None:
-        """Converts a file attachment to a content part for the API."""
-        try:
-            content_type = attachment.content_type or guess_type(attachment.filename)[0] or ""
-            file_bytes = await attachment.read()
-            b64_data = base64.b64encode(file_bytes).decode()
-            mime_type = content_type.split(";")[0].strip()
-            if not mime_type:
-                logfire.warn(
-                    f"Skipping attachment with unknown MIME type: {attachment.filename} ({attachment.url})"
-                )
-                return None
-            data_uri = f"data:{mime_type};base64,{b64_data}"
-            return ResponseInputFileParam(
-                filename=attachment.filename, file_data=data_uri, type="input_file"
-            )
-        except Exception:
-            logfire.warn(f"Failed to download this attachment: {attachment.url}")
-            return None
-
-    @staticmethod
-    def _required_modality(content_type: str) -> Literal["image", "video", "audio", "unknown"]:
-        """Maps a MIME type to the input modality the model must accept.
-
-        Documents (PDF / Office / text / code) fall through to `image` as a
-        proxy: LiteLLM only reports text/image/audio/video, and image-capable
-        models in practice also accept `input_file`. Known binaries (archives,
-        executables, octet-stream) are checked first and return `unknown` so
-        they are dropped before reaching the API.
+        Returns:
+            A builder bound to this bot and runtime model catalog.
         """
-        unsupported_binary_mimes = frozenset({
-            "application/octet-stream",
-            "application/zip",
-            "application/x-zip-compressed",
-            "application/x-rar-compressed",
-            "application/vnd.rar",
-            "application/x-7z-compressed",
-            "application/x-tar",
-            "application/gzip",
-            "application/x-gzip",
-            "application/x-bzip",
-            "application/x-bzip2",
-            "application/x-xz",
-            "application/java-archive",
-            "application/x-msdownload",
-            "application/x-dosexec",
-            "application/x-executable",
-            "application/x-mach-binary",
-            "application/x-sharedlib",
-            "application/wasm",
-        })
-        if content_type in unsupported_binary_mimes:
-            return "unknown"
-        if content_type.startswith("video/"):
-            return "video"
-        if content_type.startswith("audio/"):
-            return "audio"
-        if content_type.startswith("image/"):
-            return "image"
-        return "image"
-
-    async def _get_attachment_parts(
-        self, message: Message
-    ) -> list[ResponseInputImageParam | ResponseInputFileParam]:
-        """Extracts attachment content parts from a message."""
-        slow_model = self.runtime_models.slow_model
-        modalities = get_supported_modalities(model_name=slow_model.name)
-        content_parts: list[ResponseInputImageParam | ResponseInputFileParam | None] = []
-
-        for attachment in message.attachments:
-            content_type = attachment.content_type or guess_type(attachment.filename)[0] or ""
-            required = self._required_modality(content_type=content_type)
-            if required in modalities:
-                if content_type.startswith("image/"):
-                    content_parts.append(await self._image_to_part(source=attachment))
-                else:
-                    content_parts.append(await self._attachment_to_part(attachment=attachment))
-            else:
-                logfire.warn(
-                    f"Skipping {required} attachment for {slow_model.name}: {attachment.filename}"
-                )
-
-        if "image" in modalities:
-            for sticker in message.stickers:
-                content_parts.append(await self._image_to_part(source=sticker))
-
-            # Prefer Discord's proxy_url (media.discordapp.net) over the original URL, since sources like Threads CDN expire and reject requests without specific headers.
-            for embed in message.embeds:
-                if embed.image and (url := embed.image.proxy_url or embed.image.url):
-                    content_parts.append(await self._image_to_part(source=url))
-                if embed.thumbnail and (url := embed.thumbnail.proxy_url or embed.thumbnail.url):
-                    content_parts.append(await self._image_to_part(source=url))
-
-        content_parts = [part for part in content_parts if part is not None]
-        return content_parts
-
-    async def _process_single_message(self, message: Message) -> EasyInputMessageParam:
-        """Processes a single Discord message into a Responses API input message."""
-        try:
-            content = await self._get_cleaned_content(message=message)
-            attachment_parts = await self._get_attachment_parts(message=message)
-            is_bot = bool(self.bot.user and message.author.id == self.bot.user.id)
-
-            # Bot's own history without attachments → role=assistant carries identity,
-            # so the sender-prefix is dropped here. Without this, the model sees its
-            # own past replies prefixed with `Bot (bot) [id: ...]:` and learns to mimic
-            # that header, which leaks into output despite the prompt-level guard.
-            if is_bot and not attachment_parts:
-                return EasyInputMessageParam(role="assistant", content=content)
-
-            prefixed = (
-                f"{message.author.display_name} ({message.author.name}) "
-                f"[id: {message.author.id}]: {content}"
-            )
-
-            # No attachments → use EasyInputMessageParam's string-content shorthand.
-            # The SDK serializes it as `input_text` for role=user, which satisfies
-            # GPT-5.4's strict rule about content-part types per role.
-            if not attachment_parts:
-                return EasyInputMessageParam(role="user", content=prefixed)
-
-            # Has attachments → must use a content list with input_text/input_image.
-            # role=assistant cannot carry `input_image` (only output_text/refusal),
-            # so bot replies that include generated images (from _handle_image_reply)
-            # fall back to role=user; the author prefix above preserves bot identity.
-            return EasyInputMessageParam(
-                role="user",
-                content=[
-                    ResponseInputTextParam(text=prefixed, type="input_text"),
-                    *attachment_parts,
-                ],
-            )
-        except Exception:
-            logfire.warn(f"Failed to process message {message.id}", _exc_info=True)
-            return EasyInputMessageParam(role="user", content="")
+        return MessageInputBuilder(bot=self.bot, runtime_models=self.runtime_models)
 
     async def _get_history_message(
         self, message: Message, limit: int
@@ -290,7 +84,7 @@ class ReplyGeneratorCogs(commands.Cog):
         if hist_messages:
             tasks: list[Awaitable[EasyInputMessageParam]] = []
             for hist_msg in hist_messages:
-                task = self._process_single_message(message=hist_msg)
+                task = self.input_builder.process_single_message(message=hist_msg)
                 tasks.append(task)
             processed: list[EasyInputMessageParam] = await asyncio.gather(*tasks)
 
@@ -330,7 +124,7 @@ class ReplyGeneratorCogs(commands.Cog):
 
         tasks: list[Awaitable[EasyInputMessageParam]] = []
         for ref in chain:
-            task = self._process_single_message(message=ref)
+            task = self.input_builder.process_single_message(message=ref)
             tasks.append(task)
         processed: list[EasyInputMessageParam] = await asyncio.gather(*tasks)
 
@@ -367,7 +161,7 @@ class ReplyGeneratorCogs(commands.Cog):
                 ],
             )
         ]
-        current_msg = await self._process_single_message(message=message)
+        current_msg = await self.input_builder.process_single_message(message=message)
         messages.append(current_msg)
         return messages
 
@@ -397,12 +191,12 @@ class ReplyGeneratorCogs(commands.Cog):
         image_model = self.runtime_models.image_model
         if message.reference and isinstance(message.reference.resolved, Message):
             own_parts, ref_parts = await asyncio.gather(
-                self._get_attachment_parts(message=message),
-                self._get_attachment_parts(message=message.reference.resolved),
+                self.input_builder.get_attachment_parts(message=message),
+                self.input_builder.get_attachment_parts(message=message.reference.resolved),
             )
             attachment_parts = own_parts + ref_parts
         else:
-            attachment_parts = await self._get_attachment_parts(message=message)
+            attachment_parts = await self.input_builder.get_attachment_parts(message=message)
 
         data_uris: list[str] = []
         for part in attachment_parts:
@@ -471,17 +265,6 @@ class ReplyGeneratorCogs(commands.Cog):
         final_content = f"{message.author.mention} {image_description}"
         await message.reply(content=final_content, file=image_file)
 
-    async def _handle_reaction(
-        self, message: Message, emoji: str, previous: str | None = None
-    ) -> str:
-        """Handles adding and removing reactions on a message."""
-        if previous and self.bot.user:
-            with contextlib.suppress(Exception):
-                await message.remove_reaction(emoji=previous, member=self.bot.user)
-        with contextlib.suppress(Exception):
-            await message.add_reaction(emoji=emoji)
-        return emoji
-
     async def _route_message(self, message: Message) -> Literal["IMAGE", "QA", "SUMMARY", "VIDEO"]:
         """Routes the message to the appropriate handler."""
         message_list: list[EasyInputMessageParam] = []
@@ -514,141 +297,6 @@ class ReplyGeneratorCogs(commands.Cog):
             logfire.warn("RouteDecision parse failed, model returned no text; defaulting to QA")
             return "QA"
 
-    @staticmethod
-    def _split_reply_for_discord(content: str, footer: str) -> tuple[str, list[str]]:
-        """Splits a completed reply into one parent message plus follow-up chunks."""
-        if len(f"{content}{footer}") <= _DISCORD_MESSAGE_LIMIT:
-            return f"{content}{footer}", []
-
-        tail_capacity = _DISCORD_MESSAGE_LIMIT - len(footer)
-        if tail_capacity <= 0:
-            raise ValueError("Usage footer is too long for Discord message content")
-
-        parent_content = content[:_DISCORD_MESSAGE_LIMIT]
-        remaining = content[_DISCORD_MESSAGE_LIMIT:]
-        follow_up_chunks: list[str] = []
-
-        while len(remaining) > _DISCORD_MESSAGE_LIMIT:
-            follow_up_chunks.append(remaining[:_DISCORD_MESSAGE_LIMIT])
-            remaining = remaining[_DISCORD_MESSAGE_LIMIT:]
-
-        if len(remaining) <= tail_capacity:
-            follow_up_chunks.append(f"{remaining}{footer}")
-        else:
-            follow_up_chunks.append(remaining[:tail_capacity])
-            follow_up_chunks.append(f"{remaining[tail_capacity:]}{footer}")
-        return parent_content, follow_up_chunks
-
-    async def _write_streaming_preview(
-        self, message: Message, reply: Message | None, content: str, displayed_content: str
-    ) -> tuple[Message | None, str]:
-        """Writes at most one Discord message worth of streaming preview text."""
-        preview = content[:_DISCORD_MESSAGE_LIMIT]
-        if preview == displayed_content:
-            return reply, displayed_content
-        if reply is None:
-            reply = await message.reply(content=preview)
-        else:
-            await reply.edit(content=preview)
-        return reply, preview
-
-    async def _finalize_streaming_reply(
-        self, message: Message, reply: Message | None, content: str, footer: str
-    ) -> Message:
-        """Writes the final reply, continuing overflow as follow-up replies in the same channel."""
-        parent_content, follow_up_chunks = self._split_reply_for_discord(
-            content=content, footer=footer
-        )
-        if reply is None:
-            reply = await message.reply(content=parent_content)
-        else:
-            await reply.edit(content=parent_content)
-        previous = reply
-        for chunk in follow_up_chunks:
-            previous = await previous.reply(content=chunk)
-        return reply
-
-    async def _handle_streaming(  # noqa: C901 -- dispatches on multiple Responses API stream event types
-        self, responses: AsyncStream[ResponseStreamEvent], message: Message
-    ) -> str:
-        """Handles streaming responses from the API and updates the Discord message."""
-        stored_content = ""
-        counted_content = 0
-        reply: Message | None = None
-        displayed_content = ""
-        content_started = False
-        model_name = ""
-        input_tokens = 0
-        output_tokens = 0
-        used_web_search = False
-
-        async for response in responses:
-            if response.type == "response.completed":
-                model_name = response.response.model
-                if response.response.usage:
-                    input_tokens = response.response.usage.input_tokens
-                    output_tokens = response.response.usage.output_tokens
-            elif response.type in {
-                "response.web_search_call.in_progress",
-                "response.web_search_call.searching",
-                "response.web_search_call.completed",
-                "response.output_text.annotation.added",
-            }:
-                used_web_search = True
-            elif response.type == "response.output_text.delta":
-                delta = response.delta
-                if not content_started:
-                    delta = delta.lstrip("\n")
-                    if not delta:
-                        continue
-                    content_started = True
-                stored_content += delta
-                counted_content += len(delta)
-
-                if counted_content >= 30:
-                    reply, displayed_content = await self._write_streaming_preview(
-                        message=message,
-                        reply=reply,
-                        content=stored_content,
-                        displayed_content=displayed_content,
-                    )
-                    counted_content = 0
-
-        input_rate, output_rate = get_token_rates(model_name=model_name)
-        cost = input_rate * input_tokens + output_rate * output_tokens
-
-        # Award chat points equal to total tokens used. We await this (rather than fire-and-forget)
-        # so the resulting balance can land in the footer.
-        # On DB failure, it returns None and the footer falls back to the delta-only format.
-        total_tokens = input_tokens + output_tokens
-        avatar_url = await guild_avatar_url(
-            user=message.author, guild=getattr(message, "guild", None)
-        )
-        result = await credit_with_repayment(
-            user_id=message.author.id,
-            name=message.author.name,
-            avatar_url=avatar_url,
-            amount=total_tokens,
-        )
-
-        stored_content = _CODED_MENTION_RE.sub(r"\1", stored_content)
-        if result.new_balance is not None:
-            balance_text = f"{currency_text(amount=result.new_balance, compact=True)} ({currency_text(amount=total_tokens, signed=True, compact=True)})"
-        else:
-            balance_text = currency_text(amount=total_tokens, signed=True, compact=True)
-        usage_footer = f"\n\n-# {model_name} · ⬆ {input_tokens:,} ⬇ {output_tokens:,} · ${cost:.8f} · {balance_text}"
-
-        # Final update to ensure complete message is displayed.
-        await self._finalize_streaming_reply(
-            message=message, reply=reply, content=stored_content, footer=usage_footer
-        )
-        stored_content += usage_footer
-
-        if used_web_search:
-            await self._handle_reaction(message=message, emoji="🌐")
-
-        return stored_content
-
     async def _handle_message_reply(
         self, message: Message, system_prompt: str, history_limit: int
     ) -> None:
@@ -677,7 +325,7 @@ class ReplyGeneratorCogs(commands.Cog):
             extra_body={"mock_testing_fallbacks": False},
         )
 
-        await self._handle_streaming(responses=responses, message=message)
+        await ResponseStreamer(message=message, responses=responses).stream()
 
     @commands.Cog.listener()
     async def on_message(self, message: Message) -> None:
@@ -699,46 +347,50 @@ class ReplyGeneratorCogs(commands.Cog):
         if not is_dm and (not self.bot.user or f"<@{self.bot.user.id}>" not in message.content):
             return
 
-        user_prompt = await self._get_user_prompt(content=message.content)
+        user_prompt = await self.input_builder.get_user_prompt(content=message.content)
         has_attachment = bool(message.attachments or message.stickers)
 
         if not user_prompt and not has_attachment:
-            await self._handle_reaction(message=message, emoji="❓")
+            await update_reaction(message=message, bot_user=self.bot.user, emoji="❓")
             await message.reply(content="?")
             return
 
         try:
-            current_emoji = await self._handle_reaction(message=message, emoji="🔀")
+            current_emoji = await update_reaction(
+                message=message, bot_user=self.bot.user, emoji="🔀"
+            )
             route = await self._route_message(message=message)
             if route == "IMAGE":
-                current_emoji = await self._handle_reaction(
-                    message=message, emoji="🎨", previous=current_emoji
+                current_emoji = await update_reaction(
+                    message=message, bot_user=self.bot.user, emoji="🎨", previous=current_emoji
                 )
                 await self._handle_image_reply(message=message, user_prompt=user_prompt)
             elif route == "VIDEO":
-                current_emoji = await self._handle_reaction(
-                    message=message, emoji="🎬", previous=current_emoji
+                current_emoji = await update_reaction(
+                    message=message, bot_user=self.bot.user, emoji="🎬", previous=current_emoji
                 )
                 await self._handle_video_reply(message=message, user_prompt=user_prompt)
             elif route == "SUMMARY":
-                current_emoji = await self._handle_reaction(
-                    message=message, emoji="📖", previous=current_emoji
+                current_emoji = await update_reaction(
+                    message=message, bot_user=self.bot.user, emoji="📖", previous=current_emoji
                 )
                 await self._handle_message_reply(
                     message=message, system_prompt=SUMMARY_PROMPT, history_limit=50
                 )
             else:
-                current_emoji = await self._handle_reaction(
-                    message=message, emoji="❓", previous=current_emoji
+                current_emoji = await update_reaction(
+                    message=message, bot_user=self.bot.user, emoji="❓", previous=current_emoji
                 )
                 await self._handle_message_reply(
                     message=message, system_prompt=REPLY_PROMPT, history_limit=30
                 )
-            await self._handle_reaction(message=message, emoji="🆗", previous=current_emoji)
+            await update_reaction(
+                message=message, bot_user=self.bot.user, emoji="🆗", previous=current_emoji
+            )
         except Exception as e:
             logfire.error("Failed to generate reply", user_id=message.author.name, _exc_info=True)
             with contextlib.suppress(Exception):
-                await self._handle_reaction(message=message, emoji="❌")
+                await update_reaction(message=message, bot_user=self.bot.user, emoji="❌")
                 error_embed = Embed(
                     title="Something went wrong",
                     description=f"```\n{extract_friendly_error(exc=e)}\n```",

--- a/src/discordbot/cogs/parse_threads.py
+++ b/src/discordbot/cogs/parse_threads.py
@@ -9,6 +9,7 @@ from nextcord import File, Color, Embed, Message
 from nextcord.ext import commands
 
 from discordbot.utils.threads import ThreadsOutput, ThreadsDownloader
+from discordbot.utils.reactions import update_reaction
 from discordbot.utils.discord_embeds import embed_spacer_payload
 
 URL_REGEX = re.compile(r"https?://(?:www\.)?threads\.(?:net|com)/@[^/]+/post/[^\s\"'<>)]+")
@@ -33,17 +34,6 @@ class ThreadsCogs(commands.Cog):
         self.output_folder = Path("./data/downloads")
         self.output_folder.mkdir(parents=True, exist_ok=True)
         self.downloader = ThreadsDownloader(output_folder=str(self.output_folder))
-
-    async def _handle_reaction(
-        self, message: Message, emoji: str, previous_emoji: str | None = None
-    ) -> str:
-        """Handles adding and removing reactions on a message."""
-        if previous_emoji and self.bot.user:
-            with contextlib.suppress(Exception):
-                await message.remove_reaction(emoji=previous_emoji, member=self.bot.user)
-        with contextlib.suppress(Exception):
-            await message.add_reaction(emoji=emoji)
-        return emoji
 
     @staticmethod
     def _gradient_color(index: int, total: int) -> Color:
@@ -140,13 +130,13 @@ class ThreadsCogs(commands.Cog):
             return
 
         url = match.group(0)
-        current_emoji = await self._handle_reaction(message=message, emoji="🔗")
+        current_emoji = await update_reaction(message=message, bot_user=self.bot.user, emoji="🔗")
 
         try:
             with self.downloader.parse(url) as results:
                 if not results:
-                    await self._handle_reaction(
-                        message=message, emoji="⚠️", previous_emoji=current_emoji
+                    await update_reaction(
+                        message=message, bot_user=self.bot.user, emoji="⚠️", previous=current_emoji
                     )
                     return
 
@@ -164,8 +154,8 @@ class ThreadsCogs(commands.Cog):
                     or len(target.video_paths) + len(target.image_urls) > 10
                     or len(target.text) > 4096
                 ):
-                    await self._handle_reaction(
-                        message=message, emoji="⚠️", previous_emoji=current_emoji
+                    await update_reaction(
+                        message=message, bot_user=self.bot.user, emoji="⚠️", previous=current_emoji
                     )
                     return
 
@@ -187,14 +177,14 @@ class ThreadsCogs(commands.Cog):
                         embeds=embeds, is_edit=False, target=message, extra_files=files
                     ),
                 )
-                await self._handle_reaction(
-                    message=message, emoji="🆗", previous_emoji=current_emoji
+                await update_reaction(
+                    message=message, bot_user=self.bot.user, emoji="🆗", previous=current_emoji
                 )
         except Exception:
             logfire.error("Failed to send Threads message", _exc_info=True)
             with contextlib.suppress(Exception):
-                await self._handle_reaction(
-                    message=message, emoji="❌", previous_emoji=current_emoji
+                await update_reaction(
+                    message=message, bot_user=self.bot.user, emoji="❌", previous=current_emoji
                 )
 
 

--- a/src/discordbot/utils/reactions.py
+++ b/src/discordbot/utils/reactions.py
@@ -1,0 +1,30 @@
+"""Shared helper for status reactions on a Discord message."""
+
+import contextlib
+
+from nextcord import Message, ClientUser
+
+
+async def update_reaction(
+    message: Message, bot_user: ClientUser | None, emoji: str, previous: str | None = None
+) -> str:
+    """Adds a status reaction to a message, replacing the bot's previous one.
+
+    Both add and remove are best-effort; transient API failures are suppressed
+    so reaction bookkeeping never breaks the surrounding flow.
+
+    Args:
+        message: The message to react on.
+        bot_user: The bot's own user, used to scope the removal of `previous`.
+        emoji: The reaction to add.
+        previous: The bot's prior reaction to remove first, if any.
+
+    Returns:
+        The emoji that was added, so callers can track the current reaction.
+    """
+    if previous and bot_user:
+        with contextlib.suppress(Exception):
+            await message.remove_reaction(emoji=previous, member=bot_user)
+    with contextlib.suppress(Exception):
+        await message.add_reaction(emoji=emoji)
+    return emoji

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -12,8 +12,10 @@ from PIL import Image
 import pytest
 from nextcord import File, Embed
 
-from discordbot.cogs.gen_reply import _USAGE_FOOTER_RE, _DISCORD_MESSAGE_LIMIT, ReplyGeneratorCogs
+from discordbot.cogs.gen_reply import ReplyGeneratorCogs
 from discordbot.typings.models import ModelSettings, RouteDecision, RuntimeModelCatalog
+from discordbot.cogs._gen_reply.input import USAGE_FOOTER_RE
+from discordbot.cogs._gen_reply.streaming import DISCORD_MESSAGE_LIMIT, ResponseStreamer
 from discordbot.cogs._gen_reply.exceptions import extract_friendly_error
 
 TEST_LLM_MODEL = "test-llm-model"
@@ -314,10 +316,9 @@ async def test_handle_streaming_allows_missing_output_token_details(
 ) -> None:
     """Regression: LiteLLM may return usage with output_tokens_details=null."""
     del economy_isolated_db
-    cog = ReplyGeneratorCogs.__new__(ReplyGeneratorCogs)
     message = FakeMessage()
 
-    result = await cog._handle_streaming(responses=_stream_events(), message=message)
+    result = await ResponseStreamer(message=message, responses=_stream_events()).stream()
 
     expected = (
         f"hello from stream\n\n-# {TEST_LLM_MODEL} · ⬆ 12 ⬇ 34 · $0.00000000"
@@ -336,7 +337,8 @@ async def test_handle_streaming_continues_long_reply_as_reply_chain(
     message = FakeMessage(content="<@999> explain how long Discord replies are handled")
     body = "x" * 4500
 
-    result = await cog._handle_streaming(
+    result = await ResponseStreamer(
+        message=message,
         responses=_stream_events_from(
             events=[
                 SimpleNamespace(type="response.output_text.delta", delta=body),
@@ -349,8 +351,7 @@ async def test_handle_streaming_continues_long_reply_as_reply_chain(
                 ),
             ]
         ),
-        message=message,
-    )
+    ).stream()
 
     usage_footer = (
         f"\n\n-# {TEST_LLM_MODEL} · ⬆ 1 ⬇ 2 · $0.00000000 · 3 虛擬歡樂豆 (+3 虛擬歡樂豆)"
@@ -358,17 +359,17 @@ async def test_handle_streaming_continues_long_reply_as_reply_chain(
     assert result == f"{body}{usage_footer}"
 
     parent = message.replies[0]
-    assert parent.content == body[:_DISCORD_MESSAGE_LIMIT]
+    assert parent.content == body[:DISCORD_MESSAGE_LIMIT]
 
     first_follow_up = parent.replies[0]
-    assert first_follow_up.content == body[_DISCORD_MESSAGE_LIMIT : _DISCORD_MESSAGE_LIMIT * 2]
+    assert first_follow_up.content == body[DISCORD_MESSAGE_LIMIT : DISCORD_MESSAGE_LIMIT * 2]
 
     second_follow_up = first_follow_up.replies[0]
-    assert second_follow_up.content == f"{body[_DISCORD_MESSAGE_LIMIT * 2 :]}{usage_footer}"
+    assert second_follow_up.content == f"{body[DISCORD_MESSAGE_LIMIT * 2 :]}{usage_footer}"
     assert second_follow_up.replies == []
 
     chain_chunks = [parent.content, first_follow_up.content, second_follow_up.content]
-    assert all(len(chunk) <= _DISCORD_MESSAGE_LIMIT for chunk in chain_chunks)
+    assert all(len(chunk) <= DISCORD_MESSAGE_LIMIT for chunk in chain_chunks)
     assert cog.client.responses.create_models == []
 
 
@@ -377,10 +378,10 @@ async def test_handle_streaming_marks_web_search_from_call_event(
 ) -> None:
     """Verifies native web_search_call events trigger the web reaction."""
     del economy_isolated_db
-    cog = _cog()
     message = FakeMessage()
 
-    await cog._handle_streaming(
+    await ResponseStreamer(
+        message=message,
         responses=_stream_events_from(
             events=[
                 SimpleNamespace(type="response.output_text.delta", delta="answer"),
@@ -394,8 +395,7 @@ async def test_handle_streaming_marks_web_search_from_call_event(
                 ),
             ]
         ),
-        message=message,
-    )
+    ).stream()
 
     assert message.added_reactions == ["🌐"]
 
@@ -410,10 +410,10 @@ async def test_handle_streaming_marks_web_search_from_annotation(
     a search signal.
     """
     del economy_isolated_db
-    cog = _cog()
     message = FakeMessage()
 
-    await cog._handle_streaming(
+    await ResponseStreamer(
+        message=message,
         responses=_stream_events_from(
             events=[
                 SimpleNamespace(type="response.output_text.delta", delta="grounded answer"),
@@ -430,8 +430,7 @@ async def test_handle_streaming_marks_web_search_from_annotation(
                 ),
             ]
         ),
-        message=message,
-    )
+    ).stream()
 
     assert message.added_reactions == ["🌐"]
 
@@ -454,35 +453,35 @@ async def test_gen_reply_message_content_and_attachment_helpers(
     embed.add_field(name="Field", value="Value")
     embed.set_footer(text="Footer")
 
-    assert await cog._get_user_prompt(content="hi <@999>") == "hi"
-    assert "Author" in cog._extract_embed_text(embeds=[embed])
+    assert await cog.input_builder.get_user_prompt(content="hi <@999>") == "hi"
+    assert "Author" in cog.input_builder.extract_embed_text(embeds=[embed])
 
     bot_message = FakeMessage(
         content="answer\n\n-# model · ⬆ 1 ⬇ 2 · $0.0 · +3",
         author=FakeAuthor(bot=True, user_id=999),
     )
-    assert await cog._get_cleaned_content(message=bot_message) == "answer"
-    assert _USAGE_FOOTER_RE.search(string=bot_message.content)
+    assert await cog.input_builder.get_cleaned_content(message=bot_message) == "answer"
+    assert USAGE_FOOTER_RE.search(string=bot_message.content)
 
     embed_message = FakeMessage()
     embed_message.embeds = [embed]
-    assert "Title" in await cog._get_cleaned_content(message=embed_message)
+    assert "Title" in await cog.input_builder.get_cleaned_content(message=embed_message)
 
     system_message = FakeMessage()
     system_message.system_content = "joined"
-    assert await cog._get_cleaned_content(message=system_message) == "joined"
+    assert await cog.input_builder.get_cleaned_content(message=system_message) == "joined"
 
-    assert cog._required_modality(content_type="video/mp4") == "video"
-    assert cog._required_modality(content_type="audio/mpeg") == "audio"
-    assert cog._required_modality(content_type="application/pdf") == "image"
+    assert cog.input_builder.required_modality(content_type="video/mp4") == "video"
+    assert cog.input_builder.required_modality(content_type="audio/mpeg") == "audio"
+    assert cog.input_builder.required_modality(content_type="application/pdf") == "image"
 
-    file_part = await cog._attachment_to_part(
+    file_part = await cog.input_builder.attachment_to_part(
         attachment=FakeAttachment(filename="note.txt", content_type="text/plain", payload=b"abc")
     )
     assert file_part is not None
     assert file_part["file_data"] == "data:text/plain;base64,YWJj"
 
-    image_part = await cog._image_to_part(
+    image_part = await cog.input_builder.image_to_part(
         source=FakeAttachment(
             filename="pixel.png", content_type="image/png", payload=base64.b64decode(_png_b64())
         )
@@ -491,7 +490,7 @@ async def test_gen_reply_message_content_and_attachment_helpers(
     assert image_part["type"] == "input_image"
 
     monkeypatch.setattr(
-        "discordbot.cogs.gen_reply.get_supported_modalities", lambda model_name: {"image"}
+        "discordbot.cogs._gen_reply.input.get_supported_modalities", lambda model_name: {"image"}
     )
     message = FakeMessage()
     message.attachments = [
@@ -508,8 +507,10 @@ async def test_gen_reply_message_content_and_attachment_helpers(
     img_embed = Embed()
     img_embed.set_image(url="https://example.test/image.png")
     message.embeds = [img_embed]
-    monkeypatch.setattr("discordbot.cogs.gen_reply.get_image_data", lambda image_file: _png_b64())
-    parts = await cog._get_attachment_parts(message=message)
+    monkeypatch.setattr(
+        "discordbot.cogs._gen_reply.input.get_image_data", lambda image_file: _png_b64()
+    )
+    parts = await cog.input_builder.get_attachment_parts(message=message)
     assert [part["type"] for part in parts] == ["input_image", "input_image", "input_image"]
 
 
@@ -519,16 +520,17 @@ async def test_gen_reply_processes_history_reference_and_current_messages(
     """Verifies message processing for history, references, and current prompts."""
     cog = _cog()
     monkeypatch.setattr(
-        "discordbot.cogs.gen_reply.get_supported_modalities", lambda model_name: {"text", "image"}
+        "discordbot.cogs._gen_reply.input.get_supported_modalities",
+        lambda model_name: {"text", "image"},
     )
     bot_msg = FakeMessage(content="bot answer", author=FakeAuthor(bot=True, user_id=999))
     user_msg = FakeMessage(content="hello", author=FakeAuthor(user_id=1))
     with_attachment = FakeMessage(content="see file", author=FakeAuthor(user_id=2))
     with_attachment.attachments = [FakeAttachment(filename="note.txt", content_type="text/plain")]
 
-    bot_processed = await cog._process_single_message(message=bot_msg)
-    user_processed = await cog._process_single_message(message=user_msg)
-    attachment_processed = await cog._process_single_message(message=with_attachment)
+    bot_processed = await cog.input_builder.process_single_message(message=bot_msg)
+    user_processed = await cog.input_builder.process_single_message(message=user_msg)
+    attachment_processed = await cog.input_builder.process_single_message(message=with_attachment)
     assert bot_processed["role"] == "assistant"
     assert user_processed["role"] == "user"
     assert attachment_processed["role"] == "user"
@@ -579,13 +581,22 @@ async def test_gen_reply_routes_and_handlers_without_api(monkeypatch: pytest.Mon
     assert isinstance(message.replies[-1].content, str)
     assert message.replies[-1].content.startswith("<@1> caption")
 
-    async def fake_streaming(responses: SimpleNamespace, message: FakeMessage) -> str:
-        """Records the message passed to streaming."""
-        streamed.append(message)
-        return "done"
-
     streamed: list[FakeMessage] = []
-    monkeypatch.setattr(cog, "_handle_streaming", fake_streaming)
+
+    class FakeResponder:
+        """Records the message handed to the streaming responder."""
+
+        def __init__(self, message: FakeMessage, responses: SimpleNamespace) -> None:
+            """Stores the streaming inputs."""
+            self.message = message
+            self.responses = responses
+
+        async def stream(self) -> str:
+            """Records the message and returns placeholder content."""
+            streamed.append(self.message)
+            return "done"
+
+    monkeypatch.setattr("discordbot.cogs.gen_reply.ResponseStreamer", FakeResponder)
     await cog._handle_message_reply(message=message, system_prompt="system", history_limit=2)
     assert cog.client.responses.create_streams[-1] is True
     assert streamed[-1] is message
@@ -611,7 +622,9 @@ async def test_gen_reply_on_message_dispatches_routes(
         """Returns the parametrized route."""
         return route
 
-    async def fake_reaction(message: FakeMessage, emoji: str, previous: str | None = None) -> str:
+    async def fake_reaction(
+        message: FakeMessage, bot_user: object, emoji: str, previous: str | None = None
+    ) -> str:
         """Records reaction state transitions."""
         calls.append(f"reaction:{emoji}")
         return emoji
@@ -631,7 +644,7 @@ async def test_gen_reply_on_message_dispatches_routes(
         calls.append("_handle_message_reply")
 
     monkeypatch.setattr(cog, "_route_message", fake_route)
-    monkeypatch.setattr(cog, "_handle_reaction", fake_reaction)
+    monkeypatch.setattr("discordbot.cogs.gen_reply.update_reaction", fake_reaction)
     monkeypatch.setattr(cog, "_handle_image_reply", fake_image_handler)
     monkeypatch.setattr(cog, "_handle_video_reply", fake_video_handler)
     monkeypatch.setattr(cog, "_handle_message_reply", fake_message_handler)


### PR DESCRIPTION
## Summary

Splits the oversized `ReplyGeneratorCogs` (`cogs/gen_reply.py`) into focused, Pydantic-based service helpers so the cog keeps only routing, context assembly, and dispatch.

## Changes

- **New `cogs/_gen_reply/input.py` — `MessageInputBuilder`**: converts a Discord message into Responses API input (prompt cleanup, embed text, attachment/modality handling, single-message processing).
- **New `cogs/_gen_reply/streaming.py` — `ResponseStreamer`**: renders a streaming Responses API reply onto Discord (preview edits, overflow reply chain, usage footer, chat-reward credit).
- **New `utils/reactions.py` — `update_reaction(...)`**: shared status-reaction helper, replacing the duplicated `_handle_reaction` previously copy-pasted in both `gen_reply.py` and `parse_threads.py`.
- `gen_reply.py` keeps `_get_history/reference/current_message`, routing, image/video handlers, and `on_message` dispatch.
- Tests migrated to exercise the new helpers directly.

No user-visible behavior change; this is an internal refactor.

## Validation

- [x] `uv run pytest` — 503 passed, 80% coverage gate met
- [x] `uv run pre-commit run -a` — ruff and mypy clean
- [x] `make gen-docs` — reference nav regenerated

## Notes

Kept as **draft** on purpose: it will be flipped to ready-for-review only after GitHub Actions pass, so the automated review reads a green build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
