### PR TITLE
refactor: audit cleanup, perf and DB-backed state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ make gen-docs                    # regenerate docs/ from sources
 
 - `src/discordbot/cli.py` defines `DiscordBot(commands.Bot)`.
 - Intents start from `Intents.all()`, then disable `members` and `presences`.
-- Cog loading is synchronous inside `DiscordBot.__init__` before gateway connection. First `on_ready` syncs global application commands, warms the model-pricing cache off the event loop, and starts the status task.
+- Cog loading is synchronous inside `DiscordBot.__init__` before gateway connection. First `on_ready` syncs global application commands, starts the status task, and warms the model-pricing cache off the event loop.
 - The status task rotates presence lines from the `bot_status` table in `data/global_state.db` (managed offline via `scripts/manage_bot_status.py`); an empty table falls back to a built-in default.
 - Every cog module must expose sync `def setup(bot): ...` and add cogs with `override=True`. Do not use `async def setup`; nextcord schedules it without awaiting, so the first command sync can see no commands.
 - Helper packages live in sibling `_<cog>/` directories so they are not auto-loaded as cogs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,8 @@ make gen-docs                    # regenerate docs/ from sources
 
 - `src/discordbot/cli.py` defines `DiscordBot(commands.Bot)`.
 - Intents start from `Intents.all()`, then disable `members` and `presences`.
-- Cog loading is synchronous inside `DiscordBot.__init__` before gateway connection. First `on_ready` syncs global application commands and starts the status task.
+- Cog loading is synchronous inside `DiscordBot.__init__` before gateway connection. First `on_ready` syncs global application commands, warms the model-pricing cache off the event loop, and starts the status task.
+- The status task rotates presence lines from the `bot_status` table in `data/global_state.db` (managed offline via `scripts/manage_bot_status.py`); an empty table falls back to a built-in default.
 - Every cog module must expose sync `def setup(bot): ...` and add cogs with `override=True`. Do not use `async def setup`; nextcord schedules it without awaiting, so the first command sync can see no commands.
 - Helper packages live in sibling `_<cog>/` directories so they are not auto-loaded as cogs.
 - Add common command errors in `DiscordBot.on_command_error` instead of catching them in each cog.
@@ -60,7 +61,7 @@ make gen-docs                    # regenerate docs/ from sources
 
 ## Economy
 
-- SQLite files are separate: `data/messages.db` for message logs, `data/economy.db` for per-user 虛擬歡樂豆, `data/global_state.db` for bot-wide shared state such as jackpot pools, and `data/game_cleanup.db` for public message cleanup targets.
+- SQLite files are separate: `data/messages.db` for message logs, `data/economy.db` for per-user 虛擬歡樂豆, `data/global_state.db` for bot-wide shared state such as jackpot pools and bot presence rotation, and `data/game_cleanup.db` for public message cleanup targets.
 - `cogs/_economy/database.py` owns the module-level async engines `_engine` and `_global_state_engine`. Do not move them to `cached_property`; tests monkeypatch those engines and expect helpers to bind sessions directly from the current object.
 - `UserAccount` has no `guild_id`. Identity, VIP, check-ins, admin flags, central banker flags, and leaderboard visibility are cross-server by design. Spendable balances and gross totals live in `user_wallet`, which also denormalizes `name` for direct DB inspection; long-term loans live in `loan_proposal` and `loan_contract`; daily casino counters live in `casino_account`. Economy money columns are stored as decimal strings and parsed to Python `int` for arithmetic so they do not inherit SQLite's 64-bit integer ceiling.
 - `UserAccount.avatar_url` is a last-seen cache. Discord-facing write paths use `utils.avatars.guild_avatar_url(...)` with guild context so guild avatars are stored when available, falling back to global `display_avatar`. Do not backfill existing avatar URLs; they refresh naturally on later writes.
@@ -86,7 +87,7 @@ make gen-docs                    # regenerate docs/ from sources
 - `stock_news` refreshes at most once per `news_cadence_hours` per symbol. `StockNewsAI` may use the existing `AsyncOpenAI` Responses API stack when LLM config is available, but database helpers must always have deterministic fallback news and must not block settlement on LLM failure.
 - Stock news sentiment is impulse: each news contributes its `clamp(sentiment_bps, ±NEWS_SENTIMENT_LIMIT_BPS)` exactly once at its firing tick boundary inside `advance_market_in_session`, not as a decayed drift over every following tick. `_news_impulse_by_boundary` routes news that landed in skipped backlog ticks to the next surviving boundary. The decay-aware `_decayed_news_sentiment_for_context` is only fed to the AI news generation prompt as ambient sentiment.
 - Stock news generation receives `StockNewsGenerationContext` with daily price change, recent decayed order-flow pressure, and existing news sentiment. Prompts and fallback copy templates live in `src/discordbot/cogs/_stock/prompts.py`; keep generated news fictional, absurd, harmless, and broadly aligned with that market context.
-- For Discord UI that needs precise layout beyond embed and Markdown limits, render a PNG with Pillow, attach it with `File`, then reference it from the embed via `attachment://...`. Use a CJK-capable font such as Noto Sans CJK for Traditional Chinese, and keep source data typed so the image renderer stays presentation-only.
+- For Discord UI that needs precise layout beyond embed and Markdown limits, render a PNG with Pillow, attach it with `File`, then reference it from the embed via `attachment://...`. Use a CJK-capable font such as Noto Sans CJK for Traditional Chinese, and keep source data typed so the image renderer stays presentation-only. Shared font loading and text-anchoring helpers live in `utils/pil_text.py`; reuse them instead of re-implementing per renderer.
 - Market pressure uses decayed order flow and per-stock liquidity. Do not reintroduce a multi-day aggregate pressure term that applies the same directional drift on every tick.
 - Execution price uses order-size slippage from `liquidity_shares`, capped by `max_tick_change_bps`. Store and display the per-leg execution `price_cents`; do not settle large orders at the quote price.
 - Stock tables that persist `user_id` also persist `user_name`. Public stock UI should display stored names instead of Discord IDs.

--- a/scripts/manage_bot_status.py
+++ b/scripts/manage_bot_status.py
@@ -1,0 +1,89 @@
+"""Manage the bot presence rotation stored in data/global_state.db.
+
+The status task picks a random enabled line every minute; an empty table falls
+back to the built-in default. Run while the bot is stopped.
+
+Usage::
+
+    uv run python scripts/manage_bot_status.py list
+    uv run python scripts/manage_bot_status.py add "playing with fire" --order 1
+    uv run python scripts/manage_bot_status.py remove 3
+"""
+
+import asyncio
+import argparse
+from collections.abc import Sequence
+
+from rich.console import Console
+
+from discordbot.typings.economy import BotStatusEntry
+from discordbot.cogs._economy.database import (
+    add_bot_status,
+    remove_bot_status,
+    list_bot_status_rows,
+)
+
+console = Console()
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parses CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Add, remove, or list bot presence lines stored in data/global_state.db."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    add_parser = subparsers.add_parser(name="add", help="Add a presence line.")
+    add_parser.add_argument("status_text", help="The presence text to display.")
+    add_parser.add_argument(
+        "--order", type=int, default=0, help="Ascending rotation/display order hint."
+    )
+    add_parser.add_argument(
+        "--disabled", action="store_true", help="Add the line but leave it disabled."
+    )
+
+    remove_parser = subparsers.add_parser(name="remove", help="Remove a presence line by id.")
+    remove_parser.add_argument("status_id", type=int, help="The status_id to remove.")
+
+    subparsers.add_parser(name="list", help="List current presence lines.")
+    return parser.parse_args(args=argv)
+
+
+def _print_rows(rows: list[BotStatusEntry]) -> None:
+    """Prints the presence rotation rows."""
+    console.print(f"[bold]Bot statuses[/bold]: {len(rows)}")
+    for row in rows:
+        state = "enabled" if row.enabled else "disabled"
+        console.print(f"#{row.status_id} [{state}] order={row.order_index}: {row.status_text}")
+
+
+async def _async_main(argv: Sequence[str] | None = None) -> None:
+    """Runs the CLI."""
+    args = _parse_args(argv=argv)
+    if args.command == "add":
+        status_id = await add_bot_status(
+            status_text=args.status_text, order_index=args.order, enabled=not args.disabled
+        )
+        console.print(f"[bold]Added[/bold] status #{status_id}: {args.status_text}")
+    elif args.command == "remove":
+        removed = await remove_bot_status(status_id=args.status_id)
+        console.print(
+            f"[bold]Removed[/bold] status #{args.status_id}"
+            if removed
+            else f"[bold]No status #{args.status_id}[/bold]"
+        )
+    else:
+        _print_rows(rows=await list_bot_status_rows())
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Runs the bot status management CLI.
+
+    Args:
+        argv (Sequence[str] | None): Optional argument sequence to parse instead of `sys.argv`.
+    """
+    asyncio.run(main=_async_main(argv=argv))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/discordbot/cli.py
+++ b/src/discordbot/cli.py
@@ -1,6 +1,7 @@
 """Discord bot entry point and runtime event handlers."""
 
 import os
+import asyncio
 import logging
 from pathlib import Path
 import secrets
@@ -16,6 +17,7 @@ from discordbot import setup_logging
 from discordbot.utils.avatars import guild_avatar_url
 from discordbot.typings.config import DiscordConfig
 from discordbot.typings.economy import BASE_MESSAGE_REWARD_AMOUNT
+from discordbot.utils.model_pricing import warm_pricing_cache
 from discordbot.utils.discord_embeds import embed_spacer_payload
 from discordbot.cogs._economy.database import credit_with_repayment
 
@@ -86,6 +88,9 @@ class DiscordBot(commands.Bot):
 
         await self.sync_all_application_commands()
         self.status_task.start()
+        # Fetch the LiteLLM price table now, off the event loop, so the first
+        # AI reply does not stall on a synchronous network call.
+        await asyncio.to_thread(warm_pricing_cache)
 
         app_info = await self.application_info()
         invite_url = (

--- a/src/discordbot/cli.py
+++ b/src/discordbot/cli.py
@@ -19,7 +19,7 @@ from discordbot.typings.config import DiscordConfig
 from discordbot.typings.economy import BASE_MESSAGE_REWARD_AMOUNT
 from discordbot.utils.model_pricing import warm_pricing_cache
 from discordbot.utils.discord_embeds import embed_spacer_payload
-from discordbot.cogs._economy.database import credit_with_repayment
+from discordbot.cogs._economy.database import get_bot_statuses, credit_with_repayment
 
 
 class DiscordBot(commands.Bot):
@@ -110,7 +110,7 @@ class DiscordBot(commands.Bot):
     @tasks.loop(minutes=1.0)
     async def status_task(self) -> None:
         """Periodically updates the bot's game status."""
-        statuses = ["your mama"]
+        statuses = await get_bot_statuses() or ["your mama"]
         random_status = secrets.choice(statuses)
         await self.change_presence(activity=Game(random_status))
         logfire.info("Status Changed", new_status=self.activity.name)

--- a/src/discordbot/cogs/_economy/boards.py
+++ b/src/discordbot/cogs/_economy/boards.py
@@ -6,9 +6,10 @@ from typing import Final, TypedDict
 from functools import cache
 from collections.abc import Sequence
 
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageDraw
 from pydantic import BaseModel, ConfigDict
 
+from discordbot.utils.pil_text import Font, fit_text, load_font, draw_text_right, draw_text_center
 from discordbot.typings.economy import LeaderboardEntry, LossLeaderboardEntry
 from discordbot.utils.number_text import compact_amount
 from discordbot.cogs._economy.presentation import CURRENCY_NAME
@@ -34,29 +35,16 @@ _NAME_X = 128
 _AMOUNT_RIGHT = 908
 _NAME_MAX_WIDTH = 520
 _BOARD_IMAGE_CACHE_TTL_SECONDS: Final[float] = 5.0
-_REGULAR_FONT_CANDIDATES = (
-    "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
-    "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
-    "NotoSansCJK-Regular.ttc",
-    "DejaVuSans.ttf",
-)
-_BOLD_FONT_CANDIDATES = (
-    "/usr/share/fonts/opentype/noto/NotoSansCJK-Bold.ttc",
-    "/usr/share/fonts/truetype/noto/NotoSansCJK-Bold.ttc",
-    "NotoSansCJK-Bold.ttc",
-    "DejaVuSans-Bold.ttf",
-)
-type _BoardFont = ImageFont.ImageFont | ImageFont.FreeTypeFont
 
 
 class _BoardFonts(TypedDict):
     """Font set used by economy board images."""
 
-    title: _BoardFont
-    header: _BoardFont
-    rank: _BoardFont
-    body: _BoardFont
-    small: _BoardFont
+    title: Font
+    header: Font
+    rank: Font
+    body: Font
+    small: Font
 
 
 class _RankingBoardSpec(BaseModel):
@@ -173,23 +161,12 @@ def _render_ranking_board_image(spec: _RankingBoardSpec) -> bytes:
 def _board_fonts() -> _BoardFonts:
     """Loads CJK-capable fonts for ranking boards."""
     return {
-        "title": _load_font(size=34, bold=True),
-        "header": _load_font(size=19, bold=True),
-        "rank": _load_font(size=26, bold=True),
-        "body": _load_font(size=24, bold=False),
-        "small": _load_font(size=16, bold=False),
+        "title": load_font(size=34, bold=True),
+        "header": load_font(size=19, bold=True),
+        "rank": load_font(size=26, bold=True),
+        "body": load_font(size=24, bold=False),
+        "small": load_font(size=16, bold=False),
     }
-
-
-def _load_font(size: int, bold: bool) -> _BoardFont:
-    """Loads a CJK-capable font when available."""
-    candidates = _BOLD_FONT_CANDIDATES if bold else _REGULAR_FONT_CANDIDATES
-    for candidate in candidates:
-        try:
-            return ImageFont.truetype(font=candidate, size=size)
-        except OSError:
-            continue
-    return ImageFont.load_default()
 
 
 def _draw_header(
@@ -211,7 +188,7 @@ def _draw_header(
         outline=accent,
         width=2,
     )
-    _draw_text_center(
+    draw_text_center(
         draw=draw,
         text="PUBLIC",
         center=(_BOARD_WIDTH - 96, y + 23),
@@ -235,7 +212,7 @@ def _draw_table_header(
     baseline = y + 12
     draw.text(xy=(_RANK_X, baseline), text="排名", font=fonts["header"], fill=_MUTED)
     draw.text(xy=(_NAME_X, baseline), text="玩家", font=fonts["header"], fill=_MUTED)
-    _draw_text_right(
+    draw_text_right(
         draw=draw,
         text=amount_header,
         xy=(_AMOUNT_RIGHT, baseline),
@@ -266,11 +243,11 @@ def _draw_rank_row(
         font=fonts["rank"],
         fill=spec.accent if position <= 3 else _MUTED,
     )
-    display_name = _fit_text(
+    display_name = fit_text(
         draw=draw, text=row.name or "未知玩家", font=fonts["body"], max_width=_NAME_MAX_WIDTH
     )
     draw.text(xy=(_NAME_X, y + 13), text=display_name, font=fonts["body"], fill=_TEXT)
-    _draw_text_right(
+    draw_text_right(
         draw=draw,
         text=_ranking_amount_text(spec=spec, amount=row.amount),
         xy=(_AMOUNT_RIGHT, y + 13),
@@ -293,58 +270,6 @@ def _ranking_amount_text(spec: _RankingBoardSpec, amount: int) -> str:
     if not spec.amount_label:
         return amount_text
     return f"{spec.amount_label} {amount_text}"
-
-
-def _draw_text_right(
-    draw: ImageDraw.ImageDraw,
-    text: str,
-    xy: tuple[int, int],
-    font: _BoardFont,
-    fill: tuple[int, int, int],
-) -> None:
-    """Draws text with its right edge anchored at x."""
-    right, y = xy
-    bbox = draw.textbbox(xy=(0, 0), text=text, font=font)
-    draw.text(xy=(right - (bbox[2] - bbox[0]), y), text=text, font=font, fill=fill)
-
-
-def _draw_text_center(
-    draw: ImageDraw.ImageDraw,
-    text: str,
-    center: tuple[int, int],
-    font: _BoardFont,
-    fill: tuple[int, int, int],
-) -> None:
-    """Draws text centered around a point."""
-    x, y = center
-    bbox = draw.textbbox(xy=(0, 0), text=text, font=font)
-    width = bbox[2] - bbox[0]
-    draw.text(xy=(x - width // 2, y), text=text, font=font, fill=fill)
-
-
-def _fit_text(draw: ImageDraw.ImageDraw, text: str, font: _BoardFont, max_width: int) -> str:
-    """Truncates text to fit the requested pixel width."""
-    if _text_width(draw=draw, text=text, font=font) <= max_width:
-        return text
-    suffix = "..."
-    low = 0
-    high = len(text)
-    while low < high:
-        midpoint = (low + high + 1) // 2
-        candidate = f"{text[:midpoint]}{suffix}"
-        if _text_width(draw=draw, text=candidate, font=font) <= max_width:
-            low = midpoint
-        else:
-            high = midpoint - 1
-    if low == 0:
-        return suffix
-    return f"{text[:low]}{suffix}"
-
-
-def _text_width(draw: ImageDraw.ImageDraw, text: str, font: _BoardFont) -> int:
-    """Returns rendered text width."""
-    bbox = draw.textbbox(xy=(0, 0), text=text, font=font)
-    return bbox[2] - bbox[0]
 
 
 def _rank_text(position: int) -> str:

--- a/src/discordbot/cogs/_economy/database.py
+++ b/src/discordbot/cogs/_economy/database.py
@@ -62,6 +62,7 @@ from sqlalchemy import (
     func,
     text,
     event,
+    delete,
     select,
     update,
 )
@@ -83,6 +84,7 @@ from discordbot.typings.economy import (
     CreditResult,
     CheckinResult,
     PortfolioView,
+    BotStatusEntry,
     LoanLenderType,
     TransferResult,
     WalletDeltaLeg,
@@ -446,6 +448,35 @@ class CasinoLedger(GlobalStateBase):
     balance: Mapped[int] = mapped_column(StoredInteger(), default=0, nullable=False)
     total_earned: Mapped[int] = mapped_column(StoredInteger(), default=0, nullable=False)
     total_spent: Mapped[int] = mapped_column(StoredInteger(), default=0, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_database_now, onupdate=_database_now
+    )
+
+
+class BotStatus(GlobalStateBase):
+    """Operator-tunable presence lines rotated by the status task.
+
+    Rows are managed out-of-band via offline DB maintenance; an empty table lets
+    the status task fall back to its built-in default, so a fresh database still
+    shows a presence. Read once per status tick and never written at runtime, so
+    there is no write amplification.
+
+    Attributes:
+        status_id: Autoincrement primary key.
+        status_text: Presence text shown via `change_presence`.
+        enabled: Whether this line is eligible for rotation.
+        order_index: Ascending rotation/display order hint.
+        updated_at: Taiwan-local timestamp of the last write.
+    """
+
+    __tablename__ = "bot_status"
+
+    status_id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    status_text: Mapped[str] = mapped_column(String(length=128), nullable=False)
+    enabled: Mapped[bool] = mapped_column(
+        Boolean, default=True, server_default="1", nullable=False
+    )
+    order_index: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=_database_now, onupdate=_database_now
     )
@@ -3399,3 +3430,54 @@ async def get_portfolio(user_id: int) -> PortfolioView:
         portfolio = await _portfolio_in_session(session=session, user_id=user_id, now=now)
         await session.commit()
         return portfolio
+
+
+async def get_bot_statuses() -> list[str]:
+    """Returns enabled presence lines ordered for rotation; empty when unset."""
+    await _ensure_global_state_schema()
+    async with open_global_state_session() as session:
+        result = await session.execute(
+            statement=select(BotStatus.status_text)
+            .where(BotStatus.enabled.is_(True))
+            .order_by(BotStatus.order_index, BotStatus.status_id)
+        )
+        return list(result.scalars().all())
+
+
+async def list_bot_status_rows() -> list[BotStatusEntry]:
+    """Returns every presence rotation row for maintenance display."""
+    await _ensure_global_state_schema()
+    async with open_global_state_session() as session:
+        result = await session.execute(
+            statement=select(BotStatus).order_by(BotStatus.order_index, BotStatus.status_id)
+        )
+        return [
+            BotStatusEntry(
+                status_id=row.status_id,
+                status_text=row.status_text,
+                enabled=row.enabled,
+                order_index=row.order_index,
+            )
+            for row in result.scalars().all()
+        ]
+
+
+async def add_bot_status(status_text: str, order_index: int = 0, enabled: bool = True) -> int:
+    """Adds a presence rotation line and returns its new id."""
+    await _ensure_global_state_schema()
+    async with open_global_state_session() as session:
+        row = BotStatus(status_text=status_text, order_index=order_index, enabled=enabled)
+        session.add(row)
+        await session.commit()
+        return row.status_id
+
+
+async def remove_bot_status(status_id: int) -> bool:
+    """Removes a presence rotation line; returns True when a row was deleted."""
+    await _ensure_global_state_schema()
+    async with open_global_state_session() as session:
+        result = await session.execute(
+            statement=delete(BotStatus).where(BotStatus.status_id == status_id)
+        )
+        await session.commit()
+        return bool(result.rowcount)

--- a/src/discordbot/cogs/_economy/database.py
+++ b/src/discordbot/cogs/_economy/database.py
@@ -3172,7 +3172,8 @@ async def _apply_loan_payment_in_session(  # noqa: PLR0913 -- payment needs acto
                 )
             )
             lender_balance = credit_result.scalar_one()
-            invalidate_economy_leaderboard_cache()
+            # The borrower debit above already cleared the leaderboard cache for
+            # this transaction, so the lender credit needs no extra invalidation.
 
         total_paid += paid
         total_interest_paid += interest_paid

--- a/src/discordbot/cogs/_gen_reply/input.py
+++ b/src/discordbot/cogs/_gen_reply/input.py
@@ -3,6 +3,7 @@
 import re
 import base64
 from typing import Literal
+import asyncio
 from mimetypes import guess_type
 
 import logfire
@@ -83,7 +84,9 @@ class MessageInputBuilder(BaseModel):
         """Converts an image source to a content part for the API."""
         try:
             if isinstance(source, str):
-                b64_data = get_image_data(image_file=source)
+                # A URL source fetches over the network inside get_image_data, so
+                # keep that blocking work off the event loop.
+                b64_data = await asyncio.to_thread(get_image_data, image_file=source)
                 data_uri = convert_base64_to_data_uri(base64_image=b64_data)
                 return ResponseInputImageParam(
                     image_url=data_uri, detail="low", type="input_image"

--- a/src/discordbot/cogs/_maplestory/service.py
+++ b/src/discordbot/cogs/_maplestory/service.py
@@ -7,17 +7,14 @@ caching, and searching MapleStory data from JSON files.
 from __future__ import annotations
 
 import json
-from typing import TypeVar
 from pathlib import Path
 
 import logfire
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, PrivateAttr
 
 from .models import NPC, Quest, Scroll, Monster, Useable, MapEntry, MiscItem, Equipment, MapleStats
 
 DEFAULT_DATA_DIR = Path("./data/maplestory")
-
-T = TypeVar("T", bound=BaseModel)
 
 
 def _load_json[T: BaseModel](path: Path, model: type[T]) -> list[T]:
@@ -43,29 +40,29 @@ def _load_translations(data_dir: Path) -> dict[str, dict[str, str]]:
         return {}
 
 
-class MapleStoryService:
+class MapleStoryService(BaseModel):
     """Encapsulates all Artale data lookups with caching."""
 
-    def __init__(self) -> None:
-        """Initializes the MapleStoryService with empty data and caches."""
-        self._monsters: list[Monster] = []
-        self._equipment: list[Equipment] = []
-        self._scrolls: list[Scroll] = []
-        self._useable: list[Useable] = []
-        self._npcs: list[NPC] = []
-        self._quests: list[Quest] = []
-        self._maps: list[MapEntry] = []
-        self._misc: list[MiscItem] = []
-        self._translations: dict[str, dict[str, str]] = {}
-        # Caches — typed per-category to avoid mypy issues with generic dict
-        self._monster_cache: dict[str, list[Monster]] = {}
-        self._equip_cache: dict[str, list[Equipment]] = {}
-        self._scroll_cache: dict[str, list[Scroll]] = {}
-        self._npc_cache: dict[str, list[NPC]] = {}
-        self._quest_cache: dict[str, list[Quest]] = {}
-        self._map_cache: dict[str, list[MapEntry]] = {}
-        self._item_cache: dict[str, list[str]] = {}
-        self._stats: MapleStats | None = None
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    _monsters: list[Monster] = PrivateAttr(default_factory=list)
+    _equipment: list[Equipment] = PrivateAttr(default_factory=list)
+    _scrolls: list[Scroll] = PrivateAttr(default_factory=list)
+    _useable: list[Useable] = PrivateAttr(default_factory=list)
+    _npcs: list[NPC] = PrivateAttr(default_factory=list)
+    _quests: list[Quest] = PrivateAttr(default_factory=list)
+    _maps: list[MapEntry] = PrivateAttr(default_factory=list)
+    _misc: list[MiscItem] = PrivateAttr(default_factory=list)
+    _translations: dict[str, dict[str, str]] = PrivateAttr(default_factory=dict)
+    # Caches — typed per-category to avoid mypy issues with generic dict
+    _monster_cache: dict[str, list[Monster]] = PrivateAttr(default_factory=dict)
+    _equip_cache: dict[str, list[Equipment]] = PrivateAttr(default_factory=dict)
+    _scroll_cache: dict[str, list[Scroll]] = PrivateAttr(default_factory=dict)
+    _npc_cache: dict[str, list[NPC]] = PrivateAttr(default_factory=dict)
+    _quest_cache: dict[str, list[Quest]] = PrivateAttr(default_factory=dict)
+    _map_cache: dict[str, list[MapEntry]] = PrivateAttr(default_factory=dict)
+    _item_cache: dict[str, list[str]] = PrivateAttr(default_factory=dict)
+    _stats: MapleStats | None = PrivateAttr(default=None)
 
     @classmethod
     def from_directory(cls, data_dir: Path = DEFAULT_DATA_DIR) -> MapleStoryService:
@@ -80,19 +77,6 @@ class MapleStoryService:
         svc = cls()
         svc._load_all(data_dir)
         return svc
-
-    # Keep backwards compat for existing callers
-    @classmethod
-    def from_file(cls, file_path: Path = DEFAULT_DATA_DIR / "monsters.json") -> MapleStoryService:
-        """Creates a service instance, inferring the directory from a file path.
-
-        Args:
-            file_path: Path to a data file (e.g., monsters.json).
-
-        Returns:
-            An initialized MapleStoryService instance.
-        """
-        return cls.from_directory(file_path.parent)
 
     def _load_all(self, data_dir: Path) -> None:
         """Loads all MapleStory JSON data and resets derived caches."""

--- a/src/discordbot/cogs/_stock/presentation.py
+++ b/src/discordbot/cogs/_stock/presentation.py
@@ -4,7 +4,7 @@ from io import BytesIO
 from typing import TypedDict
 from functools import cache, lru_cache
 
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageDraw
 from nextcord import Embed
 from pydantic import BaseModel, ConfigDict
 
@@ -19,6 +19,7 @@ from discordbot.typings.stock import (
     StockSettlementResult,
     StockParticipantPositionView,
 )
+from discordbot.utils.pil_text import Font, fit_text, load_font, draw_text_right
 from discordbot.utils.number_text import compact_amount, share_quantity_text
 from discordbot.cogs._stock.market import cash_floor, format_price
 from discordbot.cogs._economy.presentation import CURRENCY_NAME, amount_code, currency_text
@@ -58,29 +59,16 @@ _MARKET_PRESSURE_RIGHT = 930
 _MARKET_CAP_RIGHT = 1068
 _MARKET_NAME_MAX_WIDTH = 280
 _MARKET_CATEGORY_MAX_WIDTH = 112
-_REGULAR_FONT_CANDIDATES = (
-    "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
-    "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
-    "NotoSansCJK-Regular.ttc",
-    "DejaVuSans.ttf",
-)
-_BOLD_FONT_CANDIDATES = (
-    "/usr/share/fonts/opentype/noto/NotoSansCJK-Bold.ttc",
-    "/usr/share/fonts/truetype/noto/NotoSansCJK-Bold.ttc",
-    "NotoSansCJK-Bold.ttc",
-    "DejaVuSans-Bold.ttf",
-)
-type _MarketFont = ImageFont.ImageFont | ImageFont.FreeTypeFont
 
 
 class _MarketFonts(TypedDict):
     """Font set used by the stock market board image."""
 
-    title: _MarketFont
-    header: _MarketFont
-    symbol: _MarketFont
-    body: _MarketFont
-    small: _MarketFont
+    title: Font
+    header: Font
+    symbol: Font
+    body: Font
+    small: Font
 
 
 class _MarketBoardQuote(BaseModel):
@@ -236,23 +224,12 @@ def _market_page[MarketPageRow](
 def _market_fonts() -> _MarketFonts:
     """Loads the market board fonts with a bundled-system fallback chain."""
     return {
-        "title": _load_font(size=34, bold=True),
-        "header": _load_font(size=20, bold=True),
-        "symbol": _load_font(size=28, bold=True),
-        "body": _load_font(size=24, bold=False),
-        "small": _load_font(size=16, bold=False),
+        "title": load_font(size=34, bold=True),
+        "header": load_font(size=20, bold=True),
+        "symbol": load_font(size=28, bold=True),
+        "body": load_font(size=24, bold=False),
+        "small": load_font(size=16, bold=False),
     }
-
-
-def _load_font(size: int, bold: bool) -> _MarketFont:
-    """Loads a CJK-capable font when available."""
-    candidates = _BOLD_FONT_CANDIDATES if bold else _REGULAR_FONT_CANDIDATES
-    for candidate in candidates:
-        try:
-            return ImageFont.truetype(font=candidate, size=size)
-        except OSError:
-            continue
-    return ImageFont.load_default()
 
 
 def _draw_market_header(
@@ -270,7 +247,7 @@ def _draw_market_header(
     if page_count > 1:
         summary = f"{summary} · 第 {page_index + 1}/{page_count} 頁"
     draw.text(xy=(x, y + 40), text=summary, font=fonts["small"], fill=_MARKET_MUTED)
-    _draw_text_right(
+    draw_text_right(
         draw=draw,
         text=f"單位: {CURRENCY_NAME}",
         xy=(_MARKET_CAP_RIGHT, y + 40),
@@ -295,28 +272,28 @@ def _draw_market_table_header(draw: ImageDraw.ImageDraw, fonts: _MarketFonts, y:
     draw.text(
         xy=(_MARKET_CATEGORY_X, baseline), text="分類", font=fonts["header"], fill=_MARKET_MUTED
     )
-    _draw_text_right(
+    draw_text_right(
         draw=draw,
         text="股價",
         xy=(_MARKET_PRICE_RIGHT, baseline),
         font=fonts["header"],
         fill=_MARKET_MUTED,
     )
-    _draw_text_right(
+    draw_text_right(
         draw=draw,
         text="今日",
         xy=(_MARKET_CHANGE_RIGHT, baseline),
         font=fonts["header"],
         fill=_MARKET_MUTED,
     )
-    _draw_text_right(
+    draw_text_right(
         draw=draw,
         text="買賣壓力",
         xy=(_MARKET_PRESSURE_RIGHT, baseline),
         font=fonts["header"],
         fill=_MARKET_MUTED,
     )
-    _draw_text_right(
+    draw_text_right(
         draw=draw,
         text="市值",
         xy=(_MARKET_CAP_RIGHT, baseline),
@@ -348,10 +325,10 @@ def _draw_market_row(
         width=1,
     )
     market_cap = cash_floor(cents=quote.price_cents * quote.total_shares)
-    name = _fit_text(
+    name = fit_text(
         draw=draw, text=quote.name, font=fonts["body"], max_width=_MARKET_NAME_MAX_WIDTH
     )
-    category = _fit_text(
+    category = fit_text(
         draw=draw, text=quote.category, font=fonts["small"], max_width=_MARKET_CATEGORY_MAX_WIDTH
     )
     draw.text(
@@ -359,28 +336,28 @@ def _draw_market_row(
     )
     draw.text(xy=(_MARKET_COMPANY_X, y + 8), text=name, font=fonts["body"], fill=_MARKET_TEXT)
     _draw_tag(draw=draw, text=category, xy=(_MARKET_CATEGORY_X, y + 19), font=fonts["small"])
-    _draw_text_right(
+    draw_text_right(
         draw=draw,
         text=format_price(price_cents=quote.price_cents),
         xy=(_MARKET_PRICE_RIGHT, y + 12),
         font=fonts["body"],
         fill=_MARKET_TEXT,
     )
-    _draw_text_right(
+    draw_text_right(
         draw=draw,
         text=signed_percent(bps=quote.change_bps),
         xy=(_MARKET_CHANGE_RIGHT, y + 12),
         font=fonts["body"],
         fill=_metric_color(bps=quote.change_bps),
     )
-    _draw_text_right(
+    draw_text_right(
         draw=draw,
         text=signed_percent(bps=quote.pressure_bps),
         xy=(_MARKET_PRESSURE_RIGHT, y + 12),
         font=fonts["body"],
         fill=_metric_color(bps=quote.pressure_bps),
     )
-    _draw_text_right(
+    draw_text_right(
         draw=draw,
         text=compact_amount(amount=market_cap),
         xy=(_MARKET_CAP_RIGHT, y + 12),
@@ -403,9 +380,7 @@ def _draw_empty_market_row(draw: ImageDraw.ImageDraw, fonts: _MarketFonts, y: in
     )
 
 
-def _draw_tag(
-    draw: ImageDraw.ImageDraw, text: str, xy: tuple[int, int], font: _MarketFont
-) -> None:
+def _draw_tag(draw: ImageDraw.ImageDraw, text: str, xy: tuple[int, int], font: Font) -> None:
     """Draws a compact category tag."""
     x, y = xy
     bbox = draw.textbbox(xy=(0, 0), text=text, font=font)
@@ -414,44 +389,6 @@ def _draw_tag(
         xy=(x, y, x + width, y + 20), radius=8, fill=(67, 57, 35), outline=(94, 78, 44)
     )
     draw.text(xy=(x + 8, y + 1), text=text, font=font, fill=_MARKET_TAG)
-
-
-def _draw_text_right(
-    draw: ImageDraw.ImageDraw,
-    text: str,
-    xy: tuple[int, int],
-    font: _MarketFont,
-    fill: tuple[int, int, int],
-) -> None:
-    """Draws text with its right edge anchored at x."""
-    right, y = xy
-    bbox = draw.textbbox(xy=(0, 0), text=text, font=font)
-    draw.text(xy=(right - (bbox[2] - bbox[0]), y), text=text, font=font, fill=fill)
-
-
-def _fit_text(draw: ImageDraw.ImageDraw, text: str, font: _MarketFont, max_width: int) -> str:
-    """Truncates text to fit the requested pixel width."""
-    if _text_width(draw=draw, text=text, font=font) <= max_width:
-        return text
-    suffix = "..."
-    low = 0
-    high = len(text)
-    while low < high:
-        midpoint = (low + high + 1) // 2
-        candidate = f"{text[:midpoint]}{suffix}"
-        if _text_width(draw=draw, text=candidate, font=font) <= max_width:
-            low = midpoint
-        else:
-            high = midpoint - 1
-    if low == 0:
-        return suffix
-    return f"{text[:low]}{suffix}"
-
-
-def _text_width(draw: ImageDraw.ImageDraw, text: str, font: _MarketFont) -> int:
-    """Returns rendered text width."""
-    bbox = draw.textbbox(xy=(0, 0), text=text, font=font)
-    return bbox[2] - bbox[0]
 
 
 def _metric_color(bps: int) -> tuple[int, int, int]:

--- a/src/discordbot/cogs/parse_threads.py
+++ b/src/discordbot/cogs/parse_threads.py
@@ -1,6 +1,7 @@
 """Cog that expands Threads post URLs into Discord embeds and media files."""
 
 import re
+import asyncio
 from pathlib import Path
 import contextlib
 
@@ -133,7 +134,12 @@ class ThreadsCogs(commands.Cog):
         current_emoji = await update_reaction(message=message, bot_user=self.bot.user, emoji="🔗")
 
         try:
-            with self.downloader.parse(url) as results:
+            # parse() blocks on HTTP fetch + media downloads, so run its enter
+            # off the event loop; the reply runs while the temp files still exist
+            # and the matching exit cleans them up afterwards.
+            parse_cm = self.downloader.parse(url)
+            results = await asyncio.to_thread(parse_cm.__enter__)
+            try:
                 if not results:
                     await update_reaction(
                         message=message, bot_user=self.bot.user, emoji="⚠️", previous=current_emoji
@@ -180,6 +186,8 @@ class ThreadsCogs(commands.Cog):
                 await update_reaction(
                     message=message, bot_user=self.bot.user, emoji="🆗", previous=current_emoji
                 )
+            finally:
+                await asyncio.to_thread(parse_cm.__exit__, None, None, None)
         except Exception:
             logfire.error("Failed to send Threads message", _exc_info=True)
             with contextlib.suppress(Exception):

--- a/src/discordbot/cogs/video.py
+++ b/src/discordbot/cogs/video.py
@@ -1,5 +1,6 @@
 """Slash command cog for downloading videos through yt-dlp."""
 
+import asyncio
 from pathlib import Path
 import contextlib
 
@@ -70,7 +71,8 @@ class VideoCogs(commands.Cog):
 
         try:
             downloader = VideoDownloader(output_folder="./data/downloads")
-            with downloader.download(url=url, quality=quality) as result:
+            result = await asyncio.to_thread(downloader.download, url=url, quality=quality)
+            with result:
                 file_size_mb = result.filename.stat().st_size / 1024 / 1024
                 if result.filename.stat().st_size <= _DISCORD_FILE_LIMIT_BYTES:
                     await self._deliver(
@@ -90,7 +92,8 @@ class VideoCogs(commands.Cog):
                 await interaction.edit_original_message(
                     content=f"-# 檔案過大 ({file_size_mb:.1f}MB)，正在重新下載低畫質版本..."
                 )
-                with downloader.download(url=url, quality="low") as low_result:
+                low_result = await asyncio.to_thread(downloader.download, url=url, quality="low")
+                with low_result:
                     file_size_mb = low_result.filename.stat().st_size / 1024 / 1024
                     if low_result.filename.stat().st_size > _DISCORD_FILE_LIMIT_BYTES:
                         await interaction.edit_original_message(

--- a/src/discordbot/typings/economy.py
+++ b/src/discordbot/typings/economy.py
@@ -84,6 +84,17 @@ class CentralBankerAccount(BaseModel):
     name: str
 
 
+class BotStatusEntry(BaseModel):
+    """One bot presence rotation row for maintenance display."""
+
+    model_config = ConfigDict(frozen=True)
+
+    status_id: int
+    status_text: str
+    enabled: bool
+    order_index: int
+
+
 class LeaderboardEntry(BaseModel):
     """One account row in the balance leaderboard."""
 

--- a/src/discordbot/utils/model_pricing.py
+++ b/src/discordbot/utils/model_pricing.py
@@ -71,6 +71,16 @@ def get_token_rates(model_name: str) -> tuple[float, float]:
     return info.input_cost_per_token, info.output_cost_per_token
 
 
+def warm_pricing_cache() -> None:
+    """Populates the price-table cache eagerly.
+
+    Calling this once at startup (off the event loop) keeps the first runtime
+    `get_token_rates` / `get_supported_modalities` lookup from blocking on the
+    upstream HTTP fetch during a live interaction.
+    """
+    _load_model_prices()
+
+
 def get_supported_modalities(model_name: str) -> set[str]:
     """Returns the input modalities accepted by `model_name`.
 

--- a/src/discordbot/utils/pil_text.py
+++ b/src/discordbot/utils/pil_text.py
@@ -1,0 +1,86 @@
+"""Shared Pillow font and text-drawing primitives for board/chart renderers.
+
+The economy ranking boards and the stock market board both render CJK text
+onto PNGs with the same font loading and text-anchoring helpers. This module
+is the single source for those primitives so the two renderers stay aligned.
+"""
+
+from PIL import ImageDraw, ImageFont
+
+type Font = ImageFont.ImageFont | ImageFont.FreeTypeFont
+
+REGULAR_FONT_CANDIDATES = (
+    "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+    "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
+    "NotoSansCJK-Regular.ttc",
+    "DejaVuSans.ttf",
+)
+BOLD_FONT_CANDIDATES = (
+    "/usr/share/fonts/opentype/noto/NotoSansCJK-Bold.ttc",
+    "/usr/share/fonts/truetype/noto/NotoSansCJK-Bold.ttc",
+    "NotoSansCJK-Bold.ttc",
+    "DejaVuSans-Bold.ttf",
+)
+
+
+def load_font(size: int, bold: bool) -> Font:
+    """Loads a CJK-capable font when available, else the Pillow default."""
+    candidates = BOLD_FONT_CANDIDATES if bold else REGULAR_FONT_CANDIDATES
+    for candidate in candidates:
+        try:
+            return ImageFont.truetype(font=candidate, size=size)
+        except OSError:
+            continue
+    return ImageFont.load_default()
+
+
+def text_width(draw: ImageDraw.ImageDraw, text: str, font: Font) -> int:
+    """Returns the rendered pixel width of `text`."""
+    bbox = draw.textbbox(xy=(0, 0), text=text, font=font)
+    return bbox[2] - bbox[0]
+
+
+def fit_text(draw: ImageDraw.ImageDraw, text: str, font: Font, max_width: int) -> str:
+    """Truncates `text` with an ellipsis so it fits within `max_width` pixels."""
+    if text_width(draw=draw, text=text, font=font) <= max_width:
+        return text
+    suffix = "..."
+    low = 0
+    high = len(text)
+    while low < high:
+        midpoint = (low + high + 1) // 2
+        candidate = f"{text[:midpoint]}{suffix}"
+        if text_width(draw=draw, text=candidate, font=font) <= max_width:
+            low = midpoint
+        else:
+            high = midpoint - 1
+    if low == 0:
+        return suffix
+    return f"{text[:low]}{suffix}"
+
+
+def draw_text_right(
+    draw: ImageDraw.ImageDraw,
+    text: str,
+    xy: tuple[int, int],
+    font: Font,
+    fill: tuple[int, int, int],
+) -> None:
+    """Draws `text` with its right edge anchored at x."""
+    right, y = xy
+    bbox = draw.textbbox(xy=(0, 0), text=text, font=font)
+    draw.text(xy=(right - (bbox[2] - bbox[0]), y), text=text, font=font, fill=fill)
+
+
+def draw_text_center(
+    draw: ImageDraw.ImageDraw,
+    text: str,
+    center: tuple[int, int],
+    font: Font,
+    fill: tuple[int, int, int],
+) -> None:
+    """Draws `text` centered horizontally around a point."""
+    x, y = center
+    bbox = draw.textbbox(xy=(0, 0), text=text, font=font)
+    width = bbox[2] - bbox[0]
+    draw.text(xy=(x - width // 2, y), text=text, font=font, fill=fill)

--- a/tests/test_economy.py
+++ b/tests/test_economy.py
@@ -50,13 +50,17 @@ from discordbot.cogs._economy.database import (
     open_session,
     _database_now,
     _ensure_schema,
+    add_bot_status,
     adjust_balance,
     checkin_reward,
     _taipei_midnight,
+    get_bot_statuses,
     get_jackpot_pool,
     get_casino_ledger,
+    remove_bot_status,
     _stored_int_to_int,
     get_jackpot_snapshot,
+    list_bot_status_rows,
     credit_with_repayment,
     apply_round_settlement,
     get_casino_daily_stats,
@@ -540,7 +544,7 @@ async def test_ensure_schema_bootstraps_current_databases(
         "loan_contract",
         "casino_account",
     }
-    assert global_state_tables == {"jackpot_pool", "casino_ledger"}
+    assert global_state_tables == {"jackpot_pool", "casino_ledger", "bot_status"}
     assert {"user_id", "name", "is_central_banker"} <= table_columns["user_account"]
     assert {"user_id", "name", "balance", "total_earned", "total_spent"} <= table_columns[
         "user_wallet"
@@ -2636,3 +2640,28 @@ async def test_ensure_schema_seeds_dragon_gate_jackpot_once(
 
     await engine.dispose()
     await global_state_engine.dispose()
+
+
+async def test_get_bot_statuses_empty_returns_empty_list() -> None:
+    """A fresh database has no presence lines, so callers fall back to a default."""
+    assert await get_bot_statuses() == []
+
+
+async def test_bot_status_rotation_orders_enabled_lines() -> None:
+    """Enabled lines are returned ordered by order_index then id; disabled excluded."""
+    second_id = await add_bot_status(status_text="second", order_index=2)
+    await add_bot_status(status_text="first", order_index=1)
+    await add_bot_status(status_text="hidden", order_index=0, enabled=False)
+
+    assert await get_bot_statuses() == ["first", "second"]
+
+    rows = await list_bot_status_rows()
+    assert [(row.status_text, row.enabled) for row in rows] == [
+        ("hidden", False),
+        ("first", True),
+        ("second", True),
+    ]
+
+    assert await remove_bot_status(status_id=second_id) is True
+    assert await get_bot_statuses() == ["first"]
+    assert await remove_bot_status(status_id=second_id) is False


### PR DESCRIPTION
## Context

A horizontal audit of the bot after many refactor iterations, focused on:
- Code-level performance that can stall user interactions (LLM latency itself is acceptable).
- Better use of the existing SQLite databases for state that is currently hardcoded or kept only in process memory.
- Removing duplication, dead code, and legacy shims; tightening pydantic conventions.

Several initially-flagged "bugs" were verified to be false positives or unsafe to change and were intentionally dropped (see notes below).

## Changes

### Shared helpers / cleanup (done)
- Extract duplicated Pillow font and text primitives (`load_font`, `text_width`, `fit_text`, `draw_text_right`, `draw_text_center`, font candidate lists, `Font` type alias) into `utils/pil_text.py`; the economy ranking boards and the stock market board now import them instead of carrying verbatim copies.
- Model `MapleStoryService` as a pydantic `BaseModel` (PrivateAttr-backed state, no hand-written `__init__`); remove the zero-caller `from_file` shim and an unused module-level `TypeVar`.
- Drop a redundant leaderboard-cache invalidation in loan repayment (the borrower debit in the same transaction already clears the cache).

### Event-loop blocking (in progress)
- Offload synchronous `requests` / `yt-dlp` / Pillow work that currently runs inside `async` handlers to `asyncio.to_thread` so a single video download / Threads link / image encode no longer freezes the whole bot for every other user. Pre-warm the model-pricing cache at startup.

### DB-backed state (in progress)
- Move the hardcoded bot status rotation and the in-memory auto-unmute last-active-channel map into `global_state.db`.

## Intentionally dropped (verified)
- VIP five-card-21 bonus: the existing `max()` is correct per CLAUDE.md ("VIP adds one 0.5x bonus") and is covered by existing tests; the original "fix" was a false positive.
- `asyncio.gather` across queries on one `AsyncSession` (unsafe), SQL aggregation/ordering over decimal-text money/share columns (overflow / lexical), and several proposed indexes already covered by existing composite indexes.

## Verification
- `uv run pre-commit run -a` (ruff + mypy) green.
- `uv run pytest` green (coverage gate 80%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)