### PR TITLE
refactor(economy): split cog into _economy helper modules

### DIFF
--- a/src/discordbot/cogs/_economy/embeds.py
+++ b/src/discordbot/cogs/_economy/embeds.py
@@ -1,0 +1,772 @@
+"""Embed and text builders for economy command and view responses."""
+
+from nextcord import Embed
+from pydantic import BaseModel, ConfigDict
+
+from discordbot.typings.stock import StockPortfolioView, StockPortfolioHolding
+from discordbot.typings.economy import (
+    VIP_PURCHASE_COST,
+    LOAN_PROPOSAL_TIMEOUT_SECONDS,
+    CheckinResult,
+    PortfolioView,
+    TransferResult,
+    LeaderboardEntry,
+    LoanContractView,
+    CentralBankStatus,
+    LoanPaymentResult,
+    VipPurchaseResult,
+    CasinoLedgerSnapshot,
+    LossLeaderboardEntry,
+    BalanceAdjustmentResult,
+    LoanProposalAcceptResult,
+)
+from discordbot.utils.number_text import share_quantity_text
+from discordbot.cogs._stock.market import format_price
+from discordbot.cogs._economy.boards import (
+    LOSS_LEADERBOARD_BOARD_FILENAME,
+    BALANCE_LEADERBOARD_BOARD_FILENAME,
+)
+from discordbot.cogs._economy.database import (
+    checkin_reward,
+    apply_vip_blackjack_bonus,
+    monthly_rate_bps_to_percent,
+)
+from discordbot.cogs._economy.presentation import (
+    CURRENCY_NAME,
+    amount_code,
+    bold_currency,
+    currency_text,
+)
+
+BALANCE_COLOR = 0x57F287
+LEADERBOARD_COLOR = 0xFEE75C
+LOSS_LEADERBOARD_COLOR = 0xE67E22
+TRANSFER_COLOR = 0x5865F2
+ADMIN_COLOR = 0x3498DB
+CASINO_COLOR = 0xEB459E
+BORROW_COLOR = 0xF1C40F
+REPAY_COLOR = 0x2ECC71
+CENTRAL_BANK_COLOR = 0x1ABC9C
+CHECKIN_COLOR = 0x9B59B6
+VIP_COLOR = 0xF1C40F
+ERROR_COLOR = 0xED4245
+_STOCK_POSITION_LINE_LIMIT = 5
+_STOCK_POSITION_NAME_LIMIT = 20
+
+
+class TransferParticipant(BaseModel):
+    """Display identity for one side of a transfer embed."""
+
+    model_config = ConfigDict(frozen=True)
+
+    mention: str
+    display_name: str
+
+
+class LoanParty(BaseModel):
+    """Display identity for one side of a loan request embed."""
+
+    model_config = ConfigDict(frozen=True)
+
+    mention: str
+    display_name: str = ""
+    avatar_url: str = ""
+
+
+def _vip_perk_lines(checkin_streak: int = 1) -> str:
+    """Formats VIP perks with the base number and the boosted number."""
+    base_checkin = checkin_reward(streak=checkin_streak, is_vip=False)
+    vip_checkin = checkin_reward(streak=checkin_streak, is_vip=True)
+    sample_win = 10_000
+    boosted_win = apply_vip_blackjack_bonus(delta=sample_win, is_vip=True)
+    checkin_label = "簽到基礎" if checkin_streak == 1 else f"第 {checkin_streak} 天簽到"
+    return (
+        f"{checkin_label} {amount_code(amount=base_checkin, compact=True)} → "
+        f"{amount_code(amount=vip_checkin, compact=True)}\n"
+        f"Blackjack 贏局例 {amount_code(amount=sample_win, signed=True, compact=True)} → "
+        f"{amount_code(amount=boosted_win, signed=True, compact=True)}"
+    )
+
+
+def _set_optional_thumbnail(embed: Embed, avatar_url: str) -> None:
+    """Sets an embed thumbnail when an avatar URL is available."""
+    if avatar_url:
+        embed.set_thumbnail(url=avatar_url)
+
+
+def _stock_position_lines(stock_portfolio: StockPortfolioView) -> str:
+    """Formats stock holdings for the private balance embed."""
+    if not stock_portfolio.holdings:
+        return "目前沒有股票部位"
+    lines = [
+        _stock_position_line(holding=holding)
+        for holding in stock_portfolio.holdings[:_STOCK_POSITION_LINE_LIMIT]
+    ]
+    remaining = len(stock_portfolio.holdings) - _STOCK_POSITION_LINE_LIMIT
+    if remaining > 0:
+        lines.append(f"還有 `{remaining:,}` 檔未列出")
+    return "\n".join(lines)
+
+
+def _stock_position_line(holding: StockPortfolioHolding) -> str:
+    """Formats one stock holding into a compact balance line."""
+    position_parts: list[str] = []
+    if holding.long_shares > 0:
+        position_parts.append(
+            f"持股 `{share_quantity_text(shares=holding.long_shares)}` / 市值 "
+            f"{amount_code(amount=holding.long_market_value, compact=True)}"
+        )
+    if holding.short_shares > 0:
+        short_equity = (
+            holding.short_collateral + holding.short_entry_value - holding.short_cover_cost
+        )
+        position_parts.append(
+            f"做空 `{share_quantity_text(shares=holding.short_shares)}` / 淨值 "
+            f"{amount_code(amount=short_equity, compact=True)}"
+        )
+    position_text = " · ".join(position_parts) if position_parts else "無部位"
+    name = _stock_position_name(name=holding.name)
+    return (
+        f"`{holding.symbol}` {name} · 股價 `{format_price(price_cents=holding.price_cents)}` · "
+        f"{position_text} · 未實現 "
+        f"{amount_code(amount=holding.unrealized_pnl, signed=True, compact=True)}"
+    )
+
+
+def _stock_position_name(name: str) -> str:
+    """Keeps long company names from filling the stock field."""
+    if len(name) <= _STOCK_POSITION_NAME_LIMIT:
+        return name
+    return f"{name[:_STOCK_POSITION_NAME_LIMIT]}..."
+
+
+def _debt_summary_text(*, principal: int, interest: int) -> str:
+    """Formats outstanding loan principal and interest."""
+    if principal <= 0 and interest <= 0:
+        return "無未還債務"
+    return (
+        f"本金 {amount_code(amount=principal, compact=True)}\n"
+        f"利息 {amount_code(amount=interest, compact=True)}"
+    )
+
+
+def _vip_status_text(is_vip: bool) -> str:
+    """Formats VIP status for the private balance embed."""
+    if not is_vip:
+        return "一般會員"
+    return f"👑 VIP\n{_vip_perk_lines()}"
+
+
+def rate_text(monthly_rate_bps: int) -> str:
+    """Formats a monthly loan rate."""
+    return f"每月 {monthly_rate_bps_to_percent(monthly_rate_bps=monthly_rate_bps):g}%"
+
+
+def _loan_terms_text(amount: int, monthly_rate_bps: int) -> str:
+    """Formats the loan terms shown before acceptance."""
+    return (
+        f"本金 {amount_code(amount=amount, compact=True)}\n"
+        f"利率 `{rate_text(monthly_rate_bps=monthly_rate_bps)}`\n"
+        "利息採單利，依經過天數按比例計算\n"
+        "還款會先抵利息，再抵本金；貸方可催收"
+    )
+
+
+def payment_summary_text(  # noqa: PLR0913 -- summary needs all visible repayment fields
+    paid_amount: int,
+    interest_paid: int,
+    principal_paid: int,
+    remaining_principal: int,
+    remaining_interest: int,
+    borrower_balance: int,
+) -> str:
+    """Formats one repayment or collection result."""
+    return (
+        f"本次扣款 {amount_code(amount=paid_amount, compact=True)}\n"
+        f"償還利息 {amount_code(amount=interest_paid, compact=True)}\n"
+        f"償還本金 {amount_code(amount=principal_paid, compact=True)}\n"
+        f"剩餘本金 {amount_code(amount=remaining_principal, compact=True)}\n"
+        f"剩餘利息 {amount_code(amount=remaining_interest, compact=True)}\n"
+        f"借方餘額 {amount_code(amount=borrower_balance, compact=True)}"
+    )
+
+
+def _credit_request_footer() -> str:
+    """Formats the personal credit request button hint."""
+    return (
+        f"貸方可用下方按鈕批准或拒絕，發起者可取消，{LOAN_PROPOSAL_TIMEOUT_SECONDS} 秒後自動拒絕"
+    )
+
+
+def _central_bank_request_footer() -> str:
+    """Formats the central-bank request button hint."""
+    return f"央行成員可用下方按鈕批准或拒絕，發起者可取消，{LOAN_PROPOSAL_TIMEOUT_SECONDS} 秒後自動拒絕"
+
+
+def build_error_embed(
+    *,
+    title: str,
+    description: str,
+    author_name: str | None = None,
+    author_icon_url: str | None = None,
+    thumbnail_url: str | None = None,
+) -> Embed:
+    """Builds a red error embed with optional author and thumbnail.
+
+    The `description` is used verbatim, including any leading Markdown heading.
+    """
+    embed = Embed(title=title, description=description, color=ERROR_COLOR)
+    if author_name is not None:
+        embed.set_author(name=author_name, icon_url=author_icon_url)
+    if thumbnail_url is not None:
+        _set_optional_thumbnail(embed=embed, avatar_url=thumbnail_url)
+    return embed
+
+
+def build_simple_embed(  # noqa: PLR0913 -- generic single-section embed exposes each optional slot
+    *,
+    title: str,
+    description: str,
+    color: int,
+    author_name: str | None = None,
+    author_icon_url: str | None = None,
+    thumbnail_url: str | None = None,
+    footer_text: str | None = None,
+) -> Embed:
+    """Builds a single-section embed with optional author, thumbnail, and footer."""
+    embed = Embed(title=title, description=description, color=color)
+    if author_name is not None:
+        embed.set_author(name=author_name, icon_url=author_icon_url)
+    if thumbnail_url is not None:
+        _set_optional_thumbnail(embed=embed, avatar_url=thumbnail_url)
+    if footer_text is not None:
+        embed.set_footer(text=footer_text)
+    return embed
+
+
+def build_invalid_admin_amount_embed(*, title: str) -> Embed:
+    """Builds the validation embed for malformed admin adjustment amounts."""
+    return Embed(
+        title=title,
+        description="### 金額格式錯誤\n請輸入正整數，可以加逗號，例如 `1,000`。",
+        color=ERROR_COLOR,
+    )
+
+
+def build_admin_adjustment_embed(  # noqa: PLR0913 -- mirrors every visible adjustment field
+    *,
+    title: str,
+    member_mention: str,
+    actor_name: str,
+    actor_avatar_url: str,
+    member_avatar_url: str,
+    requested_delta: int,
+    result: BalanceAdjustmentResult,
+    is_collect_clamped: bool,
+) -> Embed:
+    """Builds the public result embed for an admin balance adjustment."""
+    embed = Embed(
+        title=title,
+        description=(
+            f"### {member_mention}\n"
+            f"{currency_text(amount=result.applied_delta, signed=True, compact=True)}"
+        ),
+        color=ADMIN_COLOR,
+    )
+    embed.set_author(name=actor_name, icon_url=actor_avatar_url)
+    _set_optional_thumbnail(embed=embed, avatar_url=member_avatar_url)
+    embed.add_field(
+        name="操作結果",
+        value=(
+            f"申請 {amount_code(amount=requested_delta, signed=True, compact=True)}\n"
+            f"實際 {amount_code(amount=result.applied_delta, signed=True, compact=True)}\n"
+            f"餘額 {amount_code(amount=result.new_balance, compact=True)}"
+        ),
+        inline=False,
+    )
+    if is_collect_clamped:
+        embed.set_footer(text="收稅最多扣到餘額 0")
+    return embed
+
+
+def build_balance_embed(  # noqa: PLR0913 -- mirrors every financial-overview field
+    *,
+    display_name: str,
+    avatar_url: str,
+    portfolio: PortfolioView,
+    stock_portfolio: StockPortfolioView,
+    is_vip: bool,
+    age_days: int,
+) -> Embed:
+    """Builds the private financial-overview embed for a member."""
+    net_worth = portfolio.net_worth + stock_portfolio.equity_value
+    embed = Embed(
+        title="💰 財務總覽",
+        color=BALANCE_COLOR,
+        description=(f"## {display_name}\n淨資產 {bold_currency(amount=net_worth, compact=True)}"),
+    )
+    embed.set_author(name=f"{display_name} 的財務總覽", icon_url=avatar_url)
+    _set_optional_thumbnail(embed=embed, avatar_url=avatar_url)
+    embed.add_field(
+        name="現金", value=amount_code(amount=portfolio.balance, compact=True), inline=True
+    )
+    embed.add_field(
+        name="股票淨值",
+        value=(
+            f"估值 {amount_code(amount=stock_portfolio.equity_value, compact=True)}\n"
+            f"未實現 "
+            f"{amount_code(amount=stock_portfolio.unrealized_pnl, signed=True, compact=True)}\n"
+            f"已實現 "
+            f"{amount_code(amount=stock_portfolio.realized_pnl, signed=True, compact=True)}"
+        ),
+        inline=True,
+    )
+    embed.add_field(
+        name="債務",
+        value=_debt_summary_text(
+            principal=portfolio.debt_principal, interest=portfolio.debt_interest
+        ),
+        inline=True,
+    )
+    embed.add_field(
+        name="股票部位", value=_stock_position_lines(stock_portfolio=stock_portfolio), inline=False
+    )
+    embed.add_field(name="會員狀態", value=_vip_status_text(is_vip=is_vip), inline=False)
+    vip_badge = " · 👑 VIP" if is_vip else ""
+    embed.set_footer(text=f"帳號 {age_days} 天{vip_badge}")
+    return embed
+
+
+def build_leaderboard_embed(*, champion: LeaderboardEntry) -> Embed:
+    """Builds the public balance leaderboard embed referencing its board image."""
+    embed = Embed(
+        title=f"🏆 {CURRENCY_NAME} Top 10",
+        description="### 公開排行榜\n依可用餘額排序。",
+        color=LEADERBOARD_COLOR,
+    )
+    embed.set_author(name="目前第一名", icon_url=champion.avatar_url or None)
+    _set_optional_thumbnail(embed=embed, avatar_url=champion.avatar_url)
+    embed.set_image(url=f"attachment://{BALANCE_LEADERBOARD_BOARD_FILENAME}")
+    return embed
+
+
+def build_loss_leaderboard_embed(*, champion: LossLeaderboardEntry) -> Embed:
+    """Builds the public daily loss leaderboard embed referencing its board image."""
+    embed = Embed(
+        title=f"💸 今日輸局累計 {CURRENCY_NAME}",
+        description="### 今日累計輸排序\n以 gross loss 排名，贏回來不抵扣。",
+        color=LOSS_LEADERBOARD_COLOR,
+    )
+    embed.set_author(name="今日累計輸最多", icon_url=champion.avatar_url or None)
+    _set_optional_thumbnail(embed=embed, avatar_url=champion.avatar_url)
+    embed.set_image(url=f"attachment://{LOSS_LEADERBOARD_BOARD_FILENAME}")
+    embed.set_footer(text="今日實際輸掉累計 | 贏回來不抵扣 | 每天 0:00 (Asia/Taipei) 重置")
+    return embed
+
+
+def build_transfer_embed(  # noqa: PLR0913 -- mirrors both transfer sides and balances
+    *,
+    amount: int,
+    sender: TransferParticipant,
+    sender_avatar_url: str,
+    receiver: TransferParticipant,
+    receiver_avatar_url: str,
+    result: TransferResult,
+) -> Embed:
+    """Builds the public transfer-completed embed."""
+    embed = Embed(
+        title="💸 轉帳完成",
+        description=(
+            f"### {currency_text(amount=amount, compact=True)}\n"
+            f"{sender.mention} → {receiver.mention}"
+        ),
+        color=TRANSFER_COLOR,
+    )
+    embed.set_author(name=sender.display_name, icon_url=sender_avatar_url)
+    _set_optional_thumbnail(embed=embed, avatar_url=receiver_avatar_url)
+    embed.add_field(
+        name="轉帳後餘額",
+        value=(
+            f"**{sender.display_name}** "
+            f"{amount_code(amount=result.sender_balance, compact=True)}\n"
+            f"**{receiver.display_name}** "
+            f"{amount_code(amount=result.receiver_balance, compact=True)}"
+        ),
+        inline=False,
+    )
+    return embed
+
+
+def build_transfer_insufficient_embed(
+    *, sender_name: str, sender_avatar_url: str, balance_now: int, amount: int
+) -> Embed:
+    """Builds the transfer failure embed for an insufficient sender balance."""
+    return build_error_embed(
+        title="轉帳失敗",
+        description=(
+            f"### 餘額不足\n"
+            f"目前 {bold_currency(amount=balance_now, compact=True)}\n"
+            f"想轉 {bold_currency(amount=amount, compact=True)}"
+        ),
+        author_name=sender_name,
+        author_icon_url=sender_avatar_url,
+    )
+
+
+def build_casino_embed(*, snapshot: CasinoLedgerSnapshot) -> Embed:
+    """Builds the casino system cumulative P&L embed."""
+    balance = snapshot.balance
+    if balance > 0:
+        verdict = rf"\+ {bold_currency(amount=balance, compact=True)}"
+        color = BALANCE_COLOR
+    elif balance < 0:
+        verdict = rf"\- {bold_currency(amount=abs(balance), compact=True)}"
+        color = ERROR_COLOR
+    else:
+        verdict = "⚖️ 打平"
+        color = CASINO_COLOR
+    embed = Embed(title="🎰 賭場戰績", description=f"## {verdict}", color=color)
+    embed.set_author(name="賭場系統")
+    embed.add_field(
+        name="流水",
+        value=(
+            f"贏到 {amount_code(amount=snapshot.total_earned, compact=True)}\n"
+            f"賠出 {amount_code(amount=snapshot.total_spent, compact=True)}"
+        ),
+        inline=False,
+    )
+    embed.set_footer(text="跨伺服器累積 | 賭場資金無上限")
+    return embed
+
+
+def build_pocat_embed(
+    *, name: str, avatar_url: str, balance: int, total_earned: int, total_spent: int
+) -> Embed:
+    """Builds the bot player's own wallet embed."""
+    if balance > 0:
+        verdict = rf"{bold_currency(amount=balance, compact=True)}"
+        color = BALANCE_COLOR
+    elif balance < 0:
+        verdict = rf"\- {bold_currency(amount=abs(balance), compact=True)}"
+        color = ERROR_COLOR
+    else:
+        verdict = "餘額 0"
+        color = CASINO_COLOR
+    embed = Embed(title="🐱 破貓戰績", description=f"## {verdict}", color=color)
+    embed.set_author(name=name, icon_url=avatar_url)
+    _set_optional_thumbnail(embed=embed, avatar_url=avatar_url)
+    embed.add_field(
+        name="流水",
+        value=(
+            f"贏到 {amount_code(amount=total_earned, compact=True)}\n"
+            f"賠出 {amount_code(amount=total_spent, compact=True)}"
+        ),
+        inline=False,
+    )
+    embed.set_footer(text="bot 玩家錢包")
+    return embed
+
+
+def build_credit_request_embed(
+    *, borrower: LoanParty, lender: LoanParty, amount: int, monthly_rate_bps: int
+) -> Embed:
+    """Builds the public personal credit request embed."""
+    embed = Embed(
+        title="💴 信貸申請已建立",
+        description=(
+            f"### {borrower.mention} → {lender.mention}\n"
+            f"{currency_text(amount=amount, compact=True)}"
+        ),
+        color=BORROW_COLOR,
+    )
+    embed.set_author(name=borrower.display_name, icon_url=borrower.avatar_url)
+    _set_optional_thumbnail(embed=embed, avatar_url=lender.avatar_url)
+    embed.add_field(
+        name="條款",
+        value=_loan_terms_text(amount=amount, monthly_rate_bps=monthly_rate_bps),
+        inline=False,
+    )
+    embed.set_footer(text=_credit_request_footer())
+    return embed
+
+
+def build_central_bank_request_embed(
+    *, borrower: LoanParty, amount: int, monthly_rate_bps: int
+) -> Embed:
+    """Builds the public central-bank loan request embed."""
+    embed = Embed(
+        title="🏛️ 央行借款申請已建立",
+        description=f"### {borrower.mention}\n{currency_text(amount=amount, compact=True)}",
+        color=CENTRAL_BANK_COLOR,
+    )
+    embed.set_author(name=borrower.display_name, icon_url=borrower.avatar_url)
+    embed.add_field(
+        name="條款",
+        value=_loan_terms_text(amount=amount, monthly_rate_bps=monthly_rate_bps),
+        inline=False,
+    )
+    embed.set_footer(text=_central_bank_request_footer())
+    return embed
+
+
+def build_credit_repay_embed(
+    *, actor_name: str, actor_avatar_url: str, lender_display_name: str, result: LoanPaymentResult
+) -> Embed:
+    """Builds the personal credit repayment result embed."""
+    embed = Embed(
+        title="🧾 信貸還款完成",
+        description=(
+            f"### {currency_text(amount=-result.paid_amount, signed=True, compact=True)} 扣款"
+        ),
+        color=REPAY_COLOR,
+    )
+    embed.set_author(name=actor_name, icon_url=actor_avatar_url)
+    _set_optional_thumbnail(embed=embed, avatar_url=actor_avatar_url)
+    embed.add_field(
+        name=f"還給 {lender_display_name}",
+        value=payment_summary_text(
+            paid_amount=result.paid_amount,
+            interest_paid=result.interest_paid,
+            principal_paid=result.principal_paid,
+            remaining_principal=result.remaining_principal,
+            remaining_interest=result.remaining_interest,
+            borrower_balance=result.borrower_balance,
+        ),
+        inline=False,
+    )
+    return embed
+
+
+def build_credit_call_embed(
+    *, actor_name: str, actor_avatar_url: str, borrower_mention: str, result: LoanPaymentResult
+) -> Embed:
+    """Builds the personal credit forced-collection result embed."""
+    embed = Embed(
+        title="📣 信貸催收完成",
+        description=(
+            f"### 從 {borrower_mention} 回收 "
+            f"{currency_text(amount=result.paid_amount, compact=True)}"
+        ),
+        color=REPAY_COLOR,
+    )
+    embed.set_author(name=actor_name, icon_url=actor_avatar_url)
+    embed.add_field(
+        name="回收明細",
+        value=payment_summary_text(
+            paid_amount=result.paid_amount,
+            interest_paid=result.interest_paid,
+            principal_paid=result.principal_paid,
+            remaining_principal=result.remaining_principal,
+            remaining_interest=result.remaining_interest,
+            borrower_balance=result.borrower_balance,
+        ),
+        inline=False,
+    )
+    return embed
+
+
+def build_credit_status_embed(*, contracts: list[LoanContractView], viewer_id: int) -> Embed:
+    """Builds the caller's active personal credit contracts embed."""
+    lines = [
+        (
+            f"{'欠 ' + contract.lender_name if contract.borrower_id == viewer_id else contract.borrower_name + ' 欠你'} "
+            f"本金 {amount_code(amount=contract.principal_remaining, compact=True)} · "
+            f"利息 {amount_code(amount=contract.interest_due, compact=True)} · "
+            f"{rate_text(monthly_rate_bps=contract.monthly_rate_bps)}"
+        )
+        for contract in contracts[:10]
+    ]
+    return Embed(title="信貸狀態", description="\n".join(lines), color=BORROW_COLOR)
+
+
+def build_central_bank_repay_embed(
+    *, actor_name: str, actor_avatar_url: str, user_mention: str, result: LoanPaymentResult
+) -> Embed:
+    """Builds the central-bank repayment result embed."""
+    embed = Embed(
+        title="🏛️ 央行還款完成",
+        description=(
+            f"### {user_mention}\n"
+            + payment_summary_text(
+                paid_amount=result.paid_amount,
+                interest_paid=result.interest_paid,
+                principal_paid=result.principal_paid,
+                remaining_principal=result.remaining_principal,
+                remaining_interest=result.remaining_interest,
+                borrower_balance=result.borrower_balance,
+            )
+        ),
+        color=CENTRAL_BANK_COLOR,
+    )
+    embed.set_author(name=actor_name, icon_url=actor_avatar_url)
+    _set_optional_thumbnail(embed=embed, avatar_url=actor_avatar_url)
+    return embed
+
+
+def build_central_bank_call_embed(
+    *,
+    actor_name: str,
+    actor_avatar_url: str,
+    borrower_mention: str,
+    borrower_avatar_url: str,
+    result: LoanPaymentResult,
+) -> Embed:
+    """Builds the central-bank forced-collection result embed."""
+    embed = Embed(
+        title="🏛️ 央行催收完成",
+        description=(
+            f"### 從 {borrower_mention} 回收\n"
+            + payment_summary_text(
+                paid_amount=result.paid_amount,
+                interest_paid=result.interest_paid,
+                principal_paid=result.principal_paid,
+                remaining_principal=result.remaining_principal,
+                remaining_interest=result.remaining_interest,
+                borrower_balance=result.borrower_balance,
+            )
+        ),
+        color=CENTRAL_BANK_COLOR,
+    )
+    embed.set_author(name=actor_name, icon_url=actor_avatar_url)
+    _set_optional_thumbnail(embed=embed, avatar_url=borrower_avatar_url)
+    return embed
+
+
+def build_central_bank_status_embed(*, status: CentralBankStatus) -> Embed:
+    """Builds the central bank lending-capacity embed."""
+    embed = Embed(
+        title="🏛️ 中央銀行狀態",
+        description=f"## 可放貸 {bold_currency(amount=status.available_credit, compact=True)}",
+        color=CENTRAL_BANK_COLOR,
+    )
+    embed.add_field(
+        name="資金池",
+        value=(
+            f"全體正餘額 "
+            f"{amount_code(amount=status.total_positive_user_balance, compact=True)}\n"
+            f"未還本金 {amount_code(amount=status.outstanding_principal, compact=True)}"
+        ),
+        inline=False,
+    )
+    return embed
+
+
+def build_checkin_embed(*, actor_name: str, avatar_url: str, result: CheckinResult) -> Embed:
+    """Builds the daily check-in result embed."""
+    vip_badge = " · 👑 VIP 2x" if result.is_vip else ""
+    embed = Embed(
+        title="📅 每日簽到",
+        description=f"## {currency_text(amount=result.amount, signed=True, compact=True)} 入帳",
+        color=CHECKIN_COLOR,
+    )
+    embed.set_author(name=f"{actor_name} 的簽到", icon_url=avatar_url)
+    _set_optional_thumbnail(embed=embed, avatar_url=avatar_url)
+    embed.add_field(name="連續簽到", value=f"第 {result.streak} / 7 天", inline=True)
+    embed.add_field(
+        name="目前餘額", value=amount_code(amount=result.new_balance, compact=True), inline=True
+    )
+    if result.is_vip:
+        base_reward = checkin_reward(streak=result.streak, is_vip=False)
+        embed.add_field(
+            name="👑 VIP加成",
+            value=(
+                f"本日簽到 {amount_code(amount=base_reward, compact=True)} → "
+                f"{amount_code(amount=result.amount, compact=True)}"
+            ),
+            inline=False,
+        )
+    embed.set_footer(text=f"連續 7 天為一個 cycle | 每天 0:00 (Asia/Taipei) 重置{vip_badge}")
+    return embed
+
+
+def build_vip_already_embed(*, actor_name: str, avatar_url: str) -> Embed:
+    """Builds the embed shown when a member already owns VIP."""
+    embed = Embed(
+        title="已經是 VIP", description="### 你已經擁有永久 VIP 了, 不用再買一次", color=VIP_COLOR
+    )
+    embed.set_author(name=actor_name, icon_url=avatar_url)
+    embed.add_field(name="👑 VIP加成", value=_vip_perk_lines(), inline=False)
+    return embed
+
+
+def build_vip_insufficient_embed(*, actor_name: str, avatar_url: str, balance_now: int) -> Embed:
+    """Builds the VIP purchase failure embed for an insufficient balance."""
+    embed = Embed(
+        title="VIP 購買失敗",
+        description=(
+            f"### 餘額不足\n"
+            f"目前 {bold_currency(amount=balance_now, compact=True)}\n"
+            f"需要 {bold_currency(amount=VIP_PURCHASE_COST, compact=True)}"
+        ),
+        color=ERROR_COLOR,
+    )
+    embed.set_author(name=actor_name, icon_url=avatar_url)
+    embed.add_field(name="👑 VIP權益", value=_vip_perk_lines(), inline=False)
+    return embed
+
+
+def build_vip_success_embed(
+    *, actor_name: str, avatar_url: str, result: VipPurchaseResult
+) -> Embed:
+    """Builds the VIP purchase success embed."""
+    embed = Embed(
+        title="👑 升級 VIP 成功",
+        description=(
+            f"### {currency_text(amount=-result.cost, signed=True, compact=True)} 扣款\n"
+            "簽到與 Blackjack 贏局加成已生效"
+        ),
+        color=VIP_COLOR,
+    )
+    embed.set_author(name=actor_name, icon_url=avatar_url)
+    _set_optional_thumbnail(embed=embed, avatar_url=avatar_url)
+    embed.add_field(name="👑 VIP加成", value=_vip_perk_lines(), inline=False)
+    embed.add_field(
+        name="目前餘額", value=amount_code(amount=result.new_balance, compact=True), inline=False
+    )
+    return embed
+
+
+def build_credit_approved_embed(
+    *, result: LoanProposalAcceptResult, approver_mention: str, lender_avatar_url: str
+) -> Embed:
+    """Builds the personal credit approval embed used by the decision view."""
+    embed = Embed(
+        title="✅ 信貸已批准",
+        description=(
+            f"### {currency_text(amount=result.contract.principal_remaining, compact=True)} 已入帳"
+        ),
+        color=BORROW_COLOR,
+    )
+    embed.add_field(name="批准者", value=approver_mention, inline=True)
+    embed.add_field(
+        name="利率",
+        value=f"`{rate_text(monthly_rate_bps=result.contract.monthly_rate_bps)}`",
+        inline=True,
+    )
+    embed.add_field(
+        name="貸方餘額",
+        value=amount_code(amount=result.lender_balance or 0, compact=True),
+        inline=True,
+    )
+    _set_optional_thumbnail(embed=embed, avatar_url=lender_avatar_url)
+    return embed
+
+
+def build_central_bank_approved_embed(
+    *, result: LoanProposalAcceptResult, approver_mention: str
+) -> Embed:
+    """Builds the central-bank approval embed used by the decision view."""
+    embed = Embed(
+        title="🏛️ 央行借款已批准",
+        description=(
+            f"### {currency_text(amount=result.contract.principal_remaining, compact=True)} 已入帳"
+        ),
+        color=CENTRAL_BANK_COLOR,
+    )
+    embed.add_field(name="批准者", value=approver_mention, inline=True)
+    embed.add_field(
+        name="央行剩餘額度",
+        value=amount_code(amount=result.central_bank_available_credit or 0, compact=True),
+        inline=True,
+    )
+    return embed

--- a/src/discordbot/cogs/_economy/interactions.py
+++ b/src/discordbot/cogs/_economy/interactions.py
@@ -1,0 +1,68 @@
+"""Shared send/edit helpers for economy interaction responses."""
+
+import nextcord
+from nextcord import Embed, Interaction
+from nextcord.ui import View
+
+from discordbot.utils.discord_embeds import embed_spacer_payload
+from discordbot.utils.message_cleanup import schedule_public_message_delete
+
+
+async def send_expiring_followup(
+    interaction: Interaction,
+    embed: Embed,
+    view: View | None = None,
+    file: nextcord.File | None = None,
+) -> None:
+    """Sends a game-related economy embed and schedules its cleanup."""
+    extra_files = [file] if file is not None else None
+    kwargs: dict[str, object] = {
+        "embed": embed,
+        "wait": True,
+        **embed_spacer_payload(
+            embeds=[embed], is_edit=False, target=interaction, extra_files=extra_files
+        ),
+    }
+    if view is not None:
+        kwargs["view"] = view
+    message = await interaction.followup.send(**kwargs)
+    user_name = interaction.user.name if interaction.user is not None else None
+    schedule_public_message_delete(message=message, user_name=user_name)
+
+
+async def send_loan_request_followup(interaction: Interaction, embed: Embed, view: View) -> None:
+    """Sends a loan request message that owns its cleanup after a terminal state."""
+    message = await interaction.followup.send(
+        embed=embed,
+        view=view,
+        wait=True,
+        **embed_spacer_payload(embeds=[embed], is_edit=False, target=interaction),
+    )
+    view.message = message
+
+
+async def send_private_followup(interaction: Interaction, embed: Embed) -> None:
+    """Sends a personal economy embed visible only to the caller."""
+    await interaction.followup.send(
+        embed=embed,
+        ephemeral=True,
+        **embed_spacer_payload(embeds=[embed], is_edit=False, target=interaction),
+    )
+
+
+async def send_ephemeral_response(interaction: Interaction, embed: Embed) -> None:
+    """Sends an ephemeral economy embed as the initial interaction response."""
+    await interaction.response.send_message(
+        embed=embed,
+        ephemeral=True,
+        **embed_spacer_payload(embeds=[embed], is_edit=False, target=interaction),
+    )
+
+
+async def edit_response_embed(interaction: Interaction, embed: Embed) -> None:
+    """Edits the interaction's public message embed and clears its controls."""
+    await interaction.response.edit_message(
+        embed=embed,
+        view=None,
+        **embed_spacer_payload(embeds=[embed], is_edit=True, target=interaction),
+    )

--- a/src/discordbot/cogs/_economy/views.py
+++ b/src/discordbot/cogs/_economy/views.py
@@ -1,0 +1,351 @@
+"""Button views for deciding public loan requests."""
+
+import contextlib
+
+import nextcord
+from nextcord import ButtonStyle, Interaction
+from nextcord.ui import View, Button
+from nextcord.ext import commands
+
+from discordbot.utils.avatars import guild_avatar_url
+from discordbot.typings.economy import LOAN_PROPOSAL_TIMEOUT_SECONDS
+from discordbot.cogs._economy.embeds import (
+    REPAY_COLOR,
+    CENTRAL_BANK_COLOR,
+    build_error_embed,
+    build_simple_embed,
+    build_credit_approved_embed,
+    build_central_bank_approved_embed,
+)
+from discordbot.utils.discord_embeds import embed_spacer_payload
+from discordbot.utils.message_cleanup import schedule_public_message_delete
+from discordbot.cogs._economy.database import (
+    get_central_banker,
+    accept_loan_proposal,
+    cancel_loan_proposal,
+    reject_loan_proposal,
+    reject_expired_loan_proposal,
+)
+from discordbot.cogs._economy.interactions import edit_response_embed, send_ephemeral_response
+
+
+class CentralBankLoanDecisionView(View):
+    """Button controls for deciding a public central-bank loan request."""
+
+    def __init__(
+        self,
+        bot: commands.Bot,
+        proposal_id: int,
+        creator_id: int,
+        allow_self_approval: bool = False,
+    ) -> None:
+        """Initializes a decision view for one proposal."""
+        super().__init__(timeout=LOAN_PROPOSAL_TIMEOUT_SECONDS)
+        self.bot = bot
+        self.proposal_id = proposal_id
+        self.creator_id = creator_id
+        self.allow_self_approval = allow_self_approval
+        self.message: nextcord.Message | None = None
+
+    def _schedule_cleanup(self, interaction: Interaction | None = None) -> None:
+        """Schedules the public request message for cleanup after a terminal state."""
+        message = self.message or getattr(interaction, "message", None)
+        if message is None:
+            return
+        user_name = None
+        if interaction is not None and interaction.user is not None:
+            user_name = interaction.user.name
+        schedule_public_message_delete(message=message, user_name=user_name)
+
+    async def on_timeout(self) -> None:
+        """Rejects a stale central-bank request and cleans up its message."""
+        proposal = await reject_expired_loan_proposal(proposal_id=self.proposal_id)
+        if proposal is None or self.message is None:
+            return
+        self.stop()
+        embed = build_simple_embed(
+            title="🏛️ 央行申請已逾時",
+            description="### 申請已逾時，自動拒絕",
+            color=CENTRAL_BANK_COLOR,
+        )
+        with contextlib.suppress(Exception):
+            await self.message.edit(
+                embed=embed,
+                view=None,
+                **embed_spacer_payload(embeds=[embed], is_edit=True, target=self.message),
+            )
+        self._schedule_cleanup()
+
+    async def _send_permission_denied(self, interaction: Interaction) -> None:
+        """Replies privately when a non-banker clicks a decision button."""
+        embed = build_error_embed(
+            title="權限不足", description="### 只有央行成員可以處理央行借款申請"
+        )
+        await send_ephemeral_response(interaction=interaction, embed=embed)
+
+    async def _is_central_banker(self, interaction: Interaction) -> bool:
+        """Returns whether the clicking user can decide central-bank proposals."""
+        if interaction.user is None:
+            return False
+        return await get_central_banker(user_id=interaction.user.id)
+
+    def _central_bank_exclude_user_ids(self) -> tuple[int, ...]:
+        """Returns bot-owned account IDs excluded from central-bank capacity."""
+        return (self.bot.user.id,) if self.bot.user is not None else ()
+
+    @nextcord.ui.button(
+        label="批准",
+        emoji="✅",
+        style=ButtonStyle.success,
+        custom_id="central_bank:approve",
+        row=0,
+    )
+    async def approve(self, _button: Button, interaction: Interaction) -> None:
+        """Approves the central-bank request when clicked by a central banker."""
+        if interaction.user is None:
+            return
+        if not await self._is_central_banker(interaction=interaction):
+            await self._send_permission_denied(interaction=interaction)
+            return
+
+        banker_avatar_url = await guild_avatar_url(
+            user=interaction.user, guild=getattr(interaction, "guild", None)
+        )
+        result = await accept_loan_proposal(
+            proposal_id=self.proposal_id,
+            actor_id=interaction.user.id,
+            actor_name=interaction.user.name,
+            actor_avatar_url=banker_avatar_url,
+            is_central_banker=True,
+            central_bank_exclude_user_ids=self._central_bank_exclude_user_ids(),
+            allow_central_bank_self_approval=self.allow_self_approval,
+        )
+        if result is None:
+            embed = build_error_embed(
+                title="批准失敗",
+                description="### 申請不存在、已處理、自我批准未開放，或央行額度不足",
+            )
+            await send_ephemeral_response(interaction=interaction, embed=embed)
+            return
+
+        embed = build_central_bank_approved_embed(
+            result=result, approver_mention=interaction.user.mention
+        )
+        self.stop()
+        await edit_response_embed(interaction=interaction, embed=embed)
+        self._schedule_cleanup(interaction=interaction)
+
+    @nextcord.ui.button(
+        label="拒絕", emoji="✖️", style=ButtonStyle.danger, custom_id="central_bank:reject", row=0
+    )
+    async def reject(self, _button: Button, interaction: Interaction) -> None:
+        """Rejects the central-bank request when clicked by a central banker."""
+        if interaction.user is None:
+            return
+        if not await self._is_central_banker(interaction=interaction):
+            await self._send_permission_denied(interaction=interaction)
+            return
+
+        proposal = await reject_loan_proposal(
+            proposal_id=self.proposal_id, actor_id=interaction.user.id, is_central_banker=True
+        )
+        if proposal is None:
+            embed = build_error_embed(
+                title="拒絕失敗", description="### 申請不存在、已處理，或你沒有權限拒絕"
+            )
+            await send_ephemeral_response(interaction=interaction, embed=embed)
+            return
+
+        embed = build_simple_embed(
+            title="🏛️ 央行申請已拒絕",
+            description=f"### 央行借款申請已關閉\n處理人 {interaction.user.mention}",
+            color=CENTRAL_BANK_COLOR,
+        )
+        self.stop()
+        await edit_response_embed(interaction=interaction, embed=embed)
+        self._schedule_cleanup(interaction=interaction)
+
+    @nextcord.ui.button(
+        label="取消",
+        emoji="🚫",
+        style=ButtonStyle.secondary,
+        custom_id="central_bank:cancel",
+        row=0,
+    )
+    async def cancel(self, _button: Button, interaction: Interaction) -> None:
+        """Cancels the central-bank request when clicked by its creator."""
+        if interaction.user is None:
+            return
+        if interaction.user.id != self.creator_id:
+            embed = build_error_embed(
+                title="權限不足", description="### 只有申請發起者可以取消央行借款申請"
+            )
+            await send_ephemeral_response(interaction=interaction, embed=embed)
+            return
+
+        proposal = await cancel_loan_proposal(
+            proposal_id=self.proposal_id, actor_id=interaction.user.id
+        )
+        if proposal is None:
+            embed = build_error_embed(
+                title="取消失敗", description="### 申請不存在、已處理，或你不是發起者"
+            )
+            await send_ephemeral_response(interaction=interaction, embed=embed)
+            return
+
+        embed = build_simple_embed(
+            title="🏛️ 央行申請已取消",
+            description=f"### 央行借款申請已關閉\n發起者 {interaction.user.mention}",
+            color=CENTRAL_BANK_COLOR,
+        )
+        self.stop()
+        await edit_response_embed(interaction=interaction, embed=embed)
+        self._schedule_cleanup(interaction=interaction)
+
+
+class CreditLoanDecisionView(View):
+    """Button controls for deciding a public personal credit request."""
+
+    def __init__(self, proposal_id: int, lender_id: int, creator_id: int) -> None:
+        """Initializes a decision view for one personal credit proposal."""
+        super().__init__(timeout=LOAN_PROPOSAL_TIMEOUT_SECONDS)
+        self.proposal_id = proposal_id
+        self.lender_id = lender_id
+        self.creator_id = creator_id
+        self.message: nextcord.Message | None = None
+
+    def _schedule_cleanup(self, interaction: Interaction | None = None) -> None:
+        """Schedules the public request message for cleanup after a terminal state."""
+        message = self.message or getattr(interaction, "message", None)
+        if message is None:
+            return
+        user_name = None
+        if interaction is not None and interaction.user is not None:
+            user_name = interaction.user.name
+        schedule_public_message_delete(message=message, user_name=user_name)
+
+    async def on_timeout(self) -> None:
+        """Rejects a stale personal credit request and cleans up its message."""
+        proposal = await reject_expired_loan_proposal(proposal_id=self.proposal_id)
+        if proposal is None or self.message is None:
+            return
+        self.stop()
+        embed = build_simple_embed(
+            title="信貸申請已逾時", description="### 申請已逾時，自動拒絕", color=REPAY_COLOR
+        )
+        with contextlib.suppress(Exception):
+            await self.message.edit(
+                embed=embed,
+                view=None,
+                **embed_spacer_payload(embeds=[embed], is_edit=True, target=self.message),
+            )
+        self._schedule_cleanup()
+
+    async def _send_permission_denied(self, interaction: Interaction, description: str) -> None:
+        """Replies privately when a user clicks a button they cannot use."""
+        embed = build_error_embed(title="權限不足", description=description)
+        await send_ephemeral_response(interaction=interaction, embed=embed)
+
+    async def _require_lender(self, interaction: Interaction) -> bool:
+        """Returns whether the clicking user is the requested lender."""
+        if interaction.user is None:
+            return False
+        if interaction.user.id == self.lender_id:
+            return True
+        await self._send_permission_denied(
+            interaction=interaction, description="### 只有指定貸方可以處理這筆信貸申請"
+        )
+        return False
+
+    @nextcord.ui.button(
+        label="批准", emoji="✅", style=ButtonStyle.success, custom_id="credit:approve", row=0
+    )
+    async def approve(self, _button: Button, interaction: Interaction) -> None:
+        """Approves the personal credit request when clicked by the lender."""
+        if interaction.user is None or not await self._require_lender(interaction=interaction):
+            return
+
+        lender_avatar_url = await guild_avatar_url(
+            user=interaction.user, guild=getattr(interaction, "guild", None)
+        )
+        result = await accept_loan_proposal(
+            proposal_id=self.proposal_id,
+            actor_id=interaction.user.id,
+            actor_name=interaction.user.name,
+            actor_avatar_url=lender_avatar_url,
+        )
+        if result is None:
+            embed = build_error_embed(
+                title="批准失敗",
+                description="### 申請不存在、已處理、不是指定貸方，或貸方餘額不足",
+            )
+            await send_ephemeral_response(interaction=interaction, embed=embed)
+            return
+
+        embed = build_credit_approved_embed(
+            result=result,
+            approver_mention=interaction.user.mention,
+            lender_avatar_url=lender_avatar_url,
+        )
+        self.stop()
+        await edit_response_embed(interaction=interaction, embed=embed)
+        self._schedule_cleanup(interaction=interaction)
+
+    @nextcord.ui.button(
+        label="拒絕", emoji="✖️", style=ButtonStyle.danger, custom_id="credit:reject", row=0
+    )
+    async def reject(self, _button: Button, interaction: Interaction) -> None:
+        """Rejects the personal credit request when clicked by the lender."""
+        if interaction.user is None or not await self._require_lender(interaction=interaction):
+            return
+
+        proposal = await reject_loan_proposal(
+            proposal_id=self.proposal_id, actor_id=interaction.user.id
+        )
+        if proposal is None:
+            embed = build_error_embed(
+                title="拒絕失敗", description="### 申請不存在、已處理，或你不是指定貸方"
+            )
+            await send_ephemeral_response(interaction=interaction, embed=embed)
+            return
+
+        embed = build_simple_embed(
+            title="信貸申請已拒絕",
+            description=f"### 信貸申請已關閉\n處理人 {interaction.user.mention}",
+            color=REPAY_COLOR,
+        )
+        self.stop()
+        await edit_response_embed(interaction=interaction, embed=embed)
+        self._schedule_cleanup(interaction=interaction)
+
+    @nextcord.ui.button(
+        label="取消", emoji="🚫", style=ButtonStyle.secondary, custom_id="credit:cancel", row=0
+    )
+    async def cancel(self, _button: Button, interaction: Interaction) -> None:
+        """Cancels the personal credit request when clicked by its creator."""
+        if interaction.user is None:
+            return
+        if interaction.user.id != self.creator_id:
+            await self._send_permission_denied(
+                interaction=interaction, description="### 只有申請發起者可以取消這筆信貸申請"
+            )
+            return
+
+        proposal = await cancel_loan_proposal(
+            proposal_id=self.proposal_id, actor_id=interaction.user.id
+        )
+        if proposal is None:
+            embed = build_error_embed(
+                title="取消失敗", description="### 申請不存在、已處理，或你不是發起者"
+            )
+            await send_ephemeral_response(interaction=interaction, embed=embed)
+            return
+
+        embed = build_simple_embed(
+            title="信貸申請已取消",
+            description=f"### 信貸申請已關閉\n發起者 {interaction.user.mention}",
+            color=REPAY_COLOR,
+        )
+        self.stop()
+        await edit_response_embed(interaction=interaction, embed=embed)
+        self._schedule_cleanup(interaction=interaction)

--- a/src/discordbot/cogs/economy.py
+++ b/src/discordbot/cogs/economy.py
@@ -2,25 +2,21 @@
 
 from io import BytesIO
 from datetime import UTC, datetime
-import contextlib
 
 import nextcord
-from nextcord import Embed, Locale, Member, ButtonStyle, Interaction, SlashOption
-from nextcord.ui import View, Button
+from nextcord import Locale, Member, Interaction, SlashOption
 from nextcord.ext import commands
 
-from discordbot.typings.stock import StockPortfolioView, StockPortfolioHolding
+from discordbot.cogs._economy import embeds
 from discordbot.utils.avatars import guild_avatar_url
 from discordbot.typings.config import EconomyConfig
 from discordbot.typings.economy import (
     VIP_PURCHASE_COST,
     BASE_CHECKIN_REWARD_AMOUNT,
     DEFAULT_LOAN_MONTHLY_RATE_BPS,
-    LOAN_PROPOSAL_TIMEOUT_SECONDS,
     LoanLenderType,
 )
-from discordbot.utils.number_text import share_quantity_text
-from discordbot.cogs._stock.market import format_price
+from discordbot.cogs._economy.views import CreditLoanDecisionView, CentralBankLoanDecisionView
 from discordbot.cogs._economy.boards import (
     LOSS_LEADERBOARD_BOARD_FILENAME,
     BALANCE_LEADERBOARD_BOARD_FILENAME,
@@ -28,8 +24,6 @@ from discordbot.cogs._economy.boards import (
     build_balance_leaderboard_board_image,
 )
 from discordbot.cogs._stock.database import get_stock_portfolio
-from discordbot.utils.discord_embeds import embed_spacer_payload
-from discordbot.utils.message_cleanup import schedule_public_message_delete
 from discordbot.cogs._economy.database import (
     top_n,
     buy_vip,
@@ -42,67 +36,25 @@ from discordbot.cogs._economy.database import (
     get_balance,
     get_portfolio,
     adjust_balance,
-    checkin_reward,
     get_casino_ledger,
     get_central_banker,
     call_personal_loans,
     list_loan_contracts,
-    accept_loan_proposal,
-    cancel_loan_proposal,
-    reject_loan_proposal,
     repay_personal_loans,
     call_central_bank_loans,
     get_central_bank_status,
     repay_central_bank_loans,
-    apply_vip_blackjack_bonus,
-    monthly_rate_bps_to_percent,
     monthly_rate_percent_to_bps,
     create_personal_loan_request,
-    reject_expired_loan_proposal,
     create_central_bank_loan_request,
 )
-from discordbot.cogs._economy.presentation import (
-    CURRENCY_NAME,
-    amount_code,
-    bold_currency,
-    currency_text,
+from discordbot.cogs._economy.interactions import (
+    send_private_followup,
+    send_expiring_followup,
+    send_ephemeral_response,
+    send_loan_request_followup,
 )
-
-_BALANCE_COLOR = 0x57F287
-_LEADERBOARD_COLOR = 0xFEE75C
-_LOSS_LEADERBOARD_COLOR = 0xE67E22
-_TRANSFER_COLOR = 0x5865F2
-_ADMIN_COLOR = 0x3498DB
-_CASINO_COLOR = 0xEB459E
-_BORROW_COLOR = 0xF1C40F
-_REPAY_COLOR = 0x2ECC71
-_CENTRAL_BANK_COLOR = 0x1ABC9C
-_CHECKIN_COLOR = 0x9B59B6
-_VIP_COLOR = 0xF1C40F
-_ERROR_COLOR = 0xED4245
-_STOCK_POSITION_LINE_LIMIT = 5
-_STOCK_POSITION_NAME_LIMIT = 20
-
-
-def _vip_perk_lines(checkin_streak: int = 1) -> str:
-    """Formats VIP perks with the base number and the boosted number."""
-    base_checkin = checkin_reward(streak=checkin_streak, is_vip=False)
-    vip_checkin = checkin_reward(streak=checkin_streak, is_vip=True)
-    sample_win = 10_000
-    boosted_win = apply_vip_blackjack_bonus(delta=sample_win, is_vip=True)
-    checkin_label = "簽到基礎" if checkin_streak == 1 else f"第 {checkin_streak} 天簽到"
-    return (
-        f"{checkin_label} {amount_code(amount=base_checkin, compact=True)} → "
-        f"{amount_code(amount=vip_checkin, compact=True)}\n"
-        f"Blackjack 贏局例 {amount_code(amount=sample_win, signed=True, compact=True)} → "
-        f"{amount_code(amount=boosted_win, signed=True, compact=True)}"
-    )
-
-
-def _set_optional_thumbnail(embed: Embed, avatar_url: str) -> None:
-    """Sets an embed thumbnail when an avatar URL is available."""
-    if avatar_url:
-        embed.set_thumbnail(url=avatar_url)
+from discordbot.cogs._economy.presentation import CURRENCY_NAME, currency_text
 
 
 def _parse_positive_amount(raw_amount: str | None) -> int | None:
@@ -117,533 +69,6 @@ def _parse_positive_amount(raw_amount: str | None) -> int | None:
     if amount <= 0:
         return None
     return amount
-
-
-def _stock_position_lines(stock_portfolio: StockPortfolioView) -> str:
-    """Formats stock holdings for the private balance embed."""
-    if not stock_portfolio.holdings:
-        return "目前沒有股票部位"
-    lines = [
-        _stock_position_line(holding=holding)
-        for holding in stock_portfolio.holdings[:_STOCK_POSITION_LINE_LIMIT]
-    ]
-    remaining = len(stock_portfolio.holdings) - _STOCK_POSITION_LINE_LIMIT
-    if remaining > 0:
-        lines.append(f"還有 `{remaining:,}` 檔未列出")
-    return "\n".join(lines)
-
-
-def _stock_position_line(holding: StockPortfolioHolding) -> str:
-    """Formats one stock holding into a compact balance line."""
-    position_parts: list[str] = []
-    if holding.long_shares > 0:
-        position_parts.append(
-            f"持股 `{share_quantity_text(shares=holding.long_shares)}` / 市值 "
-            f"{amount_code(amount=holding.long_market_value, compact=True)}"
-        )
-    if holding.short_shares > 0:
-        short_equity = (
-            holding.short_collateral + holding.short_entry_value - holding.short_cover_cost
-        )
-        position_parts.append(
-            f"做空 `{share_quantity_text(shares=holding.short_shares)}` / 淨值 "
-            f"{amount_code(amount=short_equity, compact=True)}"
-        )
-    position_text = " · ".join(position_parts) if position_parts else "無部位"
-    name = _stock_position_name(name=holding.name)
-    return (
-        f"`{holding.symbol}` {name} · 股價 `{format_price(price_cents=holding.price_cents)}` · "
-        f"{position_text} · 未實現 "
-        f"{amount_code(amount=holding.unrealized_pnl, signed=True, compact=True)}"
-    )
-
-
-def _stock_position_name(name: str) -> str:
-    """Keeps long company names from filling the stock field."""
-    if len(name) <= _STOCK_POSITION_NAME_LIMIT:
-        return name
-    return f"{name[:_STOCK_POSITION_NAME_LIMIT]}..."
-
-
-def _debt_summary_text(*, principal: int, interest: int) -> str:
-    """Formats outstanding loan principal and interest."""
-    if principal <= 0 and interest <= 0:
-        return "無未還債務"
-    return (
-        f"本金 {amount_code(amount=principal, compact=True)}\n"
-        f"利息 {amount_code(amount=interest, compact=True)}"
-    )
-
-
-def _vip_status_text(is_vip: bool) -> str:
-    """Formats VIP status for the private balance embed."""
-    if not is_vip:
-        return "一般會員"
-    return f"👑 VIP\n{_vip_perk_lines()}"
-
-
-async def _send_expiring_followup(
-    interaction: Interaction,
-    embed: Embed,
-    view: View | None = None,
-    file: nextcord.File | None = None,
-) -> None:
-    """Sends a game-related economy embed and schedules its cleanup."""
-    extra_files = [file] if file is not None else None
-    kwargs: dict[str, object] = {
-        "embed": embed,
-        "wait": True,
-        **embed_spacer_payload(
-            embeds=[embed], is_edit=False, target=interaction, extra_files=extra_files
-        ),
-    }
-    if view is not None:
-        kwargs["view"] = view
-    message = await interaction.followup.send(**kwargs)
-    user_name = interaction.user.name if interaction.user is not None else None
-    schedule_public_message_delete(message=message, user_name=user_name)
-
-
-async def _send_loan_request_followup(interaction: Interaction, embed: Embed, view: View) -> None:
-    """Sends a loan request message that owns its cleanup after a terminal state."""
-    message = await interaction.followup.send(
-        embed=embed,
-        view=view,
-        wait=True,
-        **embed_spacer_payload(embeds=[embed], is_edit=False, target=interaction),
-    )
-    view.message = message
-
-
-async def _send_private_followup(interaction: Interaction, embed: Embed) -> None:
-    """Sends a personal economy embed visible only to the caller."""
-    await interaction.followup.send(
-        embed=embed,
-        ephemeral=True,
-        **embed_spacer_payload(embeds=[embed], is_edit=False, target=interaction),
-    )
-
-
-async def _send_ephemeral_response(interaction: Interaction, embed: Embed) -> None:
-    """Sends an ephemeral economy embed as the initial interaction response."""
-    await interaction.response.send_message(
-        embed=embed,
-        ephemeral=True,
-        **embed_spacer_payload(embeds=[embed], is_edit=False, target=interaction),
-    )
-
-
-async def _edit_response_embed(interaction: Interaction, embed: Embed) -> None:
-    """Edits the interaction's public message embed and clears its controls."""
-    await interaction.response.edit_message(
-        embed=embed,
-        view=None,
-        **embed_spacer_payload(embeds=[embed], is_edit=True, target=interaction),
-    )
-
-
-def _rate_text(monthly_rate_bps: int) -> str:
-    """Formats a monthly loan rate."""
-    return f"每月 {monthly_rate_bps_to_percent(monthly_rate_bps=monthly_rate_bps):g}%"
-
-
-def _loan_terms_text(amount: int, monthly_rate_bps: int) -> str:
-    """Formats the loan terms shown before acceptance."""
-    return (
-        f"本金 {amount_code(amount=amount, compact=True)}\n"
-        f"利率 `{_rate_text(monthly_rate_bps=monthly_rate_bps)}`\n"
-        "利息採單利，依經過天數按比例計算\n"
-        "還款會先抵利息，再抵本金；貸方可催收"
-    )
-
-
-def _payment_summary_text(  # noqa: PLR0913 -- summary needs all visible repayment fields
-    paid_amount: int,
-    interest_paid: int,
-    principal_paid: int,
-    remaining_principal: int,
-    remaining_interest: int,
-    borrower_balance: int,
-) -> str:
-    """Formats one repayment or collection result."""
-    return (
-        f"本次扣款 {amount_code(amount=paid_amount, compact=True)}\n"
-        f"償還利息 {amount_code(amount=interest_paid, compact=True)}\n"
-        f"償還本金 {amount_code(amount=principal_paid, compact=True)}\n"
-        f"剩餘本金 {amount_code(amount=remaining_principal, compact=True)}\n"
-        f"剩餘利息 {amount_code(amount=remaining_interest, compact=True)}\n"
-        f"借方餘額 {amount_code(amount=borrower_balance, compact=True)}"
-    )
-
-
-def _credit_request_footer() -> str:
-    """Formats the personal credit request button hint."""
-    return (
-        f"貸方可用下方按鈕批准或拒絕，發起者可取消，{LOAN_PROPOSAL_TIMEOUT_SECONDS} 秒後自動拒絕"
-    )
-
-
-def _central_bank_request_footer() -> str:
-    """Formats the central-bank request button hint."""
-    return f"央行成員可用下方按鈕批准或拒絕，發起者可取消，{LOAN_PROPOSAL_TIMEOUT_SECONDS} 秒後自動拒絕"
-
-
-class CentralBankLoanDecisionView(View):
-    """Button controls for deciding a public central-bank loan request."""
-
-    def __init__(
-        self,
-        bot: commands.Bot,
-        proposal_id: int,
-        creator_id: int,
-        allow_self_approval: bool = False,
-    ) -> None:
-        """Initializes a decision view for one proposal."""
-        super().__init__(timeout=LOAN_PROPOSAL_TIMEOUT_SECONDS)
-        self.bot = bot
-        self.proposal_id = proposal_id
-        self.creator_id = creator_id
-        self.allow_self_approval = allow_self_approval
-        self.message: nextcord.Message | None = None
-
-    def _schedule_cleanup(self, interaction: Interaction | None = None) -> None:
-        """Schedules the public request message for cleanup after a terminal state."""
-        message = self.message or getattr(interaction, "message", None)
-        if message is None:
-            return
-        user_name = None
-        if interaction is not None and interaction.user is not None:
-            user_name = interaction.user.name
-        schedule_public_message_delete(message=message, user_name=user_name)
-
-    async def on_timeout(self) -> None:
-        """Rejects a stale central-bank request and cleans up its message."""
-        proposal = await reject_expired_loan_proposal(proposal_id=self.proposal_id)
-        if proposal is None or self.message is None:
-            return
-        self.stop()
-        embed = Embed(
-            title="🏛️ 央行申請已逾時",
-            description="### 申請已逾時，自動拒絕",
-            color=_CENTRAL_BANK_COLOR,
-        )
-        with contextlib.suppress(Exception):
-            await self.message.edit(
-                embed=embed,
-                view=None,
-                **embed_spacer_payload(embeds=[embed], is_edit=True, target=self.message),
-            )
-        self._schedule_cleanup()
-
-    async def _send_permission_denied(self, interaction: Interaction) -> None:
-        """Replies privately when a non-banker clicks a decision button."""
-        embed = Embed(
-            title="權限不足",
-            description="### 只有央行成員可以處理央行借款申請",
-            color=_ERROR_COLOR,
-        )
-        await _send_ephemeral_response(interaction=interaction, embed=embed)
-
-    async def _is_central_banker(self, interaction: Interaction) -> bool:
-        """Returns whether the clicking user can decide central-bank proposals."""
-        if interaction.user is None:
-            return False
-        return await get_central_banker(user_id=interaction.user.id)
-
-    def _central_bank_exclude_user_ids(self) -> tuple[int, ...]:
-        """Returns bot-owned account IDs excluded from central-bank capacity."""
-        return (self.bot.user.id,) if self.bot.user is not None else ()
-
-    @nextcord.ui.button(
-        label="批准",
-        emoji="✅",
-        style=ButtonStyle.success,
-        custom_id="central_bank:approve",
-        row=0,
-    )
-    async def approve(self, _button: Button, interaction: Interaction) -> None:
-        """Approves the central-bank request when clicked by a central banker."""
-        if interaction.user is None:
-            return
-        if not await self._is_central_banker(interaction=interaction):
-            await self._send_permission_denied(interaction=interaction)
-            return
-
-        banker_avatar_url = await guild_avatar_url(
-            user=interaction.user, guild=getattr(interaction, "guild", None)
-        )
-        result = await accept_loan_proposal(
-            proposal_id=self.proposal_id,
-            actor_id=interaction.user.id,
-            actor_name=interaction.user.name,
-            actor_avatar_url=banker_avatar_url,
-            is_central_banker=True,
-            central_bank_exclude_user_ids=self._central_bank_exclude_user_ids(),
-            allow_central_bank_self_approval=self.allow_self_approval,
-        )
-        if result is None:
-            embed = Embed(
-                title="批准失敗",
-                description="### 申請不存在、已處理、自我批准未開放，或央行額度不足",
-                color=_ERROR_COLOR,
-            )
-            await _send_ephemeral_response(interaction=interaction, embed=embed)
-            return
-
-        embed = Embed(
-            title="🏛️ 央行借款已批准",
-            description=(
-                f"### {currency_text(amount=result.contract.principal_remaining, compact=True)} 已入帳"
-            ),
-            color=_CENTRAL_BANK_COLOR,
-        )
-        embed.add_field(name="批准者", value=interaction.user.mention, inline=True)
-        embed.add_field(
-            name="央行剩餘額度",
-            value=amount_code(amount=result.central_bank_available_credit or 0, compact=True),
-            inline=True,
-        )
-        self.stop()
-        await _edit_response_embed(interaction=interaction, embed=embed)
-        self._schedule_cleanup(interaction=interaction)
-
-    @nextcord.ui.button(
-        label="拒絕", emoji="✖️", style=ButtonStyle.danger, custom_id="central_bank:reject", row=0
-    )
-    async def reject(self, _button: Button, interaction: Interaction) -> None:
-        """Rejects the central-bank request when clicked by a central banker."""
-        if interaction.user is None:
-            return
-        if not await self._is_central_banker(interaction=interaction):
-            await self._send_permission_denied(interaction=interaction)
-            return
-
-        proposal = await reject_loan_proposal(
-            proposal_id=self.proposal_id, actor_id=interaction.user.id, is_central_banker=True
-        )
-        if proposal is None:
-            embed = Embed(
-                title="拒絕失敗",
-                description="### 申請不存在、已處理，或你沒有權限拒絕",
-                color=_ERROR_COLOR,
-            )
-            await _send_ephemeral_response(interaction=interaction, embed=embed)
-            return
-
-        embed = Embed(
-            title="🏛️ 央行申請已拒絕",
-            description=f"### 央行借款申請已關閉\n處理人 {interaction.user.mention}",
-            color=_CENTRAL_BANK_COLOR,
-        )
-        self.stop()
-        await _edit_response_embed(interaction=interaction, embed=embed)
-        self._schedule_cleanup(interaction=interaction)
-
-    @nextcord.ui.button(
-        label="取消",
-        emoji="🚫",
-        style=ButtonStyle.secondary,
-        custom_id="central_bank:cancel",
-        row=0,
-    )
-    async def cancel(self, _button: Button, interaction: Interaction) -> None:
-        """Cancels the central-bank request when clicked by its creator."""
-        if interaction.user is None:
-            return
-        if interaction.user.id != self.creator_id:
-            embed = Embed(
-                title="權限不足",
-                description="### 只有申請發起者可以取消央行借款申請",
-                color=_ERROR_COLOR,
-            )
-            await _send_ephemeral_response(interaction=interaction, embed=embed)
-            return
-
-        proposal = await cancel_loan_proposal(
-            proposal_id=self.proposal_id, actor_id=interaction.user.id
-        )
-        if proposal is None:
-            embed = Embed(
-                title="取消失敗",
-                description="### 申請不存在、已處理，或你不是發起者",
-                color=_ERROR_COLOR,
-            )
-            await _send_ephemeral_response(interaction=interaction, embed=embed)
-            return
-
-        embed = Embed(
-            title="🏛️ 央行申請已取消",
-            description=f"### 央行借款申請已關閉\n發起者 {interaction.user.mention}",
-            color=_CENTRAL_BANK_COLOR,
-        )
-        self.stop()
-        await _edit_response_embed(interaction=interaction, embed=embed)
-        self._schedule_cleanup(interaction=interaction)
-
-
-class CreditLoanDecisionView(View):
-    """Button controls for deciding a public personal credit request."""
-
-    def __init__(self, proposal_id: int, lender_id: int, creator_id: int) -> None:
-        """Initializes a decision view for one personal credit proposal."""
-        super().__init__(timeout=LOAN_PROPOSAL_TIMEOUT_SECONDS)
-        self.proposal_id = proposal_id
-        self.lender_id = lender_id
-        self.creator_id = creator_id
-        self.message: nextcord.Message | None = None
-
-    def _schedule_cleanup(self, interaction: Interaction | None = None) -> None:
-        """Schedules the public request message for cleanup after a terminal state."""
-        message = self.message or getattr(interaction, "message", None)
-        if message is None:
-            return
-        user_name = None
-        if interaction is not None and interaction.user is not None:
-            user_name = interaction.user.name
-        schedule_public_message_delete(message=message, user_name=user_name)
-
-    async def on_timeout(self) -> None:
-        """Rejects a stale personal credit request and cleans up its message."""
-        proposal = await reject_expired_loan_proposal(proposal_id=self.proposal_id)
-        if proposal is None or self.message is None:
-            return
-        self.stop()
-        embed = Embed(
-            title="信貸申請已逾時", description="### 申請已逾時，自動拒絕", color=_REPAY_COLOR
-        )
-        with contextlib.suppress(Exception):
-            await self.message.edit(
-                embed=embed,
-                view=None,
-                **embed_spacer_payload(embeds=[embed], is_edit=True, target=self.message),
-            )
-        self._schedule_cleanup()
-
-    async def _send_permission_denied(self, interaction: Interaction, description: str) -> None:
-        """Replies privately when a user clicks a button they cannot use."""
-        embed = Embed(title="權限不足", description=description, color=_ERROR_COLOR)
-        await _send_ephemeral_response(interaction=interaction, embed=embed)
-
-    async def _require_lender(self, interaction: Interaction) -> bool:
-        """Returns whether the clicking user is the requested lender."""
-        if interaction.user is None:
-            return False
-        if interaction.user.id == self.lender_id:
-            return True
-        await self._send_permission_denied(
-            interaction=interaction, description="### 只有指定貸方可以處理這筆信貸申請"
-        )
-        return False
-
-    @nextcord.ui.button(
-        label="批准", emoji="✅", style=ButtonStyle.success, custom_id="credit:approve", row=0
-    )
-    async def approve(self, _button: Button, interaction: Interaction) -> None:
-        """Approves the personal credit request when clicked by the lender."""
-        if interaction.user is None or not await self._require_lender(interaction=interaction):
-            return
-
-        lender_avatar_url = await guild_avatar_url(
-            user=interaction.user, guild=getattr(interaction, "guild", None)
-        )
-        result = await accept_loan_proposal(
-            proposal_id=self.proposal_id,
-            actor_id=interaction.user.id,
-            actor_name=interaction.user.name,
-            actor_avatar_url=lender_avatar_url,
-        )
-        if result is None:
-            embed = Embed(
-                title="批准失敗",
-                description="### 申請不存在、已處理、不是指定貸方，或貸方餘額不足",
-                color=_ERROR_COLOR,
-            )
-            await _send_ephemeral_response(interaction=interaction, embed=embed)
-            return
-
-        embed = Embed(
-            title="✅ 信貸已批准",
-            description=f"### {currency_text(amount=result.contract.principal_remaining, compact=True)} 已入帳",
-            color=_BORROW_COLOR,
-        )
-        embed.add_field(name="批准者", value=interaction.user.mention, inline=True)
-        embed.add_field(
-            name="利率",
-            value=f"`{_rate_text(monthly_rate_bps=result.contract.monthly_rate_bps)}`",
-            inline=True,
-        )
-        embed.add_field(
-            name="貸方餘額",
-            value=amount_code(amount=result.lender_balance or 0, compact=True),
-            inline=True,
-        )
-        _set_optional_thumbnail(embed=embed, avatar_url=lender_avatar_url)
-        self.stop()
-        await _edit_response_embed(interaction=interaction, embed=embed)
-        self._schedule_cleanup(interaction=interaction)
-
-    @nextcord.ui.button(
-        label="拒絕", emoji="✖️", style=ButtonStyle.danger, custom_id="credit:reject", row=0
-    )
-    async def reject(self, _button: Button, interaction: Interaction) -> None:
-        """Rejects the personal credit request when clicked by the lender."""
-        if interaction.user is None or not await self._require_lender(interaction=interaction):
-            return
-
-        proposal = await reject_loan_proposal(
-            proposal_id=self.proposal_id, actor_id=interaction.user.id
-        )
-        if proposal is None:
-            embed = Embed(
-                title="拒絕失敗",
-                description="### 申請不存在、已處理，或你不是指定貸方",
-                color=_ERROR_COLOR,
-            )
-            await _send_ephemeral_response(interaction=interaction, embed=embed)
-            return
-
-        embed = Embed(
-            title="信貸申請已拒絕",
-            description=f"### 信貸申請已關閉\n處理人 {interaction.user.mention}",
-            color=_REPAY_COLOR,
-        )
-        self.stop()
-        await _edit_response_embed(interaction=interaction, embed=embed)
-        self._schedule_cleanup(interaction=interaction)
-
-    @nextcord.ui.button(
-        label="取消", emoji="🚫", style=ButtonStyle.secondary, custom_id="credit:cancel", row=0
-    )
-    async def cancel(self, _button: Button, interaction: Interaction) -> None:
-        """Cancels the personal credit request when clicked by its creator."""
-        if interaction.user is None:
-            return
-        if interaction.user.id != self.creator_id:
-            await self._send_permission_denied(
-                interaction=interaction, description="### 只有申請發起者可以取消這筆信貸申請"
-            )
-            return
-
-        proposal = await cancel_loan_proposal(
-            proposal_id=self.proposal_id, actor_id=interaction.user.id
-        )
-        if proposal is None:
-            embed = Embed(
-                title="取消失敗",
-                description="### 申請不存在、已處理，或你不是發起者",
-                color=_ERROR_COLOR,
-            )
-            await _send_ephemeral_response(interaction=interaction, embed=embed)
-            return
-
-        embed = Embed(
-            title="信貸申請已取消",
-            description=f"### 信貸申請已關閉\n發起者 {interaction.user.mention}",
-            color=_REPAY_COLOR,
-        )
-        self.stop()
-        await _edit_response_embed(interaction=interaction, embed=embed)
-        self._schedule_cleanup(interaction=interaction)
 
 
 class EconomyCogs(commands.Cog):
@@ -711,8 +136,9 @@ class EconomyCogs(commands.Cog):
         """Credits points to a member through the manual-adjustment audit path."""
         parsed_amount = _parse_positive_amount(raw_amount=amount)
         if parsed_amount is None:
-            await _send_ephemeral_response(
-                interaction=interaction, embed=self._invalid_admin_amount_embed(title="退稅失敗")
+            await send_ephemeral_response(
+                interaction=interaction,
+                embed=embeds.build_invalid_admin_amount_embed(title="退稅失敗"),
             )
             return
         await self._run_admin_adjustment(
@@ -760,8 +186,9 @@ class EconomyCogs(commands.Cog):
         """Debits points from a member through the manual-adjustment audit path."""
         parsed_amount = _parse_positive_amount(raw_amount=amount)
         if parsed_amount is None:
-            await _send_ephemeral_response(
-                interaction=interaction, embed=self._invalid_admin_amount_embed(title="收稅失敗")
+            await send_ephemeral_response(
+                interaction=interaction,
+                embed=embeds.build_invalid_admin_amount_embed(title="收稅失敗"),
             )
             return
         await self._run_admin_adjustment(
@@ -770,15 +197,6 @@ class EconomyCogs(commands.Cog):
             action="collect_tax",
             title="收稅完成",
             delta=-parsed_amount,
-        )
-
-    @staticmethod
-    def _invalid_admin_amount_embed(title: str) -> Embed:
-        """Builds the validation embed for malformed admin adjustment amounts."""
-        return Embed(
-            title=title,
-            description="### 金額格式錯誤\n請輸入正整數，可以加逗號，例如 `1,000`。",
-            color=_ERROR_COLOR,
         )
 
     async def _run_admin_adjustment(
@@ -792,13 +210,15 @@ class EconomyCogs(commands.Cog):
         actor_avatar_url = await guild_avatar_url(user=actor, guild=guild)
         if not await get_admin(user_id=actor.id):
             await interaction.response.defer(ephemeral=True)
-            embed = Embed(
-                title="權限不足",
-                description="### 只有 economy admin 可以執行這個操作",
-                color=_ERROR_COLOR,
+            await send_private_followup(
+                interaction=interaction,
+                embed=embeds.build_error_embed(
+                    title="權限不足",
+                    description="### 只有 economy admin 可以執行這個操作",
+                    author_name=actor.display_name,
+                    author_icon_url=actor_avatar_url,
+                ),
             )
-            embed.set_author(name=actor.display_name, icon_url=actor_avatar_url)
-            await _send_private_followup(interaction=interaction, embed=embed)
             return
         await interaction.response.defer()
         member_avatar_url = await guild_avatar_url(user=member, guild=guild)
@@ -809,28 +229,17 @@ class EconomyCogs(commands.Cog):
             allow_negative=False,
             avatar_url=member_avatar_url,
         )
-        embed = Embed(
+        embed = embeds.build_admin_adjustment_embed(
             title=title,
-            description=(
-                f"### {member.mention}\n"
-                f"{currency_text(amount=result.applied_delta, signed=True, compact=True)}"
-            ),
-            color=_ADMIN_COLOR,
+            member_mention=member.mention,
+            actor_name=actor.display_name,
+            actor_avatar_url=actor_avatar_url,
+            member_avatar_url=member_avatar_url,
+            requested_delta=delta,
+            result=result,
+            is_collect_clamped=(action == "collect_tax" and result.applied_delta != delta),
         )
-        embed.set_author(name=actor.display_name, icon_url=actor_avatar_url)
-        _set_optional_thumbnail(embed=embed, avatar_url=member_avatar_url)
-        embed.add_field(
-            name="操作結果",
-            value=(
-                f"申請 {amount_code(amount=delta, signed=True, compact=True)}\n"
-                f"實際 {amount_code(amount=result.applied_delta, signed=True, compact=True)}\n"
-                f"餘額 {amount_code(amount=result.new_balance, compact=True)}"
-            ),
-            inline=False,
-        )
-        if action == "collect_tax" and result.applied_delta != delta:
-            embed.set_footer(text="收稅最多扣到餘額 0")
-        await _send_expiring_followup(interaction=interaction, embed=embed)
+        await send_expiring_followup(interaction=interaction, embed=embed)
 
     @nextcord.slash_command(
         name="balance",
@@ -871,51 +280,15 @@ class EconomyCogs(commands.Cog):
         stock_portfolio = await get_stock_portfolio(user_id=target.id)
         is_vip = await get_vip(user_id=target.id)
         age_days = (datetime.now(tz=UTC) - target.created_at).days
-        net_worth = portfolio.net_worth + stock_portfolio.equity_value
-
-        embed = Embed(
-            title="💰 財務總覽",
-            color=_BALANCE_COLOR,
-            description=(
-                f"## {target.display_name}\n淨資產 {bold_currency(amount=net_worth, compact=True)}"
-            ),
+        embed = embeds.build_balance_embed(
+            display_name=target.display_name,
+            avatar_url=target.display_avatar.url,
+            portfolio=portfolio,
+            stock_portfolio=stock_portfolio,
+            is_vip=is_vip,
+            age_days=age_days,
         )
-        embed.set_author(
-            name=f"{target.display_name} 的財務總覽", icon_url=target.display_avatar.url
-        )
-        _set_optional_thumbnail(embed=embed, avatar_url=target.display_avatar.url)
-
-        embed.add_field(
-            name="現金", value=amount_code(amount=portfolio.balance, compact=True), inline=True
-        )
-        embed.add_field(
-            name="股票淨值",
-            value=(
-                f"估值 {amount_code(amount=stock_portfolio.equity_value, compact=True)}\n"
-                f"未實現 "
-                f"{amount_code(amount=stock_portfolio.unrealized_pnl, signed=True, compact=True)}\n"
-                f"已實現 "
-                f"{amount_code(amount=stock_portfolio.realized_pnl, signed=True, compact=True)}"
-            ),
-            inline=True,
-        )
-        embed.add_field(
-            name="債務",
-            value=_debt_summary_text(
-                principal=portfolio.debt_principal, interest=portfolio.debt_interest
-            ),
-            inline=True,
-        )
-        embed.add_field(
-            name="股票部位",
-            value=_stock_position_lines(stock_portfolio=stock_portfolio),
-            inline=False,
-        )
-        embed.add_field(name="會員狀態", value=_vip_status_text(is_vip=is_vip), inline=False)
-
-        vip_badge = " · 👑 VIP" if is_vip else ""
-        embed.set_footer(text=f"帳號 {age_days} 天{vip_badge}")
-        await _send_private_followup(interaction=interaction, embed=embed)
+        await send_private_followup(interaction=interaction, embed=embed)
 
     @nextcord.slash_command(
         name="leaderboard",
@@ -936,25 +309,18 @@ class EconomyCogs(commands.Cog):
         await interaction.response.defer()
         rows = await top_n(limit=10)
         if not rows:
-            embed = Embed(
+            embed = embeds.build_simple_embed(
                 title=f"🏆 {CURRENCY_NAME} Top 10",
                 description="### 尚未開張\n/games blackjack 或 /games dragon_gate 開局就會上榜",
-                color=_LEADERBOARD_COLOR,
+                color=embeds.LEADERBOARD_COLOR,
             )
-            await _send_expiring_followup(interaction=interaction, embed=embed)
+            await send_expiring_followup(interaction=interaction, embed=embed)
             return
 
         champion = rows[0]
         board = build_balance_leaderboard_board_image(rows=rows)
-        embed = Embed(
-            title=f"🏆 {CURRENCY_NAME} Top 10",
-            description="### 公開排行榜\n依可用餘額排序。",
-            color=_LEADERBOARD_COLOR,
-        )
-        embed.set_author(name="目前第一名", icon_url=champion.avatar_url or None)
-        _set_optional_thumbnail(embed=embed, avatar_url=champion.avatar_url)
-        embed.set_image(url=f"attachment://{BALANCE_LEADERBOARD_BOARD_FILENAME}")
-        await _send_expiring_followup(
+        embed = embeds.build_leaderboard_embed(champion=champion)
+        await send_expiring_followup(
             interaction=interaction,
             embed=embed,
             file=nextcord.File(fp=BytesIO(board), filename=BALANCE_LEADERBOARD_BOARD_FILENAME),
@@ -979,26 +345,18 @@ class EconomyCogs(commands.Cog):
         await interaction.response.defer()
         rows = await top_losers(limit=10)
         if not rows:
-            embed = Embed(
+            embed = embeds.build_simple_embed(
                 title=f"💸 今日輸局累計 {CURRENCY_NAME}",
                 description="### 今天還沒有人輸錢\n/games blackjack 或 /games dragon_gate 開局就可能進榜",
-                color=_LOSS_LEADERBOARD_COLOR,
+                color=embeds.LOSS_LEADERBOARD_COLOR,
             )
-            await _send_expiring_followup(interaction=interaction, embed=embed)
+            await send_expiring_followup(interaction=interaction, embed=embed)
             return
 
         champion = rows[0]
         board = build_loss_leaderboard_board_image(rows=rows)
-        embed = Embed(
-            title=f"💸 今日輸局累計 {CURRENCY_NAME}",
-            description="### 今日累計輸排序\n以 gross loss 排名，贏回來不抵扣。",
-            color=_LOSS_LEADERBOARD_COLOR,
-        )
-        embed.set_author(name="今日累計輸最多", icon_url=champion.avatar_url or None)
-        _set_optional_thumbnail(embed=embed, avatar_url=champion.avatar_url)
-        embed.set_image(url=f"attachment://{LOSS_LEADERBOARD_BOARD_FILENAME}")
-        embed.set_footer(text="今日實際輸掉累計 | 贏回來不抵扣 | 每天 0:00 (Asia/Taipei) 重置")
-        await _send_expiring_followup(
+        embed = embeds.build_loss_leaderboard_embed(champion=champion)
+        await send_expiring_followup(
             interaction=interaction,
             embed=embed,
             file=nextcord.File(fp=BytesIO(board), filename=LOSS_LEADERBOARD_BOARD_FILENAME),
@@ -1055,9 +413,15 @@ class EconomyCogs(commands.Cog):
         sender_avatar_url = await guild_avatar_url(user=sender, guild=guild)
 
         if member.id == sender.id:
-            embed = Embed(title="轉帳失敗", description="### 不能轉給自己", color=_ERROR_COLOR)
-            embed.set_author(name=sender.display_name, icon_url=sender_avatar_url)
-            await _send_expiring_followup(interaction=interaction, embed=embed)
+            await send_expiring_followup(
+                interaction=interaction,
+                embed=embeds.build_error_embed(
+                    title="轉帳失敗",
+                    description="### 不能轉給自己",
+                    author_name=sender.display_name,
+                    author_icon_url=sender_avatar_url,
+                ),
+            )
             return
 
         receiver_avatar_url = await guild_avatar_url(user=member, guild=guild)
@@ -1072,37 +436,30 @@ class EconomyCogs(commands.Cog):
         )
         if transfer_result is None:
             balance_now = await get_balance(user_id=sender.id)
-            embed = Embed(
-                title="轉帳失敗",
-                description=(
-                    f"### 餘額不足\n"
-                    f"目前 {bold_currency(amount=balance_now, compact=True)}\n"
-                    f"想轉 {bold_currency(amount=amount, compact=True)}"
+            await send_expiring_followup(
+                interaction=interaction,
+                embed=embeds.build_transfer_insufficient_embed(
+                    sender_name=sender.display_name,
+                    sender_avatar_url=sender_avatar_url,
+                    balance_now=balance_now,
+                    amount=amount,
                 ),
-                color=_ERROR_COLOR,
             )
-            embed.set_author(name=sender.display_name, icon_url=sender_avatar_url)
-            await _send_expiring_followup(interaction=interaction, embed=embed)
             return
 
-        embed = Embed(
-            title="💸 轉帳完成",
-            description=f"### {currency_text(amount=amount, compact=True)}\n{sender.mention} → {member.mention}",
-            color=_TRANSFER_COLOR,
-        )
-        embed.set_author(name=sender.display_name, icon_url=sender_avatar_url)
-        _set_optional_thumbnail(embed=embed, avatar_url=receiver_avatar_url)
-        embed.add_field(
-            name="轉帳後餘額",
-            value=(
-                f"**{sender.display_name}** "
-                f"{amount_code(amount=transfer_result.sender_balance, compact=True)}\n"
-                f"**{member.display_name}** "
-                f"{amount_code(amount=transfer_result.receiver_balance, compact=True)}"
+        embed = embeds.build_transfer_embed(
+            amount=amount,
+            sender=embeds.TransferParticipant(
+                mention=sender.mention, display_name=sender.display_name
             ),
-            inline=False,
+            sender_avatar_url=sender_avatar_url,
+            receiver=embeds.TransferParticipant(
+                mention=member.mention, display_name=member.display_name
+            ),
+            receiver_avatar_url=receiver_avatar_url,
+            result=transfer_result,
         )
-        await _send_expiring_followup(interaction=interaction, embed=embed)
+        await send_expiring_followup(interaction=interaction, embed=embed)
 
     @nextcord.slash_command(
         name="casino",
@@ -1118,32 +475,8 @@ class EconomyCogs(commands.Cog):
         """Shows the casino system's accumulated P&L (was `/house`)."""
         await interaction.response.defer()
         snapshot = await get_casino_ledger()
-        balance = snapshot.balance
-        total_earned = snapshot.total_earned
-        total_spent = snapshot.total_spent
-
-        if balance > 0:
-            verdict = rf"\+ {bold_currency(amount=balance, compact=True)}"
-            color = _BALANCE_COLOR
-        elif balance < 0:
-            verdict = rf"\- {bold_currency(amount=abs(balance), compact=True)}"
-            color = _ERROR_COLOR
-        else:
-            verdict = "⚖️ 打平"
-            color = _CASINO_COLOR
-
-        embed = Embed(title="🎰 賭場戰績", description=f"## {verdict}", color=color)
-        embed.set_author(name="賭場系統")
-        embed.add_field(
-            name="流水",
-            value=(
-                f"贏到 {amount_code(amount=total_earned, compact=True)}\n"
-                f"賠出 {amount_code(amount=total_spent, compact=True)}"
-            ),
-            inline=False,
-        )
-        embed.set_footer(text="跨伺服器累積 | 賭場資金無上限")
-        await _send_expiring_followup(interaction=interaction, embed=embed)
+        embed = embeds.build_casino_embed(snapshot=snapshot)
+        await send_expiring_followup(interaction=interaction, embed=embed)
 
     @nextcord.slash_command(
         name="pocat",
@@ -1159,10 +492,12 @@ class EconomyCogs(commands.Cog):
         """Shows the bot player's `user_wallet` balance and gross flows."""
         await interaction.response.defer()
         if self.bot.user is None:
-            embed = Embed(
-                title="❌ 無法查詢", description="目前無法取得機器人身份", color=_ERROR_COLOR
+            await send_expiring_followup(
+                interaction=interaction,
+                embed=embeds.build_error_embed(
+                    title="❌ 無法查詢", description="目前無法取得機器人身份"
+                ),
             )
-            await _send_expiring_followup(interaction=interaction, embed=embed)
             return
 
         bot_user = self.bot.user
@@ -1176,29 +511,14 @@ class EconomyCogs(commands.Cog):
             total_spent = account.total_spent
             name = name or account.name
 
-        if balance > 0:
-            verdict = rf"{bold_currency(amount=balance, compact=True)}"
-            color = _BALANCE_COLOR
-        elif balance < 0:
-            verdict = rf"\- {bold_currency(amount=abs(balance), compact=True)}"
-            color = _ERROR_COLOR
-        else:
-            verdict = "餘額 0"
-            color = _CASINO_COLOR
-
-        embed = Embed(title="🐱 破貓戰績", description=f"## {verdict}", color=color)
-        embed.set_author(name=name, icon_url=bot_user.display_avatar.url)
-        _set_optional_thumbnail(embed=embed, avatar_url=bot_user.display_avatar.url)
-        embed.add_field(
-            name="流水",
-            value=(
-                f"贏到 {amount_code(amount=total_earned, compact=True)}\n"
-                f"賠出 {amount_code(amount=total_spent, compact=True)}"
-            ),
-            inline=False,
+        embed = embeds.build_pocat_embed(
+            name=name,
+            avatar_url=bot_user.display_avatar.url,
+            balance=balance,
+            total_earned=total_earned,
+            total_spent=total_spent,
         )
-        embed.set_footer(text="bot 玩家錢包")
-        await _send_expiring_followup(interaction=interaction, embed=embed)
+        await send_expiring_followup(interaction=interaction, embed=embed)
 
     @nextcord.slash_command(
         name="credit",
@@ -1276,14 +596,26 @@ class EconomyCogs(commands.Cog):
         user_avatar_url = await guild_avatar_url(user=user, guild=guild)
         lender_avatar_url = await guild_avatar_url(user=member, guild=guild)
         if member.bot:
-            embed = Embed(title="借款失敗", description="### 不能向 bot 借款", color=_ERROR_COLOR)
-            embed.set_author(name=user.display_name, icon_url=user_avatar_url)
-            await _send_expiring_followup(interaction=interaction, embed=embed)
+            await send_expiring_followup(
+                interaction=interaction,
+                embed=embeds.build_error_embed(
+                    title="借款失敗",
+                    description="### 不能向 bot 借款",
+                    author_name=user.display_name,
+                    author_icon_url=user_avatar_url,
+                ),
+            )
             return
         if member.id == user.id:
-            embed = Embed(title="借款失敗", description="### 不能向自己借款", color=_ERROR_COLOR)
-            embed.set_author(name=user.display_name, icon_url=user_avatar_url)
-            await _send_expiring_followup(interaction=interaction, embed=embed)
+            await send_expiring_followup(
+                interaction=interaction,
+                embed=embeds.build_error_embed(
+                    title="借款失敗",
+                    description="### 不能向自己借款",
+                    author_name=user.display_name,
+                    author_icon_url=user_avatar_url,
+                ),
+            )
             return
 
         monthly_rate_bps = monthly_rate_percent_to_bps(monthly_rate_percent=monthly_rate_percent)
@@ -1298,28 +630,26 @@ class EconomyCogs(commands.Cog):
             monthly_rate_bps=monthly_rate_bps,
         )
         if proposal is None:
-            embed = Embed(title="借款失敗", description="### 無法建立借款申請", color=_ERROR_COLOR)
-            embed.set_author(name=user.display_name, icon_url=user_avatar_url)
-            await _send_expiring_followup(interaction=interaction, embed=embed)
+            await send_expiring_followup(
+                interaction=interaction,
+                embed=embeds.build_error_embed(
+                    title="借款失敗",
+                    description="### 無法建立借款申請",
+                    author_name=user.display_name,
+                    author_icon_url=user_avatar_url,
+                ),
+            )
             return
 
-        embed = Embed(
-            title="💴 信貸申請已建立",
-            description=(
-                f"### {user.mention} → {member.mention}\n"
-                f"{currency_text(amount=amount, compact=True)}"
+        embed = embeds.build_credit_request_embed(
+            borrower=embeds.LoanParty(
+                mention=user.mention, display_name=user.display_name, avatar_url=user_avatar_url
             ),
-            color=_BORROW_COLOR,
+            lender=embeds.LoanParty(mention=member.mention, avatar_url=lender_avatar_url),
+            amount=amount,
+            monthly_rate_bps=monthly_rate_bps,
         )
-        embed.set_author(name=user.display_name, icon_url=user_avatar_url)
-        _set_optional_thumbnail(embed=embed, avatar_url=lender_avatar_url)
-        embed.add_field(
-            name="條款",
-            value=_loan_terms_text(amount=amount, monthly_rate_bps=monthly_rate_bps),
-            inline=False,
-        )
-        embed.set_footer(text=_credit_request_footer())
-        await _send_loan_request_followup(
+        await send_loan_request_followup(
             interaction=interaction,
             embed=embed,
             view=CreditLoanDecisionView(
@@ -1380,37 +710,27 @@ class EconomyCogs(commands.Cog):
             amount=amount,
         )
         if result is None:
-            reason = f"沒有可還給 {member.display_name} 的有效個人借款"
             await interaction.response.defer(ephemeral=True)
-            embed = Embed(title="還款失敗", description=f"### {reason}", color=_ERROR_COLOR)
-            embed.set_author(name=user.display_name, icon_url=user_avatar_url)
-            _set_optional_thumbnail(embed=embed, avatar_url=user_avatar_url)
-            await _send_private_followup(interaction=interaction, embed=embed)
+            await send_private_followup(
+                interaction=interaction,
+                embed=embeds.build_error_embed(
+                    title="還款失敗",
+                    description=f"### 沒有可還給 {member.display_name} 的有效個人借款",
+                    author_name=user.display_name,
+                    author_icon_url=user_avatar_url,
+                    thumbnail_url=user_avatar_url,
+                ),
+            )
             return
 
         await interaction.response.defer()
-        embed = Embed(
-            title="🧾 信貸還款完成",
-            description=(
-                f"### {currency_text(amount=-result.paid_amount, signed=True, compact=True)} 扣款"
-            ),
-            color=_REPAY_COLOR,
+        embed = embeds.build_credit_repay_embed(
+            actor_name=user.display_name,
+            actor_avatar_url=user_avatar_url,
+            lender_display_name=member.display_name,
+            result=result,
         )
-        embed.set_author(name=user.display_name, icon_url=user_avatar_url)
-        _set_optional_thumbnail(embed=embed, avatar_url=user_avatar_url)
-        embed.add_field(
-            name=f"還給 {member.display_name}",
-            value=_payment_summary_text(
-                paid_amount=result.paid_amount,
-                interest_paid=result.interest_paid,
-                principal_paid=result.principal_paid,
-                remaining_principal=result.remaining_principal,
-                remaining_interest=result.remaining_interest,
-                borrower_balance=result.borrower_balance,
-            ),
-            inline=False,
-        )
-        await _send_expiring_followup(interaction=interaction, embed=embed)
+        await send_expiring_followup(interaction=interaction, embed=embed)
 
     @credit.subcommand(
         name="call",
@@ -1463,37 +783,24 @@ class EconomyCogs(commands.Cog):
         )
         if result is None:
             await interaction.response.defer(ephemeral=True)
-            embed = Embed(
-                title="催收失敗",
-                description=f"### {member.display_name} 沒有欠你有效個人借款，或目前無可扣餘額",
-                color=_ERROR_COLOR,
+            await send_private_followup(
+                interaction=interaction,
+                embed=embeds.build_error_embed(
+                    title="催收失敗",
+                    description=f"### {member.display_name} 沒有欠你有效個人借款，或目前無可扣餘額",
+                    author_name=user.display_name,
+                    author_icon_url=user.display_avatar.url,
+                ),
             )
-            embed.set_author(name=user.display_name, icon_url=user.display_avatar.url)
-            await _send_private_followup(interaction=interaction, embed=embed)
             return
         await interaction.response.defer()
-        embed = Embed(
-            title="📣 信貸催收完成",
-            description=(
-                f"### 從 {member.mention} 回收 "
-                f"{currency_text(amount=result.paid_amount, compact=True)}"
-            ),
-            color=_REPAY_COLOR,
+        embed = embeds.build_credit_call_embed(
+            actor_name=user.display_name,
+            actor_avatar_url=user.display_avatar.url,
+            borrower_mention=member.mention,
+            result=result,
         )
-        embed.set_author(name=user.display_name, icon_url=user.display_avatar.url)
-        embed.add_field(
-            name="回收明細",
-            value=_payment_summary_text(
-                paid_amount=result.paid_amount,
-                interest_paid=result.interest_paid,
-                principal_paid=result.principal_paid,
-                remaining_principal=result.remaining_principal,
-                remaining_interest=result.remaining_interest,
-                borrower_balance=result.borrower_balance,
-            ),
-            inline=False,
-        )
-        await _send_expiring_followup(interaction=interaction, embed=embed)
+        await send_expiring_followup(interaction=interaction, embed=embed)
 
     @credit.subcommand(
         name="status",
@@ -1515,22 +822,15 @@ class EconomyCogs(commands.Cog):
             if contract.lender_type == LoanLenderType.USER
         ]
         if not contracts:
-            embed = Embed(
-                title="信貸狀態", description="### 目前沒有有效信貸", color=_BORROW_COLOR
+            embed = embeds.build_simple_embed(
+                title="信貸狀態", description="### 目前沒有有效信貸", color=embeds.BORROW_COLOR
             )
-            await _send_private_followup(interaction=interaction, embed=embed)
+            await send_private_followup(interaction=interaction, embed=embed)
             return
-        lines = [
-            (
-                f"{'欠 ' + contract.lender_name if contract.borrower_id == interaction.user.id else contract.borrower_name + ' 欠你'} "
-                f"本金 {amount_code(amount=contract.principal_remaining, compact=True)} · "
-                f"利息 {amount_code(amount=contract.interest_due, compact=True)} · "
-                f"{_rate_text(monthly_rate_bps=contract.monthly_rate_bps)}"
-            )
-            for contract in contracts[:10]
-        ]
-        embed = Embed(title="信貸狀態", description="\n".join(lines), color=_BORROW_COLOR)
-        await _send_private_followup(interaction=interaction, embed=embed)
+        embed = embeds.build_credit_status_embed(
+            contracts=contracts, viewer_id=interaction.user.id
+        )
+        await send_private_followup(interaction=interaction, embed=embed)
 
     @nextcord.slash_command(
         name="central_bank",
@@ -1599,24 +899,21 @@ class EconomyCogs(commands.Cog):
             monthly_rate_bps=monthly_rate_bps,
         )
         if proposal is None:
-            embed = Embed(
-                title="央行借款失敗", description="### 無法建立央行借款申請", color=_ERROR_COLOR
+            await send_expiring_followup(
+                interaction=interaction,
+                embed=embeds.build_error_embed(
+                    title="央行借款失敗", description="### 無法建立央行借款申請"
+                ),
             )
-            await _send_expiring_followup(interaction=interaction, embed=embed)
             return
-        embed = Embed(
-            title="🏛️ 央行借款申請已建立",
-            description=f"### {user.mention}\n{currency_text(amount=amount, compact=True)}",
-            color=_CENTRAL_BANK_COLOR,
+        embed = embeds.build_central_bank_request_embed(
+            borrower=embeds.LoanParty(
+                mention=user.mention, display_name=user.display_name, avatar_url=user_avatar_url
+            ),
+            amount=amount,
+            monthly_rate_bps=monthly_rate_bps,
         )
-        embed.set_author(name=user.display_name, icon_url=user_avatar_url)
-        embed.add_field(
-            name="條款",
-            value=_loan_terms_text(amount=amount, monthly_rate_bps=monthly_rate_bps),
-            inline=False,
-        )
-        embed.set_footer(text=_central_bank_request_footer())
-        await _send_loan_request_followup(
+        await send_loan_request_followup(
             interaction=interaction,
             embed=embed,
             view=CentralBankLoanDecisionView(
@@ -1663,32 +960,21 @@ class EconomyCogs(commands.Cog):
         )
         if result is None:
             await interaction.response.defer(ephemeral=True)
-            embed = Embed(
-                title="央行還款失敗",
-                description="### 沒有有效央行借款，或目前無可扣餘額",
-                color=_ERROR_COLOR,
+            await send_private_followup(
+                interaction=interaction,
+                embed=embeds.build_error_embed(
+                    title="央行還款失敗", description="### 沒有有效央行借款，或目前無可扣餘額"
+                ),
             )
-            await _send_private_followup(interaction=interaction, embed=embed)
             return
         await interaction.response.defer()
-        embed = Embed(
-            title="🏛️ 央行還款完成",
-            description=(
-                f"### {user.mention}\n"
-                + _payment_summary_text(
-                    paid_amount=result.paid_amount,
-                    interest_paid=result.interest_paid,
-                    principal_paid=result.principal_paid,
-                    remaining_principal=result.remaining_principal,
-                    remaining_interest=result.remaining_interest,
-                    borrower_balance=result.borrower_balance,
-                )
-            ),
-            color=_CENTRAL_BANK_COLOR,
+        embed = embeds.build_central_bank_repay_embed(
+            actor_name=user.display_name,
+            actor_avatar_url=user_avatar_url,
+            user_mention=user.mention,
+            result=result,
         )
-        embed.set_author(name=user.display_name, icon_url=user_avatar_url)
-        _set_optional_thumbnail(embed=embed, avatar_url=user_avatar_url)
-        await _send_expiring_followup(interaction=interaction, embed=embed)
+        await send_expiring_followup(interaction=interaction, embed=embed)
 
     @central_bank.subcommand(
         name="call",
@@ -1730,12 +1016,12 @@ class EconomyCogs(commands.Cog):
             return
         if not await get_central_banker(user_id=interaction.user.id):
             await interaction.response.defer(ephemeral=True)
-            embed = Embed(
-                title="權限不足",
-                description="### 只有央行成員可以執行央行催收",
-                color=_ERROR_COLOR,
+            await send_private_followup(
+                interaction=interaction,
+                embed=embeds.build_error_embed(
+                    title="權限不足", description="### 只有央行成員可以執行央行催收"
+                ),
             )
-            await _send_private_followup(interaction=interaction, embed=embed)
             return
         borrower_avatar_url = await guild_avatar_url(
             user=member, guild=getattr(interaction, "guild", None)
@@ -1748,34 +1034,22 @@ class EconomyCogs(commands.Cog):
         )
         if result is None:
             await interaction.response.defer(ephemeral=True)
-            embed = Embed(
-                title="央行催收失敗",
-                description="### 目標沒有有效央行借款，或目前無可扣餘額",
-                color=_ERROR_COLOR,
+            await send_private_followup(
+                interaction=interaction,
+                embed=embeds.build_error_embed(
+                    title="央行催收失敗", description="### 目標沒有有效央行借款，或目前無可扣餘額"
+                ),
             )
-            await _send_private_followup(interaction=interaction, embed=embed)
             return
         await interaction.response.defer()
-        embed = Embed(
-            title="🏛️ 央行催收完成",
-            description=(
-                f"### 從 {member.mention} 回收\n"
-                + _payment_summary_text(
-                    paid_amount=result.paid_amount,
-                    interest_paid=result.interest_paid,
-                    principal_paid=result.principal_paid,
-                    remaining_principal=result.remaining_principal,
-                    remaining_interest=result.remaining_interest,
-                    borrower_balance=result.borrower_balance,
-                )
-            ),
-            color=_CENTRAL_BANK_COLOR,
+        embed = embeds.build_central_bank_call_embed(
+            actor_name=interaction.user.display_name,
+            actor_avatar_url=interaction.user.display_avatar.url,
+            borrower_mention=member.mention,
+            borrower_avatar_url=borrower_avatar_url,
+            result=result,
         )
-        embed.set_author(
-            name=interaction.user.display_name, icon_url=interaction.user.display_avatar.url
-        )
-        _set_optional_thumbnail(embed=embed, avatar_url=borrower_avatar_url)
-        await _send_expiring_followup(interaction=interaction, embed=embed)
+        await send_expiring_followup(interaction=interaction, embed=embed)
 
     @central_bank.subcommand(
         name="status",
@@ -1791,21 +1065,8 @@ class EconomyCogs(commands.Cog):
         await interaction.response.defer()
         exclude_user_ids = (self.bot.user.id,) if self.bot.user else ()
         status = await get_central_bank_status(exclude_user_ids=exclude_user_ids)
-        embed = Embed(
-            title="🏛️ 中央銀行狀態",
-            description=f"## 可放貸 {bold_currency(amount=status.available_credit, compact=True)}",
-            color=_CENTRAL_BANK_COLOR,
-        )
-        embed.add_field(
-            name="資金池",
-            value=(
-                f"全體正餘額 "
-                f"{amount_code(amount=status.total_positive_user_balance, compact=True)}\n"
-                f"未還本金 {amount_code(amount=status.outstanding_principal, compact=True)}"
-            ),
-            inline=False,
-        )
-        await _send_expiring_followup(interaction=interaction, embed=embed)
+        embed = embeds.build_central_bank_status_embed(status=status)
+        await send_expiring_followup(interaction=interaction, embed=embed)
 
     @nextcord.slash_command(
         name="checkin",
@@ -1838,41 +1099,21 @@ class EconomyCogs(commands.Cog):
         )
         result = await checkin(user_id=user.id, name=user.name, avatar_url=user_avatar_url)
         if result is None:
-            embed = Embed(
-                title="今天已經簽到過了",
-                description="### 0:00 (Asia/Taipei) 後再回來簽吧",
-                color=_ERROR_COLOR,
+            await send_private_followup(
+                interaction=interaction,
+                embed=embeds.build_error_embed(
+                    title="今天已經簽到過了",
+                    description="### 0:00 (Asia/Taipei) 後再回來簽吧",
+                    author_name=user.display_name,
+                    author_icon_url=user_avatar_url,
+                ),
             )
-            embed.set_author(name=user.display_name, icon_url=user_avatar_url)
-            await _send_private_followup(interaction=interaction, embed=embed)
             return
 
-        vip_badge = " · 👑 VIP 2x" if result.is_vip else ""
-        embed = Embed(
-            title="📅 每日簽到",
-            description=f"## {currency_text(amount=result.amount, signed=True, compact=True)} 入帳",
-            color=_CHECKIN_COLOR,
+        embed = embeds.build_checkin_embed(
+            actor_name=user.display_name, avatar_url=user_avatar_url, result=result
         )
-        embed.set_author(name=f"{user.display_name} 的簽到", icon_url=user_avatar_url)
-        _set_optional_thumbnail(embed=embed, avatar_url=user_avatar_url)
-        embed.add_field(name="連續簽到", value=f"第 {result.streak} / 7 天", inline=True)
-        embed.add_field(
-            name="目前餘額",
-            value=amount_code(amount=result.new_balance, compact=True),
-            inline=True,
-        )
-        if result.is_vip:
-            base_reward = checkin_reward(streak=result.streak, is_vip=False)
-            embed.add_field(
-                name="👑 VIP加成",
-                value=(
-                    f"本日簽到 {amount_code(amount=base_reward, compact=True)} → "
-                    f"{amount_code(amount=result.amount, compact=True)}"
-                ),
-                inline=False,
-            )
-        embed.set_footer(text=f"連續 7 天為一個 cycle | 每天 0:00 (Asia/Taipei) 重置{vip_badge}")
-        await _send_private_followup(interaction=interaction, embed=embed)
+        await send_private_followup(interaction=interaction, embed=embed)
 
     @nextcord.slash_command(
         name="vip",
@@ -1902,50 +1143,31 @@ class EconomyCogs(commands.Cog):
         )
         already_vip = await get_vip(user_id=user.id)
         if already_vip:
-            embed = Embed(
-                title="已經是 VIP",
-                description="### 你已經擁有永久 VIP 了, 不用再買一次",
-                color=_VIP_COLOR,
+            await send_private_followup(
+                interaction=interaction,
+                embed=embeds.build_vip_already_embed(
+                    actor_name=user.display_name, avatar_url=user_avatar_url
+                ),
             )
-            embed.set_author(name=user.display_name, icon_url=user_avatar_url)
-            embed.add_field(name="👑 VIP加成", value=_vip_perk_lines(), inline=False)
-            await _send_private_followup(interaction=interaction, embed=embed)
             return
 
         result = await buy_vip(user_id=user.id, name=user.name, avatar_url=user_avatar_url)
         if result is None:
             balance_now = await get_balance(user_id=user.id)
-            embed = Embed(
-                title="VIP 購買失敗",
-                description=(
-                    f"### 餘額不足\n"
-                    f"目前 {bold_currency(amount=balance_now, compact=True)}\n"
-                    f"需要 {bold_currency(amount=VIP_PURCHASE_COST, compact=True)}"
+            await send_private_followup(
+                interaction=interaction,
+                embed=embeds.build_vip_insufficient_embed(
+                    actor_name=user.display_name,
+                    avatar_url=user_avatar_url,
+                    balance_now=balance_now,
                 ),
-                color=_ERROR_COLOR,
             )
-            embed.set_author(name=user.display_name, icon_url=user_avatar_url)
-            embed.add_field(name="👑 VIP權益", value=_vip_perk_lines(), inline=False)
-            await _send_private_followup(interaction=interaction, embed=embed)
             return
 
-        embed = Embed(
-            title="👑 升級 VIP 成功",
-            description=(
-                f"### {currency_text(amount=-result.cost, signed=True, compact=True)} 扣款\n"
-                "簽到與 Blackjack 贏局加成已生效"
-            ),
-            color=_VIP_COLOR,
+        embed = embeds.build_vip_success_embed(
+            actor_name=user.display_name, avatar_url=user_avatar_url, result=result
         )
-        embed.set_author(name=user.display_name, icon_url=user_avatar_url)
-        _set_optional_thumbnail(embed=embed, avatar_url=user_avatar_url)
-        embed.add_field(name="👑 VIP加成", value=_vip_perk_lines(), inline=False)
-        embed.add_field(
-            name="目前餘額",
-            value=amount_code(amount=result.new_balance, compact=True),
-            inline=False,
-        )
-        await _send_private_followup(interaction=interaction, embed=embed)
+        await send_private_followup(interaction=interaction, embed=embed)
 
 
 def setup(bot: commands.Bot) -> None:

--- a/tests/test_cogs_smoke.py
+++ b/tests/test_cogs_smoke.py
@@ -16,6 +16,7 @@ from discordbot.cogs import games, video, economy, template, auto_unmute, parse_
 from discordbot.cogs.games import GamesCogs
 from discordbot.cogs.video import VideoCogs
 from discordbot.cogs.economy import EconomyCogs
+from discordbot.cogs._economy import views, interactions
 from discordbot.cogs.template import TemplateCogs
 from discordbot.typings.games import GameParticipant
 from discordbot.typings.stock import StockPortfolioView, StockPortfolioHolding
@@ -42,6 +43,7 @@ from discordbot.cogs.auto_unmute import AutoUnmuteCogs
 from discordbot.cogs._games.dealer import SystemNarrator
 from discordbot.cogs._games.wagers import parse_wager_amount
 from discordbot.cogs.parse_threads import ThreadsCogs
+from discordbot.cogs._economy.views import CreditLoanDecisionView, CentralBankLoanDecisionView
 from discordbot.utils.discord_embeds import DEFAULT_EMBED_SPACER_FILENAME, embed_spacer_url
 from discordbot.cogs._economy.database import (
     VIP_PURCHASE_COST,
@@ -596,7 +598,7 @@ async def test_economy_commands_use_database_facade(  # noqa: PLR0915 -- command
         """Records public cleanup scheduling from economy commands."""
         scheduled.append(message)
 
-    monkeypatch.setattr(economy, "schedule_public_message_delete", record_scheduled)
+    monkeypatch.setattr(interactions, "schedule_public_message_delete", record_scheduled)
     monkeypatch.setattr(economy, "get_balance", fake_get_balance)
     monkeypatch.setattr(economy, "get_vip", fake_get_vip)
     monkeypatch.setattr(economy, "get_admin", fake_get_admin)
@@ -615,9 +617,6 @@ async def test_economy_commands_use_database_facade(  # noqa: PLR0915 -- command
         economy, "create_central_bank_loan_request", fake_create_central_bank_request
     )
     monkeypatch.setattr(economy, "get_central_banker", fake_get_central_banker)
-    monkeypatch.setattr(economy, "accept_loan_proposal", fake_accept_loan_proposal)
-    monkeypatch.setattr(economy, "reject_loan_proposal", fake_reject_loan_proposal)
-    monkeypatch.setattr(economy, "cancel_loan_proposal", fake_cancel_loan_proposal)
     monkeypatch.setattr(economy, "list_loan_contracts", fake_list_loan_contracts)
     monkeypatch.setattr(economy, "get_central_bank_status", fake_get_central_bank_status)
     monkeypatch.setattr(economy, "repay_central_bank_loans", fake_loan_payment)
@@ -700,11 +699,11 @@ async def test_economy_commands_use_database_facade(  # noqa: PLR0915 -- command
     borrow_embed = interaction.followup.sent[8]["embed"]
     assert borrow_embed.footer.text == "貸方可用下方按鈕批准或拒絕，發起者可取消，180 秒後自動拒絕"
     borrow_view = interaction.followup.sent[8]["view"]
-    assert isinstance(borrow_view, economy.CreditLoanDecisionView)
+    assert isinstance(borrow_view, CreditLoanDecisionView)
     assert borrow_view.message is not None
     central_bank_payload = interaction.followup.sent[12]
     central_bank_view = central_bank_payload["view"]
-    assert isinstance(central_bank_view, economy.CentralBankLoanDecisionView)
+    assert isinstance(central_bank_view, CentralBankLoanDecisionView)
     assert central_bank_view.message is not None
 
     inspected_member = FakeInteraction(user=FakeUser(user_id=1))
@@ -741,10 +740,10 @@ async def test_central_bank_decision_buttons_require_banker_and_allow_self_appro
         captured_cancel_kwargs.update({"proposal_id": proposal_id, "actor_id": actor_id})
         return await fake_cancel_loan_proposal(proposal_id=proposal_id, actor_id=actor_id)
 
-    monkeypatch.setattr(economy, "get_central_banker", fake_get_central_banker_for_button)
-    monkeypatch.setattr(economy, "accept_loan_proposal", fake_accept_for_button)
-    monkeypatch.setattr(economy, "cancel_loan_proposal", fake_cancel_for_button)
-    view = economy.CentralBankLoanDecisionView(
+    monkeypatch.setattr(views, "get_central_banker", fake_get_central_banker_for_button)
+    monkeypatch.setattr(views, "accept_loan_proposal", fake_accept_for_button)
+    monkeypatch.setattr(views, "cancel_loan_proposal", fake_cancel_for_button)
+    view = CentralBankLoanDecisionView(
         bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")),
         proposal_id=42,
         creator_id=1,
@@ -768,7 +767,7 @@ async def test_central_bank_decision_buttons_require_banker_and_allow_self_appro
     assert captured_accept_kwargs["allow_central_bank_self_approval"] is True
     assert allowed.response.edited[0]["view"] is None
 
-    cancel_view = economy.CentralBankLoanDecisionView(
+    cancel_view = CentralBankLoanDecisionView(
         bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")),
         proposal_id=43,
         creator_id=1,
@@ -812,10 +811,10 @@ async def test_credit_decision_buttons_gate_lender_and_creator(
         captured_cancel_kwargs.update({"proposal_id": proposal_id, "actor_id": actor_id})
         return await fake_cancel_loan_proposal(proposal_id=proposal_id, actor_id=actor_id)
 
-    monkeypatch.setattr(economy, "accept_loan_proposal", fake_accept_for_button)
-    monkeypatch.setattr(economy, "reject_loan_proposal", fake_reject_for_button)
-    monkeypatch.setattr(economy, "cancel_loan_proposal", fake_cancel_for_button)
-    view = economy.CreditLoanDecisionView(proposal_id=42, lender_id=2, creator_id=1)
+    monkeypatch.setattr(views, "accept_loan_proposal", fake_accept_for_button)
+    monkeypatch.setattr(views, "reject_loan_proposal", fake_reject_for_button)
+    monkeypatch.setattr(views, "cancel_loan_proposal", fake_cancel_for_button)
+    view = CreditLoanDecisionView(proposal_id=42, lender_id=2, creator_id=1)
     approve_button = next(
         child for child in view.children if getattr(child, "custom_id", "") == "credit:approve"
     )
@@ -831,7 +830,7 @@ async def test_credit_decision_buttons_gate_lender_and_creator(
     assert captured_accept_kwargs["actor_id"] == 2
     assert allowed_approve.response.edited[0]["view"] is None
 
-    reject_view = economy.CreditLoanDecisionView(proposal_id=43, lender_id=2, creator_id=1)
+    reject_view = CreditLoanDecisionView(proposal_id=43, lender_id=2, creator_id=1)
     reject_button = next(
         child
         for child in reject_view.children
@@ -847,7 +846,7 @@ async def test_credit_decision_buttons_gate_lender_and_creator(
     assert captured_reject_kwargs == {"proposal_id": 43, "actor_id": 2}
     assert allowed_reject.response.edited[0]["view"] is None
 
-    cancel_view = economy.CreditLoanDecisionView(proposal_id=44, lender_id=2, creator_id=1)
+    cancel_view = CreditLoanDecisionView(proposal_id=44, lender_id=2, creator_id=1)
     cancel_button = next(
         child
         for child in cancel_view.children
@@ -885,16 +884,16 @@ async def test_loan_decision_timeout_rejects_and_schedules_cleanup(
         del delay, user_name
         scheduled.append(message)
 
-    monkeypatch.setattr(economy, "reject_expired_loan_proposal", fake_reject_expired_loan_proposal)
-    monkeypatch.setattr(economy, "schedule_public_message_delete", record_scheduled)
+    monkeypatch.setattr(views, "reject_expired_loan_proposal", fake_reject_expired_loan_proposal)
+    monkeypatch.setattr(views, "schedule_public_message_delete", record_scheduled)
 
     credit_message = FakeDiscordMessage()
-    credit_view = economy.CreditLoanDecisionView(proposal_id=42, lender_id=2, creator_id=1)
+    credit_view = CreditLoanDecisionView(proposal_id=42, lender_id=2, creator_id=1)
     credit_view.message = credit_message
     await credit_view.on_timeout()
 
     central_message = FakeDiscordMessage()
-    central_view = economy.CentralBankLoanDecisionView(
+    central_view = CentralBankLoanDecisionView(
         bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")),
         proposal_id=43,
         creator_id=1,
@@ -963,7 +962,9 @@ async def test_economy_admin_tax_accepts_string_amounts(monkeypatch: pytest.Monk
 
     monkeypatch.setattr(economy, "get_admin", fake_get_admin)
     monkeypatch.setattr(economy, "adjust_balance", record_adjust_balance)
-    monkeypatch.setattr(economy, "schedule_public_message_delete", ignore_scheduled_public_message)
+    monkeypatch.setattr(
+        interactions, "schedule_public_message_delete", ignore_scheduled_public_message
+    )
     cog = EconomyCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
     interaction = FakeInteraction(user=FakeUser(user_id=1))
 
@@ -991,7 +992,9 @@ async def test_economy_admin_tax_allows_bot_target(monkeypatch: pytest.MonkeyPat
 
     monkeypatch.setattr(economy, "get_admin", fake_get_admin)
     monkeypatch.setattr(economy, "adjust_balance", record_adjust_balance)
-    monkeypatch.setattr(economy, "schedule_public_message_delete", ignore_scheduled_public_message)
+    monkeypatch.setattr(
+        interactions, "schedule_public_message_delete", ignore_scheduled_public_message
+    )
     cog = EconomyCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
     interaction = FakeInteraction(user=FakeUser(user_id=1))
     bot_member = FakeUser(user_id=999, name="discordbot", display_name="Dealer", bot=True)
@@ -1070,7 +1073,9 @@ async def test_give_passes_guild_avatar_urls_to_database(monkeypatch: pytest.Mon
     interaction = FakeInteraction(user=sender)
     interaction.guild = guild
     monkeypatch.setattr(economy, "transfer", record_transfer)
-    monkeypatch.setattr(economy, "schedule_public_message_delete", ignore_scheduled_public_message)
+    monkeypatch.setattr(
+        interactions, "schedule_public_message_delete", ignore_scheduled_public_message
+    )
     cog = EconomyCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
 
     await EconomyCogs.give.callback(cog, interaction, member=receiver, amount=100)
@@ -1107,7 +1112,9 @@ async def test_give_allows_bot_receiver(monkeypatch: pytest.MonkeyPatch) -> None
     bot_receiver = FakeUser(user_id=999, name="discordbot", display_name="Dealer", bot=True)
     interaction = FakeInteraction(user=sender)
     monkeypatch.setattr(economy, "transfer", record_transfer)
-    monkeypatch.setattr(economy, "schedule_public_message_delete", ignore_scheduled_public_message)
+    monkeypatch.setattr(
+        interactions, "schedule_public_message_delete", ignore_scheduled_public_message
+    )
     cog = EconomyCogs(bot=SimpleNamespace(user=bot_receiver))
 
     await EconomyCogs.give.callback(cog, interaction, member=bot_receiver, amount=100)
@@ -1142,7 +1149,7 @@ async def test_loss_leaderboard_uses_daily_loss_copy(monkeypatch: pytest.MonkeyP
         scheduled.append(message)
 
     monkeypatch.setattr(economy, "top_losers", daily_losses)
-    monkeypatch.setattr(economy, "schedule_public_message_delete", record_scheduled)
+    monkeypatch.setattr(interactions, "schedule_public_message_delete", record_scheduled)
     cog = EconomyCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
     interaction = FakeInteraction(user=FakeUser(user_id=1))
 
@@ -1173,7 +1180,7 @@ async def test_loss_leaderboard_empty_state_copy(monkeypatch: pytest.MonkeyPatch
         scheduled.append(message)
 
     monkeypatch.setattr(economy, "top_losers", no_daily_losses)
-    monkeypatch.setattr(economy, "schedule_public_message_delete", record_scheduled)
+    monkeypatch.setattr(interactions, "schedule_public_message_delete", record_scheduled)
     cog = EconomyCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
     interaction = FakeInteraction(user=FakeUser(user_id=1))
 

--- a/tests/test_game_cleanup.py
+++ b/tests/test_game_cleanup.py
@@ -9,7 +9,7 @@ import pytest
 import nextcord
 from nextcord import Message, Interaction
 
-from discordbot.cogs import economy
+from discordbot.cogs._economy import interactions
 from discordbot.utils.message_cleanup import (
     PUBLIC_MESSAGE_TTL_SECONDS,
     PendingPublicMessage,
@@ -342,14 +342,14 @@ async def test_send_expiring_followup_waits_for_message_and_schedules_cleanup(
         scheduled_user_names.append(user_name)
 
     monkeypatch.setattr(
-        target=economy,
+        target=interactions,
         name="schedule_public_message_delete",
         value=fake_schedule_public_message_delete,
     )
     interaction = _InteractionStub()
     embed = nextcord.Embed(title="balance")
 
-    await economy._send_expiring_followup(
+    await interactions.send_expiring_followup(
         interaction=cast("Interaction", interaction), embed=embed
     )
 
@@ -373,14 +373,16 @@ async def test_send_private_followup_is_ephemeral_and_not_scheduled(
         scheduled_messages.append(message)
 
     monkeypatch.setattr(
-        target=economy,
+        target=interactions,
         name="schedule_public_message_delete",
         value=fake_schedule_public_message_delete,
     )
     interaction = _InteractionStub()
     embed = nextcord.Embed(title="balance")
 
-    await economy._send_private_followup(interaction=cast("Interaction", interaction), embed=embed)
+    await interactions.send_private_followup(
+        interaction=cast("Interaction", interaction), embed=embed
+    )
 
     assert interaction.followup.sent_ephemeral is True
     assert interaction.followup.sent_embed is embed


### PR DESCRIPTION
## Summary

`economy.py` had grown to ~1.9k lines, mixing color constants, embed/text builders, send/edit interaction helpers, two loan decision views, and per-command embed assembly in a single cog file. This refactor extracts those concerns into the `_economy/` helper package, matching the convention where `stock.py` / `games.py` stay thin and delegate to sibling `_<cog>/` modules.

This is a pure structural refactor with no user-facing command or behavior change, so `help.py` is untouched.

## What moved

- `_economy/interactions.py` (new): the five send/edit interaction helpers.
- `_economy/embeds.py` (new): color constants, text fragment helpers, presentation-only payloads, and one embed builder per command.
- `_economy/views.py` (new): `CreditLoanDecisionView` and `CentralBankLoanDecisionView`.
- `economy.py`: now only slash command definitions, thin coordinators, and `setup` (1958 → 1179 lines).

`presentation.py` (shared currency formatting, imported across the repo) is intentionally left untouched to avoid an import cycle with `database.py`.

## Verification

- `uv run pre-commit run -a` (ruff format + lint, mypy): green.
- `uv run pytest`: 505 passed, coverage gate satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)