### PR TITLE
refactor: repo-wide audit cleanup round 2

### DIFF
--- a/src/discordbot/cogs/_economy/database.py
+++ b/src/discordbot/cogs/_economy/database.py
@@ -2958,7 +2958,7 @@ async def _accept_loan_proposal_locked(  # noqa: C901, PLR0911, PLR0913 -- propo
     now = _database_now()
     async with open_session() as session:
         # Acquire SQLite's write lock before reading capacity or proposal state.
-        await session.execute(statement=text(text="BEGIN IMMEDIATE"))
+        await session.execute(statement=text("BEGIN IMMEDIATE"))
         result = await session.execute(
             statement=select(LoanProposal).where(
                 LoanProposal.id == proposal_id, LoanProposal.status == LoanProposalStatus.PENDING

--- a/src/discordbot/cogs/_economy/views.py
+++ b/src/discordbot/cogs/_economy/views.py
@@ -29,7 +29,23 @@ from discordbot.cogs._economy.database import (
 from discordbot.cogs._economy.interactions import edit_response_embed, send_ephemeral_response
 
 
-class CentralBankLoanDecisionView(View):
+class LoanDecisionViewBase(View):
+    """Shared cleanup behavior for public loan-decision views."""
+
+    message: nextcord.Message | None
+
+    def _schedule_cleanup(self, interaction: Interaction | None = None) -> None:
+        """Schedules the public request message for cleanup after a terminal state."""
+        message = self.message or getattr(interaction, "message", None)
+        if message is None:
+            return
+        user_name = None
+        if interaction is not None and interaction.user is not None:
+            user_name = interaction.user.name
+        schedule_public_message_delete(message=message, user_name=user_name)
+
+
+class CentralBankLoanDecisionView(LoanDecisionViewBase):
     """Button controls for deciding a public central-bank loan request."""
 
     def __init__(
@@ -46,16 +62,6 @@ class CentralBankLoanDecisionView(View):
         self.creator_id = creator_id
         self.allow_self_approval = allow_self_approval
         self.message: nextcord.Message | None = None
-
-    def _schedule_cleanup(self, interaction: Interaction | None = None) -> None:
-        """Schedules the public request message for cleanup after a terminal state."""
-        message = self.message or getattr(interaction, "message", None)
-        if message is None:
-            return
-        user_name = None
-        if interaction is not None and interaction.user is not None:
-            user_name = interaction.user.name
-        schedule_public_message_delete(message=message, user_name=user_name)
 
     async def on_timeout(self) -> None:
         """Rejects a stale central-bank request and cleans up its message."""
@@ -203,7 +209,7 @@ class CentralBankLoanDecisionView(View):
         self._schedule_cleanup(interaction=interaction)
 
 
-class CreditLoanDecisionView(View):
+class CreditLoanDecisionView(LoanDecisionViewBase):
     """Button controls for deciding a public personal credit request."""
 
     def __init__(self, proposal_id: int, lender_id: int, creator_id: int) -> None:
@@ -213,16 +219,6 @@ class CreditLoanDecisionView(View):
         self.lender_id = lender_id
         self.creator_id = creator_id
         self.message: nextcord.Message | None = None
-
-    def _schedule_cleanup(self, interaction: Interaction | None = None) -> None:
-        """Schedules the public request message for cleanup after a terminal state."""
-        message = self.message or getattr(interaction, "message", None)
-        if message is None:
-            return
-        user_name = None
-        if interaction is not None and interaction.user is not None:
-            user_name = interaction.user.name
-        schedule_public_message_delete(message=message, user_name=user_name)
 
     async def on_timeout(self) -> None:
         """Rejects a stale personal credit request and cleans up its message."""

--- a/src/discordbot/cogs/_games/blackjack_views.py
+++ b/src/discordbot/cogs/_games/blackjack_views.py
@@ -1215,6 +1215,7 @@ class BlackjackView(View):
             insurance_cost=bot_player.participant.bet // 2,
         )
         decision = await bot_ai.decide_bot_insurance(
+            dealer_cards=list(self.round_state.dealer),
             dealer_up=dealer_up,
             hand_repr=f"{render_hand(cards=first_hand.cards)} = {first_hand.total()}",
             bet=bot_player.participant.bet,

--- a/src/discordbot/cogs/_games/blackjack_views.py
+++ b/src/discordbot/cogs/_games/blackjack_views.py
@@ -14,7 +14,6 @@ from nextcord.ui import View, Button
 from discordbot.typings.games import (
     Card,
     BotAction,
-    SettleOutcome,
     GameParticipant,
     OtherPlayerView,
     BlackjackDealerStep,
@@ -67,6 +66,7 @@ from discordbot.cogs._games.presentation import (
     settlement_metadata,
     lobby_participant_line,
     build_system_talk_embed,
+    SETTLEMENT_FALLBACK_LINES,
     blackjack_outcome_presentation,
 )
 from discordbot.cogs._economy.presentation import amount_code, currency_text
@@ -86,17 +86,6 @@ FINAL_EDIT_TIMEOUT_SECONDS: Final[float] = 8.0
 PEEK_REVEAL_DELAY_SECONDS: Final[float] = 1.6
 BOT_TURN_EDIT_DELAY_SECONDS: Final[float] = 0.4
 HintRefreshContext = tuple[int, str, int, int]
-BLACKJACK_SETTLEMENT_FALLBACK_LINES: Final[dict[SettleOutcome, str]] = {
-    "win": "本局玩家獲勝, 賭場已支付賠付",
-    "lose": "本局玩家未過關, 籌碼歸入賭場",
-    "push": "本局雙方點數一致, 押注全額退回",
-    "blackjack": "Blackjack 達成, 賭場依規則支付 1.5 倍賠付",
-    "five_card_win": "過五關未爆, 玩家獲得本局勝利",
-    "five_card_twenty_one": "過五關 21 點, 額外加碼支付",
-    "player_bust": "玩家點數超過 21, 本局結算為輸",
-    "dealer_bust": "莊家點數超過 21, 本局玩家獲勝",
-    "surrender": "玩家投降, 退回一半本金",
-}
 
 
 def _blackjack_table_edit_kwargs(
@@ -1639,7 +1628,7 @@ class BlackjackView(View):
     def _fallback_settlement_line(self, results: list[BlackjackPlayerResult]) -> str:
         """Returns the immediate non-LLM narrator line for a final table."""
         if len(results) == 1:
-            return BLACKJACK_SETTLEMENT_FALLBACK_LINES[results[0].settlement.outcome]
+            return SETTLEMENT_FALLBACK_LINES[results[0].settlement.outcome]
         net_delta = sum(result.settlement.delta for result in results)
         if net_delta > 0:
             return "本桌整體玩家略勝, 賭場結算後支付差額"

--- a/src/discordbot/cogs/_games/blackjack_views.py
+++ b/src/discordbot/cogs/_games/blackjack_views.py
@@ -60,13 +60,13 @@ from discordbot.cogs._games.presentation import (
     IN_PROGRESS_COLOR,
     NATURAL_RESULT_EMOJI,
     LOBBY_PLAYERS_FIELD_EMOJI,
+    SETTLEMENT_FALLBACK_LINES,
     card_line,
     metadata_line,
     player_result_title,
     settlement_metadata,
     lobby_participant_line,
     build_system_talk_embed,
-    SETTLEMENT_FALLBACK_LINES,
     blackjack_outcome_presentation,
 )
 from discordbot.cogs._economy.presentation import amount_code, currency_text

--- a/src/discordbot/cogs/_games/bot_player.py
+++ b/src/discordbot/cogs/_games/bot_player.py
@@ -877,6 +877,7 @@ class BotPlayerAI(BaseModel):
     async def decide_bot_insurance(  # noqa: PLR0913 -- insurance prompt needs full table context.
         self,
         *,
+        dealer_cards: list[Card],
         dealer_up: Card | None,
         hand_repr: str,
         bet: int,
@@ -890,7 +891,7 @@ class BotPlayerAI(BaseModel):
         the known dealer hole card already makes a Blackjack, and declines
         otherwise.
         """
-        if insurance_context is not None and insurance_context.dealer_blackjack:
+        if fallback_insurance(dealer_cards=dealer_cards):
             fallback_decision = BotPlayerInsuranceDecision(
                 take_insurance=True, reason="暗牌成 BJ, 買保險打平"
             )

--- a/src/discordbot/cogs/_games/dealer.py
+++ b/src/discordbot/cogs/_games/dealer.py
@@ -15,6 +15,7 @@ from discordbot.cogs._games.prompts import (
     SYSTEM_SETTLE_PROMPT,
     SYSTEM_TAUNT_BET_PROMPT,
 )
+from discordbot.cogs._games.presentation import SETTLEMENT_FALLBACK_LINES
 from discordbot.cogs._economy.presentation import CURRENCY_NAME
 
 NARRATOR_AI_TIMEOUT_SECONDS = 5.0
@@ -111,17 +112,6 @@ class SystemNarrator(BaseModel):
             "dealer_bust": "莊家爆牌",
             "surrender": "玩家投降, 退回一半本金",
         }
-        fallback_lines: dict[SettleOutcome, str] = {
-            "win": "本局玩家獲勝, 賭場已支付賠付",
-            "lose": "本局玩家未過關, 籌碼歸入賭場",
-            "push": "本局雙方點數一致, 押注全額退回",
-            "blackjack": "Blackjack 達成, 賭場依規則支付 1.5 倍賠付",
-            "five_card_win": "過五關未爆, 玩家獲得本局勝利",
-            "five_card_twenty_one": "過五關 21 點, 額外加碼支付",
-            "player_bust": "玩家點數超過 21, 本局結算為輸",
-            "dealer_bust": "莊家點數超過 21, 本局玩家獲勝",
-            "surrender": "玩家投降, 退回一半本金",
-        }
         user_text = (
             f"遊戲: {game_labels[game]}\n"
             f"玩家: {player_name}\n"
@@ -134,7 +124,7 @@ class SystemNarrator(BaseModel):
         return await self._ask(
             instructions=SYSTEM_SETTLE_PROMPT,
             user_text=user_text,
-            fallback=fallback_lines[outcome],
+            fallback=SETTLEMENT_FALLBACK_LINES[outcome],
             end_user_id=_SETTLE_END_USER_ID,
         )
 

--- a/src/discordbot/cogs/_games/presentation.py
+++ b/src/discordbot/cogs/_games/presentation.py
@@ -39,6 +39,18 @@ NATURAL_RESULT_EMOJI = "✨"
 
 PlayerStatusKind = Literal["blackjack", "bust", "active", "stand", "waiting"]
 
+SETTLEMENT_FALLBACK_LINES: Final[dict[SettleOutcome, str]] = {
+    "win": "本局玩家獲勝, 賭場已支付賠付",
+    "lose": "本局玩家未過關, 籌碼歸入賭場",
+    "push": "本局雙方點數一致, 押注全額退回",
+    "blackjack": "Blackjack 達成, 賭場依規則支付 1.5 倍賠付",
+    "five_card_win": "過五關未爆, 玩家獲得本局勝利",
+    "five_card_twenty_one": "過五關 21 點, 額外加碼支付",
+    "player_bust": "玩家點數超過 21, 本局結算為輸",
+    "dealer_bust": "莊家點數超過 21, 本局玩家獲勝",
+    "surrender": "玩家投降, 退回一半本金",
+}
+
 
 def blackjack_outcome_presentation(outcome: SettleOutcome) -> tuple[str, int]:
     """Returns presentation values for a Blackjack outcome.

--- a/src/discordbot/cogs/_help/content.py
+++ b/src/discordbot/cogs/_help/content.py
@@ -1,7 +1,7 @@
 """Localized help content and the data models that drive the help view."""
 
 from nextcord import Locale
-from pydantic import BaseModel, field_validator
+from pydantic import Field, BaseModel, field_validator
 
 from discordbot.cogs._economy.presentation import CURRENCY_NAME
 
@@ -19,10 +19,14 @@ class HelpSection(BaseModel):
         detail: Full command list rendered in the category's detail embed.
     """
 
-    emoji: str
-    label: str
-    summary: str
-    detail: str
+    emoji: str = Field(description="Leading emoji for the select option and detail title.")
+    label: str = Field(
+        description="Category name used as the select option label and embed title."
+    )
+    summary: str = Field(
+        description="One-line index/select-option description (kept under 100 chars)."
+    )
+    detail: str = Field(description="Full command list rendered in the category's detail embed.")
 
 
 class HelpGuide(BaseModel):
@@ -36,11 +40,13 @@ class HelpGuide(BaseModel):
         sections: Category key to its content, keyed by `CATEGORY_ORDER`.
     """
 
-    title: str
-    intro: str
-    select_placeholder: str
-    overview_label: str
-    sections: dict[str, HelpSection]
+    title: str = Field(description="Overview embed title.")
+    intro: str = Field(description="Leading line on the overview embed.")
+    select_placeholder: str = Field(description="Placeholder shown on the category select menu.")
+    overview_label: str = Field(description="Select option label that returns to the overview.")
+    sections: dict[str, HelpSection] = Field(
+        description="Category key to its content, keyed by `CATEGORY_ORDER`."
+    )
 
     @field_validator("sections")
     @classmethod

--- a/src/discordbot/cogs/_maplestory/models.py
+++ b/src/discordbot/cogs/_maplestory/models.py
@@ -26,8 +26,8 @@ class RegionMaps(_Base):
         maps: Map names in the region.
     """
 
-    region: str
-    maps: list[str] = Field(default_factory=list)
+    region: str = Field(description="Region name.")
+    maps: list[str] = Field(default_factory=list, description="Map names in the region.")
 
 
 class AcquisitionMonster(_Base):
@@ -38,8 +38,8 @@ class AcquisitionMonster(_Base):
         level: Monster level.
     """
 
-    name: str
-    level: int = 0
+    name: str = Field(description="Monster name.")
+    level: int = Field(default=0, description="Monster level.")
 
 
 class AcquisitionNPC(_Base):
@@ -50,8 +50,8 @@ class AcquisitionNPC(_Base):
         price: Item price from the NPC.
     """
 
-    name: str
-    price: int = 0
+    name: str = Field(description="NPC name.")
+    price: int = Field(default=0, description="Item price from the NPC.")
 
 
 class AcquisitionQuest(_Base):
@@ -62,8 +62,8 @@ class AcquisitionQuest(_Base):
         level: Quest level.
     """
 
-    name: str
-    level: int = 0
+    name: str = Field(description="Quest name.")
+    level: int = Field(default=0, description="Quest level.")
 
 
 class CraftingMaterial(_Base):
@@ -74,8 +74,8 @@ class CraftingMaterial(_Base):
         quantity: Required quantity.
     """
 
-    item: str = ""
-    quantity: int = 0
+    item: str = Field(default="", description="Material item name.")
+    quantity: int = Field(default=0, description="Required quantity.")
 
 
 class CraftingRecipe(_Base):
@@ -87,9 +87,11 @@ class CraftingRecipe(_Base):
         materials: Materials required by the recipe.
     """
 
-    npc: str = ""
-    output: str = ""
-    materials: list[CraftingMaterial] = Field(default_factory=list)
+    npc: str = Field(default="", description="NPC name associated with the recipe.")
+    output: str = Field(default="", description="Crafted output name.")
+    materials: list[CraftingMaterial] = Field(
+        default_factory=list, description="Materials required by the recipe."
+    )
 
 
 class Acquisition(_Base):
@@ -102,10 +104,18 @@ class Acquisition(_Base):
         craftings: Crafting recipe entries.
     """
 
-    monsters: list[AcquisitionMonster] = Field(default_factory=list)
-    npcs: list[AcquisitionNPC] = Field(default_factory=list)
-    quests: list[AcquisitionQuest] = Field(default_factory=list)
-    craftings: list[CraftingRecipe] = Field(default_factory=list)
+    monsters: list[AcquisitionMonster] = Field(
+        default_factory=list, description="Monster acquisition entries."
+    )
+    npcs: list[AcquisitionNPC] = Field(
+        default_factory=list, description="NPC acquisition entries."
+    )
+    quests: list[AcquisitionQuest] = Field(
+        default_factory=list, description="Quest acquisition entries."
+    )
+    craftings: list[CraftingRecipe] = Field(
+        default_factory=list, description="Crafting recipe entries."
+    )
 
 
 # ── Monster ─────────────────────────────────────────────────────────
@@ -120,9 +130,9 @@ class DefenseStats(_Base):
         avoidability: Avoidability value.
     """
 
-    weapon: int = 0
-    magic: int = 0
-    avoidability: int = 0
+    weapon: int = Field(default=0, description="Weapon defense value.")
+    magic: int = Field(default=0, description="Magic defense value.")
+    avoidability: int = Field(default=0, description="Avoidability value.")
 
 
 class AccuracyStats(_Base):
@@ -133,8 +143,8 @@ class AccuracyStats(_Base):
         decrease: Accuracy decrease value.
     """
 
-    required: int = 0
-    decrease: float = 0
+    required: int = Field(default=0, description="Required accuracy value.")
+    decrease: float = Field(default=0, description="Accuracy decrease value.")
 
 
 class DropItem(_Base):
@@ -147,10 +157,12 @@ class DropItem(_Base):
         jobs: Jobs associated with the dropped item.
     """
 
-    name: str
-    level: int = 0
-    type: str = ""
-    jobs: list[str] = Field(default_factory=list)
+    name: str = Field(description="Dropped item name.")
+    level: int = Field(default=0, description="Dropped item level.")
+    type: str = Field(default="", description="Dropped item type.")
+    jobs: list[str] = Field(
+        default_factory=list, description="Jobs associated with the dropped item."
+    )
 
 
 class MonsterDrops(_Base):
@@ -164,11 +176,27 @@ class MonsterDrops(_Base):
         meso_range: Meso range dropped by the monster.
     """
 
-    equipment_items: list[DropItem] = Field(default_factory=list, alias="equipmentItems")
-    useable_items: list[DropItem] = Field(default_factory=list, alias="useableItems")
-    scrolls: list[DropItem] = Field(default_factory=list, alias="scrolls")
-    misc_items: list[DropItem] = Field(default_factory=list, alias="miscItems")
-    meso_range: list[int] = Field(default_factory=list, alias="mesoRange")
+    equipment_items: list[DropItem] = Field(
+        default_factory=list,
+        alias="equipmentItems",
+        description="Equipment items dropped by the monster.",
+    )
+    useable_items: list[DropItem] = Field(
+        default_factory=list,
+        alias="useableItems",
+        description="Useable items dropped by the monster.",
+    )
+    scrolls: list[DropItem] = Field(
+        default_factory=list, alias="scrolls", description="Scrolls dropped by the monster."
+    )
+    misc_items: list[DropItem] = Field(
+        default_factory=list,
+        alias="miscItems",
+        description="Miscellaneous items dropped by the monster.",
+    )
+    meso_range: list[int] = Field(
+        default_factory=list, alias="mesoRange", description="Meso range dropped by the monster."
+    )
 
     @property
     def all_items(self) -> list[DropItem]:
@@ -188,8 +216,8 @@ class MonsterQuest(_Base):
         level: Quest level.
     """
 
-    name: str
-    level: int = 0
+    name: str = Field(description="Quest name.")
+    level: int = Field(default=0, description="Quest level.")
 
 
 class Monster(_Base):
@@ -210,18 +238,28 @@ class Monster(_Base):
         quests: Quests associated with the monster.
     """
 
-    name: str
-    name_zh: str = Field(default="", alias="nameZh")
-    level: int = 0
-    hp: int = 0
-    mp: int = 0
-    exp: int = 0
-    def_stats: DefenseStats = Field(default_factory=DefenseStats, alias="def")
-    accuracy: AccuracyStats = Field(default_factory=AccuracyStats)
-    modifiers: list[str] = Field(default_factory=list)
-    region_to_maps_list: list[RegionMaps] = Field(default_factory=list, alias="regionToMapsList")
-    drops: MonsterDrops = Field(default_factory=MonsterDrops)
-    quests: list[MonsterQuest] = Field(default_factory=list)
+    name: str = Field(description="Monster name.")
+    name_zh: str = Field(default="", alias="nameZh", description="Chinese monster name.")
+    level: int = Field(default=0, description="Monster level.")
+    hp: int = Field(default=0, description="Monster HP.")
+    mp: int = Field(default=0, description="Monster MP.")
+    exp: int = Field(default=0, description="Monster EXP.")
+    def_stats: DefenseStats = Field(
+        default_factory=DefenseStats, alias="def", description="Monster defense statistics."
+    )
+    accuracy: AccuracyStats = Field(
+        default_factory=AccuracyStats, description="Monster accuracy statistics."
+    )
+    modifiers: list[str] = Field(default_factory=list, description="Monster modifier names.")
+    region_to_maps_list: list[RegionMaps] = Field(
+        default_factory=list,
+        alias="regionToMapsList",
+        description="Regions and maps where the monster appears.",
+    )
+    drops: MonsterDrops = Field(default_factory=MonsterDrops, description="Monster drop data.")
+    quests: list[MonsterQuest] = Field(
+        default_factory=list, description="Quests associated with the monster."
+    )
 
     @property
     def display_name(self) -> str:
@@ -253,8 +291,8 @@ class StatValue(_Base):
         range: Stat value range.
     """
 
-    middle: int = 0
-    range: list[int] = Field(default_factory=list)
+    middle: int = Field(default=0, description="Middle stat value.")
+    range: list[int] = Field(default_factory=list, description="Stat value range.")
 
 
 class EquipmentStats(_Base):
@@ -281,22 +319,28 @@ class EquipmentStats(_Base):
 
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
-    str_stat: StatValue | None = Field(default=None, alias="str")
-    dex: StatValue | None = None
-    int_stat: StatValue | None = Field(default=None, alias="int")
-    luk: StatValue | None = None
-    hp: StatValue | None = None
-    mp: StatValue | None = None
-    atk: StatValue | None = None
-    matk: StatValue | None = None
-    def_stat: StatValue | None = Field(default=None, alias="def")
-    mdef: StatValue | None = None
-    accuracy: StatValue | None = None
-    avoidability: StatValue | None = None
-    speed: StatValue | None = None
-    jump: StatValue | None = None
-    attack_speed: int | None = Field(default=None, alias="attackSpeed")
-    upgrade_slots: int | None = Field(default=None, alias="upgradeSlots")
+    str_stat: StatValue | None = Field(default=None, alias="str", description="STR stat value.")
+    dex: StatValue | None = Field(default=None, description="DEX stat value.")
+    int_stat: StatValue | None = Field(default=None, alias="int", description="INT stat value.")
+    luk: StatValue | None = Field(default=None, description="LUK stat value.")
+    hp: StatValue | None = Field(default=None, description="HP stat value.")
+    mp: StatValue | None = Field(default=None, description="MP stat value.")
+    atk: StatValue | None = Field(default=None, description="Attack stat value.")
+    matk: StatValue | None = Field(default=None, description="Magic attack stat value.")
+    def_stat: StatValue | None = Field(
+        default=None, alias="def", description="Defense stat value."
+    )
+    mdef: StatValue | None = Field(default=None, description="Magic defense stat value.")
+    accuracy: StatValue | None = Field(default=None, description="Accuracy stat value.")
+    avoidability: StatValue | None = Field(default=None, description="Avoidability stat value.")
+    speed: StatValue | None = Field(default=None, description="Speed stat value.")
+    jump: StatValue | None = Field(default=None, description="Jump stat value.")
+    attack_speed: int | None = Field(
+        default=None, alias="attackSpeed", description="Attack speed value."
+    )
+    upgrade_slots: int | None = Field(
+        default=None, alias="upgradeSlots", description="Upgrade slot count."
+    )
 
     def non_zero_stats(self) -> list[tuple[str, StatValue]]:
         """Returns (label, value) pairs for stats with non-zero middle.
@@ -333,10 +377,10 @@ class EquipmentRestriction(_Base):
         luk: LUK requirement.
     """
 
-    str_req: int = Field(default=0, alias="str")
-    dex: int = 0
-    int_req: int = Field(default=0, alias="int")
-    luk: int = 0
+    str_req: int = Field(default=0, alias="str", description="STR requirement.")
+    dex: int = Field(default=0, description="DEX requirement.")
+    int_req: int = Field(default=0, alias="int", description="INT requirement.")
+    luk: int = Field(default=0, description="LUK requirement.")
 
     def has_requirements(self) -> bool:
         """Checks if there are any stat requirements.
@@ -366,21 +410,37 @@ class Equipment(_Base):
         unavailable: Whether the equipment is marked as unavailable.
     """
 
-    type: str = ""
-    name: str
-    name_zh: str = Field(default="", alias="nameZh")
-    level: int = 0
+    type: str = Field(default="", description="Equipment type.")
+    name: str = Field(description="Equipment name.")
+    name_zh: str = Field(default="", alias="nameZh", description="Chinese equipment name.")
+    level: int = Field(default=0, description="Equipment level.")
     equipment_restriction: EquipmentRestriction = Field(
-        default_factory=EquipmentRestriction, alias="equipmentRestriction"
+        default_factory=EquipmentRestriction,
+        alias="equipmentRestriction",
+        description="Equipment stat requirements.",
     )
-    stats: EquipmentStats = Field(default_factory=EquipmentStats)
-    jobs: list[str] = Field(default_factory=list)
-    attack_speed: str = Field(default="", alias="attackSpeed")
-    acquisition: Acquisition = Field(default_factory=Acquisition)
-    tradeable: str = ""
-    event: bool = False
-    limited_time: bool = Field(default=False, alias="limitedTime")
-    unavailable: bool = False
+    stats: EquipmentStats = Field(
+        default_factory=EquipmentStats, description="Equipment stat values."
+    )
+    jobs: list[str] = Field(
+        default_factory=list, description="Jobs associated with the equipment."
+    )
+    attack_speed: str = Field(default="", alias="attackSpeed", description="Attack speed label.")
+    acquisition: Acquisition = Field(
+        default_factory=Acquisition, description="Acquisition data for the equipment."
+    )
+    tradeable: str = Field(default="", description="Tradeability label.")
+    event: bool = Field(
+        default=False, description="Whether the equipment is marked as an event item."
+    )
+    limited_time: bool = Field(
+        default=False,
+        alias="limitedTime",
+        description="Whether the equipment is marked as limited time.",
+    )
+    unavailable: bool = Field(
+        default=False, description="Whether the equipment is marked as unavailable."
+    )
 
     @property
     def display_name(self) -> str:
@@ -406,11 +466,15 @@ class Scroll(_Base):
         acquisition: Acquisition data for the scroll.
     """
 
-    name: str
-    name_zh: str = Field(default="", alias="nameZh")
-    stats: dict[str, int] = Field(default_factory=dict)
-    type: str = ""
-    acquisition: Acquisition = Field(default_factory=Acquisition)
+    name: str = Field(description="Scroll name.")
+    name_zh: str = Field(default="", alias="nameZh", description="Chinese scroll name.")
+    stats: dict[str, int] = Field(
+        default_factory=dict, description="Stat bonuses keyed by stat name."
+    )
+    type: str = Field(default="", description="Scroll type.")
+    acquisition: Acquisition = Field(
+        default_factory=Acquisition, description="Acquisition data for the scroll."
+    )
 
     @property
     def display_name(self) -> str:
@@ -432,7 +496,7 @@ class UseableStat(_Base):
         amount: Amount applied by the useable item stat.
     """
 
-    amount: int = 0
+    amount: int = Field(default=0, description="Amount applied by the useable item stat.")
 
 
 class Useable(_Base):
@@ -456,21 +520,27 @@ class Useable(_Base):
         jump: Jump stat data.
     """
 
-    name: str
-    name_zh: str = Field(default="", alias="nameZh")
-    type: str = ""
-    description: str | dict[str, str] = ""
-    acquisition: Acquisition = Field(default_factory=Acquisition)
-    hp: UseableStat | None = None
-    mp: UseableStat | None = None
-    atk: UseableStat | None = None
-    matk: UseableStat | None = None
-    def_stat: UseableStat | None = Field(default=None, alias="def")
-    mdef: UseableStat | None = None
-    accuracy: UseableStat | None = None
-    avoidability: UseableStat | None = None
-    speed: UseableStat | None = None
-    jump: UseableStat | None = None
+    name: str = Field(description="Useable item name.")
+    name_zh: str = Field(default="", alias="nameZh", description="Chinese useable item name.")
+    type: str = Field(default="", description="Useable item type.")
+    description: str | dict[str, str] = Field(
+        default="", description="Description data for the useable item."
+    )
+    acquisition: Acquisition = Field(
+        default_factory=Acquisition, description="Acquisition data for the useable item."
+    )
+    hp: UseableStat | None = Field(default=None, description="HP stat data.")
+    mp: UseableStat | None = Field(default=None, description="MP stat data.")
+    atk: UseableStat | None = Field(default=None, description="Attack stat data.")
+    matk: UseableStat | None = Field(default=None, description="Magic attack stat data.")
+    def_stat: UseableStat | None = Field(
+        default=None, alias="def", description="Defense stat data."
+    )
+    mdef: UseableStat | None = Field(default=None, description="Magic defense stat data.")
+    accuracy: UseableStat | None = Field(default=None, description="Accuracy stat data.")
+    avoidability: UseableStat | None = Field(default=None, description="Avoidability stat data.")
+    speed: UseableStat | None = Field(default=None, description="Speed stat data.")
+    jump: UseableStat | None = Field(default=None, description="Jump stat data.")
 
     @property
     def display_name(self) -> str:
@@ -493,8 +563,8 @@ class NPCItem(_Base):
         price: Sold item price.
     """
 
-    name: str
-    price: int = 0
+    name: str = Field(description="Sold item name.")
+    price: int = Field(default=0, description="Sold item price.")
 
 
 class NPC(_Base):
@@ -513,16 +583,34 @@ class NPC(_Base):
         recipes: Crafting recipes associated with the NPC.
     """
 
-    name: str
-    name_zh: str = Field(default="", alias="nameZh")
-    type: str = ""
-    region_to_maps_list: list[RegionMaps] = Field(default_factory=list, alias="regionToMapsList")
-    equipment_items: list[NPCItem] = Field(default_factory=list, alias="equipmentItems")
-    useable_items: list[NPCItem] = Field(default_factory=list, alias="useableItems")
-    scrolls: list[NPCItem] = Field(default_factory=list, alias="scrolls")
-    misc_items: list[NPCItem] = Field(default_factory=list, alias="miscItems")
-    quests: list[AcquisitionQuest] = Field(default_factory=list)
-    recipes: list[CraftingRecipe] = Field(default_factory=list)
+    name: str = Field(description="NPC name.")
+    name_zh: str = Field(default="", alias="nameZh", description="Chinese NPC name.")
+    type: str = Field(default="", description="NPC type.")
+    region_to_maps_list: list[RegionMaps] = Field(
+        default_factory=list,
+        alias="regionToMapsList",
+        description="Regions and maps where the NPC appears.",
+    )
+    equipment_items: list[NPCItem] = Field(
+        default_factory=list,
+        alias="equipmentItems",
+        description="Equipment items sold by the NPC.",
+    )
+    useable_items: list[NPCItem] = Field(
+        default_factory=list, alias="useableItems", description="Useable items sold by the NPC."
+    )
+    scrolls: list[NPCItem] = Field(
+        default_factory=list, alias="scrolls", description="Scrolls sold by the NPC."
+    )
+    misc_items: list[NPCItem] = Field(
+        default_factory=list, alias="miscItems", description="Miscellaneous items sold by the NPC."
+    )
+    quests: list[AcquisitionQuest] = Field(
+        default_factory=list, description="Quests associated with the NPC."
+    )
+    recipes: list[CraftingRecipe] = Field(
+        default_factory=list, description="Crafting recipes associated with the NPC."
+    )
 
     @property
     def display_name(self) -> str:
@@ -554,8 +642,8 @@ class HuntTarget(_Base):
         quantity: Required hunt quantity.
     """
 
-    name: str
-    quantity: int = 0
+    name: str = Field(description="Hunt target name.")
+    quantity: int = Field(default=0, description="Required hunt quantity.")
 
 
 class CollectItem(_Base):
@@ -566,8 +654,8 @@ class CollectItem(_Base):
         quantity: Required collection quantity.
     """
 
-    name: str = ""
-    quantity: int = 0
+    name: str = Field(default="", description="Collected item name.")
+    quantity: int = Field(default=0, description="Required collection quantity.")
 
 
 class QuestReward(_Base):
@@ -580,11 +668,11 @@ class QuestReward(_Base):
         items: Reward item data.
     """
 
-    exp: int = 0
-    fame: int = 0
-    mesos: int = 0
+    exp: int = Field(default=0, description="Reward EXP.")
+    fame: int = Field(default=0, description="Reward fame.")
+    mesos: int = Field(default=0, description="Reward mesos.")
     items: dict[str, list[CollectItem]] | list[dict[str, list[CollectItem]]] = Field(
-        default_factory=dict
+        default_factory=dict, description="Reward item data."
     )
 
 
@@ -598,12 +686,22 @@ class QuestStep(_Base):
         reward: Reward data for the quest step.
     """
 
-    start_npc: str = Field(default="", alias="startNPC")
-    monsters_to_hunt: list[HuntTarget] = Field(default_factory=list, alias="monstersToHunt")
-    items_to_collect: dict[str, list[CollectItem]] = Field(
-        default_factory=dict, alias="itemsToCollect"
+    start_npc: str = Field(
+        default="", alias="startNPC", description="NPC that starts the quest step."
     )
-    reward: QuestReward = Field(default_factory=QuestReward)
+    monsters_to_hunt: list[HuntTarget] = Field(
+        default_factory=list,
+        alias="monstersToHunt",
+        description="Monsters required by the quest step.",
+    )
+    items_to_collect: dict[str, list[CollectItem]] = Field(
+        default_factory=dict,
+        alias="itemsToCollect",
+        description="Items required by the quest step.",
+    )
+    reward: QuestReward = Field(
+        default_factory=QuestReward, description="Reward data for the quest step."
+    )
 
 
 class Quest(_Base):
@@ -620,14 +718,14 @@ class Quest(_Base):
         prerequisites: Prerequisite quest names.
     """
 
-    name: str
-    name_zh: str = Field(default="", alias="nameZh")
-    frequency: str = ""
-    lv_lower: int = Field(default=0, alias="lvLower")
-    lv_upper: int | None = Field(default=None, alias="lvUpper")
-    steps: list[QuestStep] = Field(default_factory=list)
-    boss: bool = False
-    prerequisites: list[str] = Field(default_factory=list)
+    name: str = Field(description="Quest name.")
+    name_zh: str = Field(default="", alias="nameZh", description="Chinese quest name.")
+    frequency: str = Field(default="", description="Quest frequency label.")
+    lv_lower: int = Field(default=0, alias="lvLower", description="Lower level bound.")
+    lv_upper: int | None = Field(default=None, alias="lvUpper", description="Upper level bound.")
+    steps: list[QuestStep] = Field(default_factory=list, description="Quest steps.")
+    boss: bool = Field(default=False, description="Whether the quest is marked as a boss quest.")
+    prerequisites: list[str] = Field(default_factory=list, description="Prerequisite quest names.")
 
     @property
     def display_name(self) -> str:
@@ -651,9 +749,9 @@ class MapNPC(_Base):
         sub_map: Sub-map name.
     """
 
-    name: str
-    type: str = ""
-    sub_map: str = Field(default="", alias="subMap")
+    name: str = Field(description="NPC name.")
+    type: str = Field(default="", description="NPC type.")
+    sub_map: str = Field(default="", alias="subMap", description="Sub-map name.")
 
 
 class MapMonster(_Base):
@@ -664,8 +762,8 @@ class MapMonster(_Base):
         level: Monster level.
     """
 
-    name: str
-    level: int = 0
+    name: str = Field(description="Monster name.")
+    level: int = Field(default=0, description="Monster level.")
 
 
 class MapEntry(_Base):
@@ -685,17 +783,17 @@ class MapEntry(_Base):
         to_region: Destination region name.
     """
 
-    region: str = ""
-    name: str
-    name_zh: str = Field(default="", alias="nameZh")
-    x: int = 0
-    y: int = 0
-    npcs: list[MapNPC] = Field(default_factory=list)
-    monsters: list[MapMonster] = Field(default_factory=list)
-    hidden: bool = False
-    from_map: str = Field(default="", alias="fromMap")
-    to_map: str = Field(default="", alias="toMap")
-    to_region: str = Field(default="", alias="toRegion")
+    region: str = Field(default="", description="Map region name.")
+    name: str = Field(description="Map name.")
+    name_zh: str = Field(default="", alias="nameZh", description="Chinese map name.")
+    x: int = Field(default=0, description="Map x-coordinate.")
+    y: int = Field(default=0, description="Map y-coordinate.")
+    npcs: list[MapNPC] = Field(default_factory=list, description="NPCs on the map.")
+    monsters: list[MapMonster] = Field(default_factory=list, description="Monsters on the map.")
+    hidden: bool = Field(default=False, description="Whether the map is hidden.")
+    from_map: str = Field(default="", alias="fromMap", description="Source map name.")
+    to_map: str = Field(default="", alias="toMap", description="Destination map name.")
+    to_region: str = Field(default="", alias="toRegion", description="Destination region name.")
 
     @property
     def display_name(self) -> str:
@@ -720,10 +818,14 @@ class MiscItem(_Base):
         acquisition: Acquisition data for the miscellaneous item.
     """
 
-    name: str
-    name_zh: str = Field(default="", alias="nameZh")
-    type: str = ""
-    acquisition: Acquisition = Field(default_factory=Acquisition)
+    name: str = Field(description="Miscellaneous item name.")
+    name_zh: str = Field(
+        default="", alias="nameZh", description="Chinese miscellaneous item name."
+    )
+    type: str = Field(default="", description="Miscellaneous item type.")
+    acquisition: Acquisition = Field(
+        default_factory=Acquisition, description="Acquisition data for the miscellaneous item."
+    )
 
     @property
     def display_name(self) -> str:
@@ -754,13 +856,13 @@ class MapleStats(_Base):
         popular_items: Popular item names.
     """
 
-    total_monsters: int
-    total_equipment: int
-    total_scrolls: int
-    total_useable: int
-    total_npcs: int
-    total_quests: int
-    total_maps: int
-    total_misc: int
-    level_distribution: dict[str, int]
-    popular_items: list[str]
+    total_monsters: int = Field(description="Total monster count.")
+    total_equipment: int = Field(description="Total equipment count.")
+    total_scrolls: int = Field(description="Total scroll count.")
+    total_useable: int = Field(description="Total useable item count.")
+    total_npcs: int = Field(description="Total NPC count.")
+    total_quests: int = Field(description="Total quest count.")
+    total_maps: int = Field(description="Total map count.")
+    total_misc: int = Field(description="Total miscellaneous item count.")
+    level_distribution: dict[str, int] = Field(description="Monster counts keyed by level range.")
+    popular_items: list[str] = Field(description="Popular item names.")

--- a/src/discordbot/cogs/_maplestory/service.py
+++ b/src/discordbot/cogs/_maplestory/service.py
@@ -368,11 +368,14 @@ class MapleStoryService(BaseModel):
             items_found: set[str] = set()
             for monster in self._monsters:
                 for drop in monster.drops.all_items:
-                    zh = (
-                        self.translate(category="equipment", name=drop.name)
-                        or self.translate(category="scrolls", name=drop.name)
-                        or self.translate(category="useable", name=drop.name)
-                        or self.translate(category="misc", name=drop.name)
+                    zh = next(
+                        (
+                            translated
+                            for category in ("equipment", "scrolls", "useable", "misc")
+                            if (translated := self.translate(category=category, name=drop.name))
+                            != drop.name
+                        ),
+                        drop.name,
                     )
                     if key in drop.name.lower() or (zh and key in zh.lower()):
                         items_found.add(drop.name)

--- a/src/discordbot/cogs/_maplestory/service.py
+++ b/src/discordbot/cogs/_maplestory/service.py
@@ -298,6 +298,21 @@ class MapleStoryService(BaseModel):
             ]
         return list(self._scroll_cache[key])
 
+    def get_scroll(self, name: str) -> Scroll | None:
+        """Gets a specific scroll by exact name (English or Chinese).
+
+        Args:
+            name: The exact name of the scroll.
+
+        Returns:
+            The Scroll object if found, None otherwise.
+        """
+        name_lower = name.lower()
+        for s in self._scrolls:
+            if s.name.lower() == name_lower or s.name_zh.lower() == name_lower:
+                return s
+        return None
+
     # ── NPC searches ────────────────────────────────────────────────
 
     def search_npcs_by_name(self, query: str) -> list[NPC]:
@@ -315,6 +330,21 @@ class MapleStoryService(BaseModel):
                 n for n in self._npcs if key in n.name.lower() or key in n.name_zh.lower()
             ]
         return list(self._npc_cache[key])
+
+    def get_npc(self, name: str) -> NPC | None:
+        """Gets a specific NPC by exact name (English or Chinese).
+
+        Args:
+            name: The exact name of the NPC.
+
+        Returns:
+            The NPC object if found, None otherwise.
+        """
+        name_lower = name.lower()
+        for n in self._npcs:
+            if n.name.lower() == name_lower or n.name_zh.lower() == name_lower:
+                return n
+        return None
 
     # ── Quest searches ──────────────────────────────────────────────
 
@@ -334,6 +364,21 @@ class MapleStoryService(BaseModel):
             ]
         return list(self._quest_cache[key])
 
+    def get_quest(self, name: str) -> Quest | None:
+        """Gets a specific quest by exact name (English or Chinese).
+
+        Args:
+            name: The exact name of the quest.
+
+        Returns:
+            The Quest object if found, None otherwise.
+        """
+        name_lower = name.lower()
+        for q in self._quests:
+            if q.name.lower() == name_lower or q.name_zh.lower() == name_lower:
+                return q
+        return None
+
     # ── Map searches ────────────────────────────────────────────────
 
     def search_maps_by_name(self, query: str) -> list[MapEntry]:
@@ -351,6 +396,21 @@ class MapleStoryService(BaseModel):
                 m for m in self._maps if key in m.name.lower() or key in m.name_zh.lower()
             ]
         return list(self._map_cache[key])
+
+    def get_map(self, name: str) -> MapEntry | None:
+        """Gets a specific map by exact name (English or Chinese).
+
+        Args:
+            name: The exact name of the map.
+
+        Returns:
+            The MapEntry object if found, None otherwise.
+        """
+        name_lower = name.lower()
+        for m in self._maps:
+            if m.name.lower() == name_lower or m.name_zh.lower() == name_lower:
+                return m
+        return None
 
     # ── Cross-type item search ──────────────────────────────────────
 

--- a/src/discordbot/cogs/_maplestory/views.py
+++ b/src/discordbot/cogs/_maplestory/views.py
@@ -31,13 +31,13 @@ if TYPE_CHECKING:
 
 def _resolve_monster(service: MapleStoryService, name: str, tr: TranslateFn) -> Embed | None:
     """Resolves a monster name to an Embed."""
-    monster = service.get_monster(name)
+    monster = service.get_monster(name=name)
     return create_monster_embed(monster=monster, translate=tr) if monster else None
 
 
 def _resolve_item(service: MapleStoryService, name: str, tr: TranslateFn) -> Embed | None:
     """Resolves an item name to an Embed showing its sources."""
-    monsters = service.get_monsters_by_drop(name)
+    monsters = service.get_monsters_by_drop(item_name=name)
     return (
         create_item_source_embed(item_name=name, monsters=monsters, translate=tr)
         if monsters
@@ -47,31 +47,31 @@ def _resolve_item(service: MapleStoryService, name: str, tr: TranslateFn) -> Emb
 
 def _resolve_equipment(service: MapleStoryService, name: str, tr: TranslateFn) -> Embed | None:
     """Resolves an equipment name to an Embed."""
-    equip = service.get_equipment(name)
+    equip = service.get_equipment(name=name)
     return create_equipment_embed(equip=equip, translate=tr) if equip else None
 
 
 def _resolve_scroll(service: MapleStoryService, name: str, tr: TranslateFn) -> Embed | None:
     """Resolves a scroll name to an Embed."""
-    match = next((s for s in service.search_scrolls_by_name(name) if s.name == name), None)
+    match = service.get_scroll(name=name)
     return create_scroll_embed(scroll=match, translate=tr) if match else None
 
 
 def _resolve_npc(service: MapleStoryService, name: str, tr: TranslateFn) -> Embed | None:
     """Resolves an NPC name to an Embed."""
-    match = next((n for n in service.search_npcs_by_name(name) if n.name == name), None)
+    match = service.get_npc(name=name)
     return create_npc_embed(npc=match, translate=tr) if match else None
 
 
 def _resolve_quest(service: MapleStoryService, name: str, tr: TranslateFn) -> Embed | None:
     """Resolves a quest name to an Embed."""
-    match = next((q for q in service.search_quests_by_name(name) if q.name == name), None)
+    match = service.get_quest(name=name)
     return create_quest_embed(quest=match, translate=tr) if match else None
 
 
 def _resolve_map(service: MapleStoryService, name: str, tr: TranslateFn) -> Embed | None:
     """Resolves a map name to an Embed."""
-    match = next((m for m in service.search_maps_by_name(name) if m.name == name), None)
+    match = service.get_map(name=name)
     return create_map_embed(map_entry=match, translate=tr) if match else None
 
 

--- a/src/discordbot/cogs/_stock/chart.py
+++ b/src/discordbot/cogs/_stock/chart.py
@@ -23,11 +23,8 @@ def build_price_chart(ticks: tuple[StockPriceTickView, ...]) -> bytes:
     return _render_price_chart(ticks=ticks)
 
 
-def invalidate_stock_chart_cache() -> None:
-    """Clears process-local stock chart images."""
-    _render_price_chart.cache_clear()
-
-
+# The cache key is the immutable tick tuple, so any quote/tick change yields a new
+# key and a fresh render; stale entries can never be served and need no invalidation.
 @lru_cache(maxsize=128)
 def _render_price_chart(ticks: tuple[StockPriceTickView, ...]) -> bytes:
     """Renders a simple non-empty 7D price chart PNG."""

--- a/src/discordbot/cogs/_stock/news.py
+++ b/src/discordbot/cogs/_stock/news.py
@@ -117,4 +117,4 @@ def _pressure_label(pressure_bps: int) -> str:
     return "balanced"
 
 
-__all__ = ["STOCK_NEWS_AI_TIMEOUT_SECONDS", "STOCK_NEWS_PROMPT", "StockNewsAI", "StockNewsDraft"]
+__all__ = ["STOCK_NEWS_AI_TIMEOUT_SECONDS", "StockNewsAI", "StockNewsDraft"]

--- a/src/discordbot/cogs/_stock/presentation.py
+++ b/src/discordbot/cogs/_stock/presentation.py
@@ -145,11 +145,6 @@ def build_market_board_image(
     )
 
 
-def invalidate_stock_market_board_cache() -> None:
-    """Clears process-local market board images."""
-    _build_market_board_image_cached.cache_clear()
-
-
 def _market_board_spec(
     quotes: tuple[StockMarketQuote, ...], page_index: int, page_size: int
 ) -> _MarketBoardSpec:
@@ -172,6 +167,8 @@ def _market_board_spec(
     )
 
 
+# The cache key is the digest of every pixel-affecting quote field, so any quote
+# change yields a new key and a fresh render; stale entries are never served.
 @lru_cache(maxsize=128)
 def _build_market_board_image_cached(spec: _MarketBoardSpec) -> bytes:
     """Renders the market list as a fixed-layout PNG board."""

--- a/src/discordbot/cogs/auto_unmute.py
+++ b/src/discordbot/cogs/auto_unmute.py
@@ -11,6 +11,7 @@ from nextcord import User, Guild, Member, Message, AuditLogAction
 from nextcord.ext import commands
 from openai.types.responses.response_input_param import ResponseInputParam, EasyInputMessageParam
 
+from discordbot.utils.llm import create_litellm_client
 from discordbot.typings.llm import LLMConfig
 from discordbot.typings.models import RuntimeModelCatalog
 from discordbot.cogs._auto_unmute.prompts import UNMUTE_PROMPT
@@ -47,8 +48,7 @@ class AutoUnmuteCogs(commands.Cog):
         Returns:
             A configured client reused across auto-unmute reply generation.
         """
-        client = AsyncOpenAI(base_url=self.config.base_url, api_key=self.config.api_key)
-        return client
+        return create_litellm_client(config=self.config)
 
     @commands.Cog.listener()
     async def on_message(self, message: Message) -> None:

--- a/src/discordbot/cogs/games.py
+++ b/src/discordbot/cogs/games.py
@@ -10,6 +10,7 @@ import nextcord
 from nextcord import Embed, Locale, Interaction, SlashOption
 from nextcord.ext import commands
 
+from discordbot.utils.llm import create_litellm_client
 from discordbot.typings.llm import LLMConfig
 from discordbot.typings.games import (
     SystemIdentity,
@@ -70,8 +71,7 @@ class GamesCogs(commands.Cog):
     @cached_property
     def client(self) -> AsyncOpenAI:
         """The cached OpenAI-compatible client used for the system narrator and bot AI."""
-        client = AsyncOpenAI(base_url=self.config.base_url, api_key=self.config.api_key)
-        return client
+        return create_litellm_client(config=self.config)
 
     @cached_property
     def narrator(self) -> SystemNarrator:

--- a/src/discordbot/cogs/gen_reply.py
+++ b/src/discordbot/cogs/gen_reply.py
@@ -159,7 +159,7 @@ class ReplyGeneratorCogs(commands.Cog):
         video_model = self.runtime_models.video_model
         video = await self.client.videos.create(
             model=video_model.name,
-            prompt=user_prompt,
+            prompt=user_prompt or "請依照訊息內容生成一段影片。",
             extra_headers={"x-litellm-end-user-id": message.author.name},
         )
         while video.status not in ("completed", "failed"):
@@ -193,13 +193,13 @@ class ReplyGeneratorCogs(commands.Cog):
                 data_uris.append(image_url)
 
         if data_uris:
-            image_bytes_list: list[bytes] = []
+            tasks = []
             for uri in data_uris:
-                image_data = get_image_data(image_file=uri, use_b64=False)
-                image_bytes_list.append(image_data)
+                tasks.append(asyncio.to_thread(get_image_data, image_file=uri, use_b64=False))
+            image_bytes_list: list[bytes] = list(await asyncio.gather(*tasks))
             result = await self.client.images.edit(
                 image=image_bytes_list,
-                prompt=user_prompt,
+                prompt=user_prompt or "請依照附件內容進行編輯或優化。",
                 model=image_model.name,
                 n=1,
                 response_format="b64_json",
@@ -209,7 +209,7 @@ class ReplyGeneratorCogs(commands.Cog):
             )
         else:
             result = await self.client.images.generate(
-                prompt=user_prompt,
+                prompt=user_prompt or "請生成一張圖片。",
                 model=image_model.name,
                 n=1,
                 response_format="b64_json",

--- a/src/discordbot/cogs/gen_reply.py
+++ b/src/discordbot/cogs/gen_reply.py
@@ -16,6 +16,7 @@ from openai.types.responses.response_input_param import ResponseInputParam, Easy
 from openai.types.responses.response_input_text_param import ResponseInputTextParam
 from openai.types.responses.response_input_image_param import ResponseInputImageParam
 
+from discordbot.utils.llm import create_litellm_client
 from discordbot.typings.llm import LLMConfig
 from discordbot.utils.images import get_image_data, convert_base64_to_data_uri
 from discordbot.typings.models import RouteDecision, RuntimeModelCatalog
@@ -67,8 +68,7 @@ class ReplyGeneratorCogs(commands.Cog):
         Returns:
             A configured AsyncOpenAI client reused across reply requests.
         """
-        client = AsyncOpenAI(base_url=self.config.base_url, api_key=self.config.api_key)
-        return client
+        return create_litellm_client(config=self.config)
 
     @cached_property
     def input_builder(self) -> MessageInputBuilder:

--- a/src/discordbot/cogs/stock.py
+++ b/src/discordbot/cogs/stock.py
@@ -42,8 +42,7 @@ class StockCogs(commands.Cog):
         except ValidationError:
             return None
         return StockNewsAI(
-            client=create_litellm_client(config=config),
-            model=self.runtime_models.fast_model,
+            client=create_litellm_client(config=config), model=self.runtime_models.fast_model
         )
 
     @nextcord.slash_command(

--- a/src/discordbot/cogs/stock.py
+++ b/src/discordbot/cogs/stock.py
@@ -3,13 +3,13 @@
 import asyncio
 from functools import cached_property
 
-from openai import AsyncOpenAI
 import logfire
 import nextcord
 from nextcord import Locale, Interaction
 from pydantic import ValidationError
 from nextcord.ext import commands
 
+from discordbot.utils.llm import create_litellm_client
 from discordbot.typings.llm import LLMConfig
 from discordbot.typings.models import RuntimeModelCatalog
 from discordbot.cogs._stock.news import StockNewsAI
@@ -42,7 +42,7 @@ class StockCogs(commands.Cog):
         except ValidationError:
             return None
         return StockNewsAI(
-            client=AsyncOpenAI(base_url=config.base_url, api_key=config.api_key),
+            client=create_litellm_client(config=config),
             model=self.runtime_models.fast_model,
         )
 

--- a/src/discordbot/cogs/video.py
+++ b/src/discordbot/cogs/video.py
@@ -73,8 +73,9 @@ class VideoCogs(commands.Cog):
             downloader = VideoDownloader(output_folder="./data/downloads")
             result = await asyncio.to_thread(downloader.download, url=url, quality=quality)
             with result:
-                file_size_mb = result.filename.stat().st_size / 1024 / 1024
-                if result.filename.stat().st_size <= _DISCORD_FILE_LIMIT_BYTES:
+                size_bytes = result.filename.stat().st_size
+                file_size_mb = size_bytes / 1024 / 1024
+                if size_bytes <= _DISCORD_FILE_LIMIT_BYTES:
                     await self._deliver(
                         interaction=interaction,
                         file_size_mb=file_size_mb,
@@ -94,8 +95,9 @@ class VideoCogs(commands.Cog):
                 )
                 low_result = await asyncio.to_thread(downloader.download, url=url, quality="low")
                 with low_result:
-                    file_size_mb = low_result.filename.stat().st_size / 1024 / 1024
-                    if low_result.filename.stat().st_size > _DISCORD_FILE_LIMIT_BYTES:
+                    low_size_bytes = low_result.filename.stat().st_size
+                    file_size_mb = low_size_bytes / 1024 / 1024
+                    if low_size_bytes > _DISCORD_FILE_LIMIT_BYTES:
                         await interaction.edit_original_message(
                             content=f"-# 下載失敗\n檔案大小超過 {file_size_mb:.1f}MB"
                         )

--- a/src/discordbot/typings/economy.py
+++ b/src/discordbot/typings/economy.py
@@ -2,7 +2,7 @@ from enum import StrEnum
 from typing import Final
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import Field, BaseModel, ConfigDict
 
 BASE_MESSAGE_REWARD_AMOUNT: Final[int] = 5_000
 BASE_CHECKIN_REWARD_AMOUNT: Final[int] = 100_000
@@ -60,10 +60,10 @@ class AccountSnapshot(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    name: str
-    balance: int
-    total_earned: int
-    total_spent: int
+    name: str = Field(description="Last-seen Discord account name.")
+    balance: int = Field(description="Current point balance.")
+    total_earned: int = Field(description="Lifetime gross earned amount.")
+    total_spent: int = Field(description="Lifetime gross spent amount.")
 
 
 class AdminAccount(BaseModel):
@@ -71,8 +71,8 @@ class AdminAccount(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    user_id: int
-    name: str
+    user_id: int = Field(description="Discord user ID of the economy admin account.")
+    name: str = Field(description="Last-seen Discord account name.")
 
 
 class CentralBankerAccount(BaseModel):
@@ -80,8 +80,8 @@ class CentralBankerAccount(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    user_id: int
-    name: str
+    user_id: int = Field(description="Discord user ID of the central banker account.")
+    name: str = Field(description="Last-seen Discord account name.")
 
 
 class BotStatusEntry(BaseModel):
@@ -89,10 +89,10 @@ class BotStatusEntry(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    status_id: int
-    status_text: str
-    enabled: bool
-    order_index: int
+    status_id: int = Field(description="Row ID of the bot status entry.")
+    status_text: str = Field(description="Presence text rotated by the status task.")
+    enabled: bool = Field(description="Whether this status entry is active in the rotation.")
+    order_index: int = Field(description="Sort order position within the rotation.")
 
 
 class LeaderboardEntry(BaseModel):
@@ -100,10 +100,12 @@ class LeaderboardEntry(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    user_id: int
-    name: str
-    balance: int
-    avatar_url: str = ""
+    user_id: int = Field(description="Discord user ID of the leaderboard account.")
+    name: str = Field(description="Last-seen Discord account name.")
+    balance: int = Field(description="Current point balance used for ranking.")
+    avatar_url: str = Field(
+        default="", description="Last-seen Discord avatar URL for the account."
+    )
 
 
 class LossLeaderboardEntry(BaseModel):
@@ -111,10 +113,12 @@ class LossLeaderboardEntry(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    user_id: int
-    name: str
-    loss_amount: int
-    avatar_url: str = ""
+    user_id: int = Field(description="Discord user ID of the leaderboard account.")
+    name: str = Field(description="Last-seen Discord account name.")
+    loss_amount: int = Field(description="Gross current-day casino loss used for ranking.")
+    avatar_url: str = Field(
+        default="", description="Last-seen Discord avatar URL for the account."
+    )
 
 
 class CreditResult(BaseModel):
@@ -129,10 +133,14 @@ class CreditResult(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    new_balance: int
-    credited_amount: int
-    principal_repaid: int
-    remaining_debt: int
+    new_balance: int = Field(description="User balance after the credit.")
+    credited_amount: int = Field(description="Amount that landed in balance.")
+    principal_repaid: int = Field(
+        description="Always zero; long-term loans are repaid explicitly."
+    )
+    remaining_debt: int = Field(
+        description="Always zero; use portfolio / loan views for active debt."
+    )
 
 
 class BalanceAdjustmentResult(BaseModel):
@@ -145,8 +153,8 @@ class BalanceAdjustmentResult(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    new_balance: int
-    applied_delta: int
+    new_balance: int = Field(description="User balance after the adjustment.")
+    applied_delta: int = Field(description="Signed balance delta that was actually applied.")
 
 
 class WalletDeltaLeg(BaseModel):
@@ -154,8 +162,8 @@ class WalletDeltaLeg(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    delta: int
-    reason: str = ""
+    delta: int = Field(description="Signed wallet delta to apply for this leg.")
+    reason: str = Field(default="", description="Optional reason describing this wallet delta.")
 
 
 class OrderedWalletDeltaResult(BaseModel):
@@ -163,8 +171,10 @@ class OrderedWalletDeltaResult(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    new_balance: int
-    applied_deltas: tuple[int, ...]
+    new_balance: int = Field(description="User balance after all ordered deltas are applied.")
+    applied_deltas: tuple[int, ...] = Field(
+        description="Signed deltas that were actually applied, in order."
+    )
 
 
 class JackpotSettlementRequest(BaseModel):
@@ -185,12 +195,24 @@ class JackpotSettlementRequest(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    player_id: int
-    player_account_name: str
-    player_delta: int
-    player_avatar_url: str = ""
-    require_full_debit: bool = False
-    expected_jackpot_generation: int | None = None
+    player_id: int = Field(description="Discord user ID for the player account.")
+    player_account_name: str = Field(
+        description="Last-seen account name stored on the player row."
+    )
+    player_delta: int = Field(
+        description="Signed change for the player; the pool receives the inverse."
+    )
+    player_avatar_url: str = Field(
+        default="", description="Last-seen Discord avatar URL for the player."
+    )
+    require_full_debit: bool = Field(
+        default=False,
+        description="Whether a negative delta must be applied in full, rejecting the whole batch instead of clamping at the player's current balance.",
+    )
+    expected_jackpot_generation: int | None = Field(
+        default=None,
+        description="Optional jackpot generation observed by the game view; positive payouts only claim from this generation.",
+    )
 
 
 class JackpotSettlementBatchResult(BaseModel):
@@ -211,12 +233,26 @@ class JackpotSettlementBatchResult(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    player_balances: dict[int, int]
-    applied_player_deltas: dict[int, int]
-    jackpot_balance: int
-    jackpot_generation: int = 0
-    jackpot_depleted: bool = False
-    rejected_player_ids: tuple[int, ...] = ()
+    player_balances: dict[int, int] = Field(
+        description="Latest post-settlement balance for each touched player."
+    )
+    applied_player_deltas: dict[int, int] = Field(
+        description="Signed player deltas that were actually applied; losses may be smaller than requested when the balance clamps at zero."
+    )
+    jackpot_balance: int = Field(
+        description="Pool balance after the final settlement and any reseed."
+    )
+    jackpot_generation: int = Field(
+        default=0, description="Pool generation after the final settlement and any reseed."
+    )
+    jackpot_depleted: bool = Field(
+        default=False,
+        description="True when a seeded pool was drained and automatically replenished during this batch.",
+    )
+    rejected_player_ids: tuple[int, ...] = Field(
+        default=(),
+        description="Player IDs whose required full debit could not be applied; no mutation is committed when non-empty.",
+    )
 
 
 class JackpotSnapshot(BaseModel):
@@ -224,8 +260,8 @@ class JackpotSnapshot(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    balance: int
-    generation: int = 0
+    balance: int = Field(description="Current jackpot pool balance.")
+    generation: int = Field(default=0, description="Current jackpot pool generation counter.")
 
 
 class JackpotSettlementResult(BaseModel):
@@ -233,12 +269,20 @@ class JackpotSettlementResult(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    player_balance: int
-    jackpot_balance: int
-    jackpot_generation: int = 0
-    applied_player_delta: int
-    jackpot_depleted: bool = False
-    rejected: bool = False
+    player_balance: int = Field(description="Player balance after this settlement.")
+    jackpot_balance: int = Field(description="Pool balance after this settlement and any reseed.")
+    jackpot_generation: int = Field(
+        default=0, description="Pool generation after this settlement and any reseed."
+    )
+    applied_player_delta: int = Field(description="Signed player delta that was actually applied.")
+    jackpot_depleted: bool = Field(
+        default=False,
+        description="True when a seeded pool was drained and replenished during this settlement.",
+    )
+    rejected: bool = Field(
+        default=False,
+        description="True when a required full debit could not be applied and no mutation was committed.",
+    )
 
 
 class CasinoLedgerSnapshot(BaseModel):
@@ -246,10 +290,10 @@ class CasinoLedgerSnapshot(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    balance: int
-    total_earned: int
-    total_spent: int
-    updated_at: datetime
+    balance: int = Field(description="Current casino system ledger balance.")
+    total_earned: int = Field(description="Lifetime gross amount earned by the casino ledger.")
+    total_spent: int = Field(description="Lifetime gross amount paid out by the casino ledger.")
+    updated_at: datetime = Field(description="Timestamp of the last casino ledger update.")
 
 
 class CasinoDailyStats(BaseModel):
@@ -261,9 +305,9 @@ class CasinoDailyStats(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    daily_loss: int
-    daily_win: int
-    daily_net: int
+    daily_loss: int = Field(description="Gross current-day casino loss total.")
+    daily_win: int = Field(description="Gross current-day casino win total.")
+    daily_net: int = Field(description="Net current-day casino result (win minus loss).")
 
 
 class RoundSettlementResult(BaseModel):
@@ -271,8 +315,10 @@ class RoundSettlementResult(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    player_balance: int
-    casino_balance: int
+    player_balance: int = Field(description="Player balance after the round settlement.")
+    casino_balance: int = Field(
+        description="Casino system ledger balance after the round settlement."
+    )
 
 
 class TransferResult(BaseModel):
@@ -285,8 +331,8 @@ class TransferResult(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    sender_balance: int
-    receiver_balance: int
+    sender_balance: int = Field(description="Sender balance after the debit.")
+    receiver_balance: int = Field(description="Receiver balance after the credit.")
 
 
 class CheckinResult(BaseModel):
@@ -303,10 +349,16 @@ class CheckinResult(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    new_balance: int
-    amount: int
-    streak: int
-    is_vip: bool
+    new_balance: int = Field(description="User balance after the payout.")
+    amount: int = Field(
+        description="Total amount credited for this check-in (base * streak bonus * VIP multiplier)."
+    )
+    streak: int = Field(
+        description="Streak counter persisted on the account after this check-in (1..CHECKIN_STREAK_CYCLE)."
+    )
+    is_vip: bool = Field(
+        description="VIP status of the account at check-in time, surfaced so the embed can label the bonus correctly."
+    )
 
 
 class VipPurchaseResult(BaseModel):
@@ -319,8 +371,8 @@ class VipPurchaseResult(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    new_balance: int
-    cost: int
+    new_balance: int = Field(description="User balance after the 10M debit.")
+    cost: int = Field(description="Points deducted for the purchase.")
 
 
 class LoanProposalView(BaseModel):
@@ -328,18 +380,20 @@ class LoanProposalView(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    proposal_id: int
-    kind: LoanProposalKind
-    status: LoanProposalStatus
-    lender_type: LoanLenderType
-    borrower_id: int
-    borrower_name: str
-    lender_id: int | None
-    lender_name: str
-    amount: int
-    monthly_rate_bps: int
-    escrow_amount: int
-    created_at: datetime
+    proposal_id: int = Field(description="Row ID of the loan proposal.")
+    kind: LoanProposalKind = Field(description="Pending loan proposal flow type.")
+    status: LoanProposalStatus = Field(description="Current lifecycle state of the proposal.")
+    lender_type: LoanLenderType = Field(description="Kind of lender backing the proposed loan.")
+    borrower_id: int = Field(description="Discord user ID of the borrower.")
+    borrower_name: str = Field(description="Last-seen account name of the borrower.")
+    lender_id: int | None = Field(
+        description="Discord user ID of the lender, or None for central-bank loans."
+    )
+    lender_name: str = Field(description="Display name of the lender.")
+    amount: int = Field(description="Proposed loan principal amount.")
+    monthly_rate_bps: int = Field(description="Monthly simple-interest rate in basis points.")
+    escrow_amount: int = Field(description="Amount held in escrow while the proposal is pending.")
+    created_at: datetime = Field(description="Timestamp the proposal was created.")
 
 
 class LoanContractView(BaseModel):
@@ -347,18 +401,22 @@ class LoanContractView(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    contract_id: int
-    lender_type: LoanLenderType
-    lender_id: int | None
-    lender_name: str
-    borrower_id: int
-    borrower_name: str
-    principal_remaining: int
-    interest_due: int
-    monthly_rate_bps: int
-    opened_at: datetime
-    last_interest_accrued_at: datetime
-    status: LoanContractStatus
+    contract_id: int = Field(description="Row ID of the loan contract.")
+    lender_type: LoanLenderType = Field(description="Kind of lender backing the contract.")
+    lender_id: int | None = Field(
+        description="Discord user ID of the lender, or None for central-bank loans."
+    )
+    lender_name: str = Field(description="Display name of the lender.")
+    borrower_id: int = Field(description="Discord user ID of the borrower.")
+    borrower_name: str = Field(description="Last-seen account name of the borrower.")
+    principal_remaining: int = Field(description="Outstanding loan principal still owed.")
+    interest_due: int = Field(description="Accrued interest currently due on the contract.")
+    monthly_rate_bps: int = Field(description="Monthly simple-interest rate in basis points.")
+    opened_at: datetime = Field(description="Timestamp the contract was opened.")
+    last_interest_accrued_at: datetime = Field(
+        description="Timestamp through which interest has been accrued."
+    )
+    status: LoanContractStatus = Field(description="Current lifecycle state of the contract.")
 
 
 class LoanProposalAcceptResult(BaseModel):
@@ -366,10 +424,18 @@ class LoanProposalAcceptResult(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    contract: LoanContractView
-    borrower_balance: int
-    lender_balance: int | None = None
-    central_bank_available_credit: int | None = None
+    contract: LoanContractView = Field(
+        description="The loan contract created from the accepted proposal."
+    )
+    borrower_balance: int = Field(description="Borrower balance after acceptance.")
+    lender_balance: int | None = Field(
+        default=None,
+        description="Lender balance after acceptance, or None for central-bank loans.",
+    )
+    central_bank_available_credit: int | None = Field(
+        default=None,
+        description="Remaining central bank available credit after acceptance, or None for personal loans.",
+    )
 
 
 class LoanPaymentResult(BaseModel):
@@ -377,14 +443,21 @@ class LoanPaymentResult(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    paid_amount: int
-    interest_paid: int
-    principal_paid: int
-    borrower_balance: int
-    lender_balance: int | None = None
-    remaining_principal: int
-    remaining_interest: int
-    closed_contract_ids: tuple[int, ...] = ()
+    paid_amount: int = Field(description="Total amount paid in this repayment or collection.")
+    interest_paid: int = Field(description="Portion of the payment applied to interest.")
+    principal_paid: int = Field(description="Portion of the payment applied to principal.")
+    borrower_balance: int = Field(description="Borrower balance after the payment.")
+    lender_balance: int | None = Field(
+        default=None,
+        description="Lender balance after the payment, or None for central-bank loans.",
+    )
+    remaining_principal: int = Field(
+        description="Outstanding principal still owed after the payment."
+    )
+    remaining_interest: int = Field(description="Accrued interest still due after the payment.")
+    closed_contract_ids: tuple[int, ...] = Field(
+        default=(), description="Contract IDs closed as a result of this payment."
+    )
 
 
 class CentralBankStatus(BaseModel):
@@ -392,9 +465,13 @@ class CentralBankStatus(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    total_positive_user_balance: int
-    outstanding_principal: int
-    available_credit: int
+    total_positive_user_balance: int = Field(
+        description="Sum of all positive user balances backing central bank credit."
+    )
+    outstanding_principal: int = Field(
+        description="Total central bank loan principal currently outstanding."
+    )
+    available_credit: int = Field(description="Remaining central bank lending capacity.")
 
 
 class PortfolioView(BaseModel):
@@ -402,12 +479,12 @@ class PortfolioView(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    user_id: int
-    name: str
-    balance: int
-    debt_principal: int
-    debt_interest: int
-    net_worth: int
+    user_id: int = Field(description="Discord user ID of the account.")
+    name: str = Field(description="Last-seen Discord account name.")
+    balance: int = Field(description="Current spendable wallet balance.")
+    debt_principal: int = Field(description="Total outstanding loan principal.")
+    debt_interest: int = Field(description="Total accrued loan interest due.")
+    net_worth: int = Field(description="Balance minus total debt principal and interest.")
 
 
 __all__ = [

--- a/src/discordbot/typings/games.py
+++ b/src/discordbot/typings/games.py
@@ -29,8 +29,8 @@ class Card(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    rank: str
-    suit: str
+    rank: str = Field(description="Card rank: one of A, 2-10, J, Q, K.")
+    suit: str = Field(description="One of the four unicode suit glyphs.")
 
     def __str__(self) -> str:
         """Human-readable label like `A♠`."""
@@ -52,13 +52,19 @@ class GameParticipant(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    user_id: int
-    account_name: str
-    display_name: str
-    avatar_url: str = ""
-    bet: int
-    balance_at_start: int
-    is_allin: bool
+    user_id: int = Field(description="Discord user ID for the account row and interaction checks.")
+    account_name: str = Field(
+        description="Stable Discord username stored in the economy account row."
+    )
+    display_name: str = Field(description="Guild-aware display name shown in game embeds.")
+    avatar_url: str = Field(
+        default="", description="Last-seen Discord avatar URL for the economy account row."
+    )
+    bet: int = Field(description="Effective wager for this player.")
+    balance_at_start: int = Field(description="Balance observed when the game session starts.")
+    is_allin: bool = Field(
+        description="True when the effective wager consumes the full observed balance."
+    )
 
 
 class GameParticipantIdentity(BaseModel):
@@ -66,10 +72,14 @@ class GameParticipantIdentity(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    user_id: int
-    account_name: str
-    display_name: str
-    avatar_url: str = ""
+    user_id: int = Field(description="Discord user ID for the account row and interaction checks.")
+    account_name: str = Field(
+        description="Stable Discord username stored in the economy account row."
+    )
+    display_name: str = Field(description="Guild-aware display name shown in game embeds.")
+    avatar_url: str = Field(
+        default="", description="Last-seen Discord avatar URL for the economy account row."
+    )
 
 
 class SystemIdentity(BaseModel):
@@ -77,9 +87,11 @@ class SystemIdentity(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    system_id: int
-    system_name: str
-    system_avatar_url: str = ""
+    system_id: int = Field(description="Discord user ID used for the casino system narrator.")
+    system_name: str = Field(description="Display name used for the casino system narrator.")
+    system_avatar_url: str = Field(
+        default="", description="Avatar URL used for the casino system narrator."
+    )
 
 
 class ParticipantPreparationResult(BaseModel):
@@ -87,8 +99,10 @@ class ParticipantPreparationResult(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    participant: GameParticipant | None
-    balance: int
+    participant: GameParticipant | None = Field(
+        description="Prepared game participant, or None when preparation failed."
+    )
+    balance: int = Field(description="Player balance observed during preparation.")
 
 
 class RefreshParticipantsResult(BaseModel):
@@ -96,8 +110,12 @@ class RefreshParticipantsResult(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    participants: list[GameParticipant] = Field(default_factory=list)
-    dropped_names: list[str] = Field(default_factory=list)
+    participants: list[GameParticipant] = Field(
+        default_factory=list, description="Players still eligible to start the round."
+    )
+    dropped_names: list[str] = Field(
+        default_factory=list, description="Display names of players dropped during the re-check."
+    )
 
 
 class WagerSettlement(BaseModel):
@@ -116,13 +134,25 @@ class WagerSettlement(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    delta: int
-    payout: int
-    new_balance: int
-    casino_balance: int
-    base_delta: int | None = None
-    vip_bonus: int = 0
-    is_vip: bool = False
+    delta: int = Field(description="Net point change for the round.")
+    payout: int = Field(
+        description="Positive player credit from the round, excluding losses and pushes."
+    )
+    new_balance: int = Field(description="Player balance after applying the signed round delta.")
+    casino_balance: int = Field(
+        description="Casino ledger balance after applying the casino-side settlement."
+    )
+    base_delta: int | None = Field(
+        default=None,
+        description=(
+            "Net point change before any VIP payout bonus; None for legacy/manual test "
+            "settlements that do not carry bonus details."
+        ),
+    )
+    vip_bonus: int = Field(default=0, description="Extra points added by the VIP payout bonus.")
+    is_vip: bool = Field(
+        default=False, description="Whether the VIP perk was active for this settlement."
+    )
 
 
 class BlackjackHandSettlement(BaseModel):
@@ -148,15 +178,24 @@ class BlackjackHandSettlement(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    cards: list[Card]
-    bet: int
-    outcome: SettleOutcome
-    delta: int
-    five_card_bonus: int = 0
-    five_card_twenty_one: bool = False
-    doubled: bool = False
-    surrendered: bool = False
-    is_split_hand: bool = False
+    cards: list[Card] = Field(description="Cards held by this sub-hand at settlement time.")
+    bet: int = Field(description="Effective wager for this hand (doubled bets land here as 2x).")
+    outcome: SettleOutcome = Field(description="Player-facing outcome label for this sub-hand.")
+    delta: int = Field(
+        description=(
+            "Dealer-paid signed point change for this single hand before VIP and "
+            "five-card bonuses."
+        )
+    )
+    five_card_bonus: int = Field(default=0, description="System-funded bonus for a five-card 21.")
+    five_card_twenty_one: bool = Field(
+        default=False, description="True when this hand made five or more cards totaling 21."
+    )
+    doubled: bool = Field(default=False, description="True if this hand was doubled.")
+    surrendered: bool = Field(default=False, description="True if this hand was surrendered.")
+    is_split_hand: bool = Field(
+        default=False, description="True if this hand came out of a Split."
+    )
 
 
 class BlackjackInsuranceSettlement(BaseModel):
@@ -171,9 +210,11 @@ class BlackjackInsuranceSettlement(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    bet: int
-    won: bool
-    delta: int
+    bet: int = Field(description="Insurance bet amount (half the original wager).")
+    won: bool = Field(description="True only when the dealer's hole-card peek was a Blackjack.")
+    delta: int = Field(
+        description="Signed point change for this side bet (+bet*2 on win, -bet on loss)."
+    )
 
 
 class BlackjackPlayerSettlement(WagerSettlement):
@@ -194,11 +235,24 @@ class BlackjackPlayerSettlement(WagerSettlement):
         five_card_bonus: Aggregate system-funded five-card 21 bonus.
     """
 
-    outcome: SettleOutcome
-    detail: str
-    hands: list[BlackjackHandSettlement] = Field(default_factory=list)
-    insurance: BlackjackInsuranceSettlement | None = None
-    five_card_bonus: int = 0
+    outcome: SettleOutcome = Field(
+        description=(
+            "Aggregate player-facing outcome. Single-hand results without insurance preserve "
+            "the hand outcome; insurance and multi-hand results collapse to win / lose / push "
+            "by net base delta."
+        )
+    )
+    detail: str = Field(description="Short game-state summary for the dealer AI prompt.")
+    hands: list[BlackjackHandSettlement] = Field(
+        default_factory=list, description="Per-hand settlements in display order."
+    )
+    insurance: BlackjackInsuranceSettlement | None = Field(
+        default=None,
+        description="Insurance side-bet result, or None when the player never took insurance.",
+    )
+    five_card_bonus: int = Field(
+        default=0, description="Aggregate system-funded five-card 21 bonus."
+    )
 
 
 class BlackjackPlayerResult(BaseModel):
@@ -211,8 +265,10 @@ class BlackjackPlayerResult(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    participant: GameParticipant
-    settlement: BlackjackPlayerSettlement
+    participant: GameParticipant = Field(description="Player identity and wager metadata.")
+    settlement: BlackjackPlayerSettlement = Field(
+        description="Database-backed result for that player's hand."
+    )
 
 
 class BlackjackDealerDecision(BaseModel):
@@ -220,8 +276,8 @@ class BlackjackDealerDecision(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    action: BlackjackDealerAction
-    reason: str
+    action: BlackjackDealerAction = Field(description="Dealer hit or stand decision.")
+    reason: str = Field(description="Rationale for the dealer's decision.")
 
 
 class BotPlayerBetDecision(BaseModel):
@@ -262,12 +318,12 @@ class BotFinancialContext(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    balance: int
-    total_earned: int
-    total_spent: int
-    daily_loss: int
-    daily_win: int
-    daily_net: int
+    balance: int = Field(description="Spendable wallet balance today.")
+    total_earned: int = Field(description="Lifetime gross points earned.")
+    total_spent: int = Field(description="Lifetime gross points spent.")
+    daily_loss: int = Field(description="Casino loss accrued during today's Taipei calendar day.")
+    daily_win: int = Field(description="Casino win accrued during today's Taipei calendar day.")
+    daily_net: int = Field(description="Net casino result during today's Taipei calendar day.")
 
 
 class OtherPlayerView(BaseModel):
@@ -275,10 +331,10 @@ class OtherPlayerView(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    display_name: str
-    bet: int
-    hands: list[str]
-    is_finished: bool
+    display_name: str = Field(description="Guild-aware display name of the other player.")
+    bet: int = Field(description="That player's effective wager.")
+    hands: list[str] = Field(description="Human-readable summaries of that player's hands.")
+    is_finished: bool = Field(description="True when that player has finished their turn.")
 
 
 class DealerOutcome(BaseModel):
@@ -352,14 +408,22 @@ class BlackjackDealerStep(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    total_before: int
-    action: BlackjackDealerAction
-    reason: str
-    source: BlackjackDealerStepSource = "auto"
-    drawn_card: Card | None = None
-    total_after: int | None = None
-    fallback: bool = False
-    forced: bool = False
+    total_before: int = Field(description="Dealer hand total before this action.")
+    action: BlackjackDealerAction = Field(description="Dealer hit or stand action taken.")
+    reason: str = Field(description="Rationale recorded for this dealer action.")
+    source: BlackjackDealerStepSource = Field(
+        default="auto", description="Whether the action came from the auto engine or a guard."
+    )
+    drawn_card: Card | None = Field(
+        default=None, description="Card drawn on a hit, or None for a stand."
+    )
+    total_after: int | None = Field(
+        default=None, description="Dealer hand total after this action, when applicable."
+    )
+    fallback: bool = Field(
+        default=False, description="True when this step came from a fallback path."
+    )
+    forced: bool = Field(default=False, description="True when this step was forced by a guard.")
 
 
 class DragonGatePlayerResult(BaseModel):
@@ -384,11 +448,23 @@ class DragonGatePlayerResult(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    participant: GameParticipant
-    delta: int
-    final_balance: int
-    withdrawn: bool
-    refunded_to_pool: int = 0
+    participant: GameParticipant = Field(description="Player identity and ante metadata.")
+    delta: int = Field(
+        description=(
+            "Running win/loss for the table (ante excluded; ante was already pushed into "
+            "the jackpot when the round started)."
+        )
+    )
+    final_balance: int = Field(
+        description="Player balance after the last settlement event touching this account."
+    )
+    withdrawn: bool = Field(
+        description="True when the player left voluntarily before timeout or pool exhaustion."
+    )
+    refunded_to_pool: int = Field(
+        default=0,
+        description='Amount refunded into the jackpot under "逆贏不拿" when the player left while ahead.',
+    )
 
 
 __all__ = [

--- a/src/discordbot/typings/models.py
+++ b/src/discordbot/typings/models.py
@@ -57,7 +57,7 @@ class RuntimeModelCatalog(BaseModel):
         """Whether runtime model selection is in the peak-hour window.
 
         Returns:
-            True during UTC weekdays from 08:00 to 17:00, otherwise False.
+            True during UTC weekdays from 08:00 up to (but excluding) 17:00, otherwise False.
         """
         now = datetime.now(UTC)
         return now.weekday() < 5 and 8 <= now.hour < 17

--- a/src/discordbot/typings/models.py
+++ b/src/discordbot/typings/models.py
@@ -8,10 +8,20 @@ from openai.types.shared_params.reasoning import Reasoning
 
 
 class ModelSettings(BaseModel):
-    """Model name and reasoning effort that should be used together."""
+    """Model name and reasoning effort that should be used together.
 
-    name: str
-    effort: ReasoningEffort = Field(default="none")
+    Attributes:
+        name: LiteLLM model string dispatched on the Responses API.
+        effort: Reasoning effort passed to the Responses API for this model.
+    """
+
+    name: str = Field(
+        description="LiteLLM model string dispatched on the Responses API.",
+        examples=["gemini-flash-latest", "gemini-3-pro-image-preview"],
+    )
+    effort: ReasoningEffort = Field(
+        default="none", description="Reasoning effort passed to the Responses API for this model."
+    )
 
     @property
     def reasoning(self) -> Reasoning:

--- a/src/discordbot/typings/stock.py
+++ b/src/discordbot/typings/stock.py
@@ -44,22 +44,32 @@ class StockProfileView(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    symbol: str
-    name: str
-    category: str
-    price_cents: int
-    previous_close_price_cents: int
-    day_open_price_cents: int
-    total_shares: int
-    float_shares: int
-    base_volatility_bps: int
-    volatility_amplifier_bps: int
-    liquidity_shares: int
-    fair_value_cents: int
-    mean_reversion_bps: int
-    max_tick_change_bps: int
-    news_cadence_hours: int
-    updated_at: datetime
+    symbol: str = Field(description="Virtual company ticker symbol.")
+    name: str = Field(description="Display name of the virtual company.")
+    category: str = Field(description="Market category the company belongs to.")
+    price_cents: int = Field(description="Latest quote price in cents.")
+    previous_close_price_cents: int = Field(
+        description="Previous trading-day close price in cents."
+    )
+    day_open_price_cents: int = Field(description="Current trading-day open price in cents.")
+    total_shares: int = Field(description="Total issued share count.")
+    float_shares: int = Field(description="Tradable float share count.")
+    base_volatility_bps: int = Field(description="Baseline per-tick volatility in basis points.")
+    volatility_amplifier_bps: int = Field(
+        description="Additional volatility amplifier in basis points."
+    )
+    liquidity_shares: int = Field(
+        description="Liquidity depth in shares used for order-size slippage."
+    )
+    fair_value_cents: int = Field(description="Mean-reversion fair value anchor in cents.")
+    mean_reversion_bps: int = Field(
+        description="Per-tick mean-reversion pull toward fair value in basis points."
+    )
+    max_tick_change_bps: int = Field(description="Cap on price change per tick in basis points.")
+    news_cadence_hours: int = Field(
+        description="Minimum hours between news refreshes for this symbol."
+    )
+    updated_at: datetime = Field(description="Timestamp of the latest profile update.")
 
 
 class StockProfileUpsert(BaseModel):
@@ -67,19 +77,52 @@ class StockProfileUpsert(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    symbol: str = Field(min_length=1, max_length=16)
-    name: str = Field(min_length=1, max_length=128)
-    category: str = Field(min_length=1, max_length=64)
-    price_cents: int = Field(ge=1)
-    total_shares: int = Field(ge=1)
-    float_shares: int = Field(ge=0)
-    base_volatility_bps: int = Field(ge=0)
-    volatility_amplifier_bps: int = Field(ge=0)
-    liquidity_shares: int = Field(ge=1)
-    fair_value_cents: int = Field(ge=1)
-    mean_reversion_bps: int = Field(ge=0)
-    max_tick_change_bps: int = Field(ge=1)
-    news_cadence_hours: int = Field(ge=1)
+    symbol: str = Field(
+        min_length=1,
+        max_length=16,
+        description="Virtual company ticker symbol.",
+        examples=["ACME"],
+    )
+    name: str = Field(
+        min_length=1,
+        max_length=128,
+        description="Display name of the virtual company.",
+        examples=["Acme Corp"],
+    )
+    category: str = Field(
+        min_length=1,
+        max_length=64,
+        description="Market category the company belongs to.",
+        examples=["tech"],
+    )
+    price_cents: int = Field(ge=1, description="Initial quote price in cents.", examples=[10000])
+    total_shares: int = Field(ge=1, description="Total issued share count.", examples=[1000000])
+    float_shares: int = Field(ge=0, description="Tradable float share count.", examples=[500000])
+    base_volatility_bps: int = Field(
+        ge=0, description="Baseline per-tick volatility in basis points.", examples=[50]
+    )
+    volatility_amplifier_bps: int = Field(
+        ge=0, description="Additional volatility amplifier in basis points.", examples=[20]
+    )
+    liquidity_shares: int = Field(
+        ge=1,
+        description="Liquidity depth in shares used for order-size slippage.",
+        examples=[10000],
+    )
+    fair_value_cents: int = Field(
+        ge=1, description="Mean-reversion fair value anchor in cents.", examples=[10000]
+    )
+    mean_reversion_bps: int = Field(
+        ge=0,
+        description="Per-tick mean-reversion pull toward fair value in basis points.",
+        examples=[10],
+    )
+    max_tick_change_bps: int = Field(
+        ge=1, description="Cap on price change per tick in basis points.", examples=[300]
+    )
+    news_cadence_hours: int = Field(
+        ge=1, description="Minimum hours between news refreshes for this symbol.", examples=[4]
+    )
 
     @model_validator(mode="after")
     def validate_share_structure(self) -> Self:
@@ -95,15 +138,23 @@ class StockPositionView(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    symbol: str
-    user_id: int
-    user_name: str = ""
-    long_shares: int = 0
-    long_cost_basis: int = 0
-    short_shares: int = 0
-    short_entry_value: int = 0
-    short_collateral: int = 0
-    realized_pnl: int = 0
+    symbol: str = Field(description="Virtual company ticker symbol.")
+    user_id: int = Field(description="Discord user ID owning the position.")
+    user_name: str = Field(default="", description="Stored display name of the position owner.")
+    long_shares: int = Field(default=0, description="Number of shares held long.")
+    long_cost_basis: int = Field(
+        default=0, description="Aggregate cost basis of the long position in cents."
+    )
+    short_shares: int = Field(default=0, description="Number of shares held short.")
+    short_entry_value: int = Field(
+        default=0, description="Aggregate entry value of the short position in cents."
+    )
+    short_collateral: int = Field(
+        default=0, description="Collateral reserved against the short position in cents."
+    )
+    realized_pnl: int = Field(
+        default=0, description="Realized profit and loss for this position in cents."
+    )
 
 
 class StockParticipantPositionView(BaseModel):
@@ -111,11 +162,11 @@ class StockParticipantPositionView(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    user_id: int
-    user_name: str
-    long_shares: int
-    short_shares: int
-    realized_pnl: int
+    user_id: int = Field(description="Discord user ID of the participant.")
+    user_name: str = Field(description="Stored display name of the participant.")
+    long_shares: int = Field(description="Number of shares the participant holds long.")
+    short_shares: int = Field(description="Number of shares the participant holds short.")
+    realized_pnl: int = Field(description="Realized profit and loss for the participant in cents.")
 
 
 class StockTradeLegView(BaseModel):
@@ -123,19 +174,23 @@ class StockTradeLegView(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    operation_id: str
-    leg_order: int
-    symbol: str
-    user_id: int
-    user_name: str = ""
-    leg_type: StockTradeLegType
-    shares: int
-    price_cents: int
-    wallet_delta: int
-    basis_delta: int
-    collateral_delta: int
-    realized_pnl_delta: int
-    created_at: datetime
+    operation_id: str = Field(description="Parent stock operation identifier.")
+    leg_order: int = Field(description="Ordering index of this leg within the operation.")
+    symbol: str = Field(description="Virtual company ticker symbol.")
+    user_id: int = Field(description="Discord user ID the leg belongs to.")
+    user_name: str = Field(default="", description="Stored display name of the leg owner.")
+    leg_type: StockTradeLegType = Field(description="Type of atomic trade leg.")
+    shares: int = Field(description="Share quantity executed in this leg.")
+    price_cents: int = Field(description="Per-leg execution price in cents.")
+    wallet_delta: int = Field(description="Wallet balance change applied by this leg.")
+    basis_delta: int = Field(description="Cost-basis change applied by this leg in cents.")
+    collateral_delta: int = Field(
+        description="Short collateral change applied by this leg in cents."
+    )
+    realized_pnl_delta: int = Field(
+        description="Realized profit and loss change applied by this leg in cents."
+    )
+    created_at: datetime = Field(description="Timestamp the leg was created.")
 
 
 class StockNewsView(BaseModel):
@@ -143,13 +198,17 @@ class StockNewsView(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    symbol: str
-    headline: str
-    sentiment_bps: int
-    source: str = "template"
-    model: str = ""
-    expires_at: datetime | None = None
-    created_at: datetime
+    symbol: str = Field(description="Virtual company ticker symbol.")
+    headline: str = Field(description="News headline text.")
+    sentiment_bps: int = Field(description="News sentiment impulse in basis points.")
+    source: str = Field(
+        default="template", description="Origin of the news item, such as template or model."
+    )
+    model: str = Field(default="", description="Model identifier that generated the news, if any.")
+    expires_at: datetime | None = Field(
+        default=None, description="Timestamp after which the news is stale, if set."
+    )
+    created_at: datetime = Field(description="Timestamp the news item was created.")
 
 
 class StockGeneratedNews(BaseModel):
@@ -157,10 +216,10 @@ class StockGeneratedNews(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    headline: str
-    sentiment_bps: int
-    source: str
-    model: str = ""
+    headline: str = Field(description="Generated news headline text.")
+    sentiment_bps: int = Field(description="Generated news sentiment impulse in basis points.")
+    source: str = Field(description="Origin of the generated news, such as template or model.")
+    model: str = Field(default="", description="Model identifier that generated the news, if any.")
 
 
 class StockNewsGenerationContext(BaseModel):
@@ -168,17 +227,23 @@ class StockNewsGenerationContext(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    profile: StockProfileView
-    change_cents: int
-    change_bps: int
-    pressure_bps: int
-    buy_side_shares: int
-    sell_side_shares: int
-    net_order_shares: int
-    recent_news_sentiment_bps: int
-    latest_news_headline: str = ""
-    latest_news_sentiment_bps: int = 0
-    lookback_hours: int
+    profile: StockProfileView = Field(description="Stock profile and latest quote for context.")
+    change_cents: int = Field(description="Daily price change in cents.")
+    change_bps: int = Field(description="Daily price change in basis points.")
+    pressure_bps: int = Field(description="Recent decayed order-flow pressure in basis points.")
+    buy_side_shares: int = Field(description="Recent buy-side order flow in shares.")
+    sell_side_shares: int = Field(description="Recent sell-side order flow in shares.")
+    net_order_shares: int = Field(description="Net order flow in shares.")
+    recent_news_sentiment_bps: int = Field(
+        description="Existing decayed news sentiment in basis points."
+    )
+    latest_news_headline: str = Field(default="", description="Most recent news headline, if any.")
+    latest_news_sentiment_bps: int = Field(
+        default=0, description="Sentiment of the most recent news in basis points."
+    )
+    lookback_hours: int = Field(
+        description="Lookback window in hours used to compute the context."
+    )
 
 
 class StockPriceTickView(BaseModel):
@@ -186,9 +251,9 @@ class StockPriceTickView(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    symbol: str
-    price_cents: int
-    created_at: datetime
+    symbol: str = Field(description="Virtual company ticker symbol.")
+    price_cents: int = Field(description="Quote price at this tick in cents.")
+    created_at: datetime = Field(description="Timestamp of the price tick.")
 
 
 class StockMarketQuote(BaseModel):
@@ -196,10 +261,10 @@ class StockMarketQuote(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    profile: StockProfileView
-    change_cents: int
-    change_bps: int
-    pressure_bps: int
+    profile: StockProfileView = Field(description="Stock profile and latest quote.")
+    change_cents: int = Field(description="Daily price change in cents.")
+    change_bps: int = Field(description="Daily price change in basis points.")
+    pressure_bps: int = Field(description="Recent order-flow pressure in basis points.")
 
 
 class StockDetailViewData(BaseModel):
@@ -207,13 +272,21 @@ class StockDetailViewData(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    quote: StockMarketQuote
-    balance: int
-    position: StockPositionView
-    recent_trades: tuple[StockTradeLegView, ...]
-    public_positions: tuple[StockParticipantPositionView, ...] = ()
-    news: tuple[StockNewsView, ...]
-    ticks: tuple[StockPriceTickView, ...]
+    quote: StockMarketQuote = Field(description="Market quote for the selected stock.")
+    balance: int = Field(description="Viewing user's wallet cash balance.")
+    position: StockPositionView = Field(
+        description="Viewing user's current position in the stock."
+    )
+    recent_trades: tuple[StockTradeLegView, ...] = Field(
+        description="Recent trade legs for the viewing user."
+    )
+    public_positions: tuple[StockParticipantPositionView, ...] = Field(
+        default=(), description="Public position summaries for all participants."
+    )
+    news: tuple[StockNewsView, ...] = Field(description="Recent news items for the stock.")
+    ticks: tuple[StockPriceTickView, ...] = Field(
+        description="Recent price ticks for the 7D chart."
+    )
 
 
 class StockPortfolioHolding(BaseModel):
@@ -221,19 +294,27 @@ class StockPortfolioHolding(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    symbol: str
-    name: str
-    price_cents: int
-    long_shares: int
-    long_cost_basis: int
-    long_market_value: int
-    short_shares: int
-    short_entry_value: int
-    short_collateral: int
-    short_cover_cost: int
-    equity_value: int
-    unrealized_pnl: int
-    realized_pnl: int
+    symbol: str = Field(description="Virtual company ticker symbol.")
+    name: str = Field(description="Display name of the virtual company.")
+    price_cents: int = Field(description="Latest quote price in cents.")
+    long_shares: int = Field(description="Number of shares held long.")
+    long_cost_basis: int = Field(description="Aggregate cost basis of the long position in cents.")
+    long_market_value: int = Field(
+        description="Current market value of the long position in cents."
+    )
+    short_shares: int = Field(description="Number of shares held short.")
+    short_entry_value: int = Field(
+        description="Aggregate entry value of the short position in cents."
+    )
+    short_collateral: int = Field(
+        description="Collateral reserved against the short position in cents."
+    )
+    short_cover_cost: int = Field(description="Current cost to cover the short position in cents.")
+    equity_value: int = Field(description="Net equity value of this holding in cents.")
+    unrealized_pnl: int = Field(
+        description="Unrealized profit and loss for this holding in cents."
+    )
+    realized_pnl: int = Field(description="Realized profit and loss for this holding in cents.")
 
 
 class StockPortfolioView(BaseModel):
@@ -241,11 +322,17 @@ class StockPortfolioView(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    user_id: int
-    holdings: tuple[StockPortfolioHolding, ...]
-    equity_value: int
-    unrealized_pnl: int
-    realized_pnl: int
+    user_id: int = Field(description="Discord user ID owning the portfolio.")
+    holdings: tuple[StockPortfolioHolding, ...] = Field(
+        description="Current stock holdings for the user."
+    )
+    equity_value: int = Field(description="Total net equity value across all holdings in cents.")
+    unrealized_pnl: int = Field(
+        description="Total unrealized profit and loss across holdings in cents."
+    )
+    realized_pnl: int = Field(
+        description="Total realized profit and loss across holdings in cents."
+    )
 
 
 class StockSettlementResult(BaseModel):
@@ -253,18 +340,26 @@ class StockSettlementResult(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    success: bool
-    operation_id: str | None
-    symbol: str
-    requested_action: StockAction
-    shares: int
-    price_cents: int
-    wallet_delta: int
-    balance_after: int
-    position: StockPositionView
-    legs: tuple[StockTradeLegView, ...]
-    status: StockOperationStatus | None = None
-    error: str = ""
+    success: bool = Field(description="Whether the settlement completed successfully.")
+    operation_id: str | None = Field(
+        description="Identifier of the settled operation, if created."
+    )
+    symbol: str = Field(description="Virtual company ticker symbol.")
+    requested_action: StockAction = Field(
+        description="Stock operation family requested by the user."
+    )
+    shares: int = Field(description="Share quantity settled.")
+    price_cents: int = Field(description="Execution price in cents.")
+    wallet_delta: int = Field(description="Net wallet balance change from the settlement.")
+    balance_after: int = Field(description="Wallet cash balance after settlement.")
+    position: StockPositionView = Field(description="Resulting position after settlement.")
+    legs: tuple[StockTradeLegView, ...] = Field(
+        description="Trade legs produced by the settlement."
+    )
+    status: StockOperationStatus | None = Field(
+        default=None, description="Final operation lifecycle status, if known."
+    )
+    error: str = Field(default="", description="Error message when the settlement fails.")
 
 
 class StockReconciliationOperation(BaseModel):
@@ -272,16 +367,20 @@ class StockReconciliationOperation(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    operation_id: str
-    status: StockOperationStatus
-    user_id: int
-    user_name: str
-    symbol: str
-    requested_action: StockAction
-    failure_reason: str
-    created_at: datetime
-    updated_at: datetime
-    legs: tuple[StockTradeLegView, ...]
+    operation_id: str = Field(description="Stock operation identifier.")
+    status: StockOperationStatus = Field(description="Current operation lifecycle status.")
+    user_id: int = Field(description="Discord user ID that initiated the operation.")
+    user_name: str = Field(description="Stored display name of the operation owner.")
+    symbol: str = Field(description="Virtual company ticker symbol.")
+    requested_action: StockAction = Field(
+        description="Stock operation family requested by the user."
+    )
+    failure_reason: str = Field(description="Recorded reason the operation did not finalize.")
+    created_at: datetime = Field(description="Timestamp the operation was created.")
+    updated_at: datetime = Field(description="Timestamp of the latest operation update.")
+    legs: tuple[StockTradeLegView, ...] = Field(
+        description="Trade legs associated with the operation."
+    )
 
 
 class StockSupplyAuditView(BaseModel):
@@ -289,17 +388,19 @@ class StockSupplyAuditView(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    symbol: str
-    name: str
-    price_cents: int
-    total_shares: int
-    float_shares: int
-    long_shares: int
-    short_shares: int
-    available_long_shares: int
-    available_short_shares: int
-    liquidity_shares: int
-    non_final_operations: int
+    symbol: str = Field(description="Virtual company ticker symbol.")
+    name: str = Field(description="Display name of the virtual company.")
+    price_cents: int = Field(description="Latest quote price in cents.")
+    total_shares: int = Field(description="Total issued share count.")
+    float_shares: int = Field(description="Tradable float share count.")
+    long_shares: int = Field(description="Aggregate long exposure in shares.")
+    short_shares: int = Field(description="Aggregate short borrow in shares.")
+    available_long_shares: int = Field(description="Remaining long capacity in shares.")
+    available_short_shares: int = Field(description="Remaining short borrow capacity in shares.")
+    liquidity_shares: int = Field(
+        description="Liquidity depth in shares used for order-size slippage."
+    )
+    non_final_operations: int = Field(description="Count of operations not yet in a final state.")
 
 
 __all__ = [

--- a/src/discordbot/utils/downloader.py
+++ b/src/discordbot/utils/downloader.py
@@ -19,8 +19,8 @@ class DownloadResult(BaseModel):
         filename: Local path of the downloaded file.
     """
 
-    title: str
-    filename: Path
+    title: str = Field(description="Video title reported by yt-dlp.")
+    filename: Path = Field(description="Local path of the downloaded file.")
 
     def unlink(self) -> None:
         """Deletes the downloaded file."""
@@ -60,7 +60,9 @@ class VideoDownloader(BaseModel):
     """
 
     output_folder: str = Field(default="./data/downloads", description="Download folder")
-    max_retries: int = Field(default=5)
+    max_retries: int = Field(
+        default=5, description="Configured maximum retry count.", examples=[5, 3]
+    )
     share_resolve_timeout: int = Field(
         default=10, description="Timeout (seconds) for resolving Facebook share URLs"
     )

--- a/src/discordbot/utils/downloader.py
+++ b/src/discordbot/utils/downloader.py
@@ -198,7 +198,7 @@ class VideoDownloader(BaseModel):
 
         params = self.get_params(quality=quality, dry_run=dry_run, url=url)
         with YoutubeDL(params=params) as ydl:
-            info = ydl.extract_info(url, download=True)
+            info = ydl.extract_info(url=url, download=True)
             title = info.get("title", "")
             filename = Path(ydl.prepare_filename(info))
             return DownloadResult(title=title, filename=filename)

--- a/src/discordbot/utils/llm.py
+++ b/src/discordbot/utils/llm.py
@@ -1,0 +1,20 @@
+"""Factory for the runtime LiteLLM-proxy OpenAI client."""
+
+from openai import AsyncOpenAI
+
+from discordbot.typings.llm import LLMConfig
+
+
+def create_litellm_client(config: LLMConfig) -> AsyncOpenAI:
+    """Returns a fresh AsyncOpenAI client pointed at the LiteLLM proxy.
+
+    Each cog keeps its own client instance; this factory only centralizes the
+    base-url / api-key wiring so proxy configuration lives in one place.
+
+    Args:
+        config: Runtime LLM configuration holding the proxy base URL and API key.
+
+    Returns:
+        A configured OpenAI-compatible client for the LiteLLM proxy.
+    """
+    return AsyncOpenAI(base_url=config.base_url, api_key=config.api_key)

--- a/src/discordbot/utils/threads.py
+++ b/src/discordbot/utils/threads.py
@@ -507,7 +507,7 @@ class ThreadsDownloader(BaseModel):
         """Fetches the HTML content of the given URL."""
         headers = {"User-Agent": "Mozilla/5.0", "Accept": "text/html"}
         try:
-            response = requests.get(url, headers=headers, timeout=15)
+            response = requests.get(url=url, headers=headers, timeout=15)
             response.raise_for_status()
             return response.text
         except requests.RequestException as e:
@@ -661,12 +661,12 @@ class ThreadsDownloader(BaseModel):
         """
         try:
             headers = {"User-Agent": "Mozilla/5.0", "Referer": "https://www.threads.net/"}
-            response = requests.get(url, headers=headers, stream=True, timeout=15)
+            response = requests.get(url=url, headers=headers, stream=True, timeout=15)
             response.raise_for_status()
 
             filepath = Path(self.output_folder) / filename
             filepath.parent.mkdir(parents=True, exist_ok=True)
-            with Path.open(filepath, "wb") as f:
+            with filepath.open("wb") as f:
                 for chunk in response.iter_content(chunk_size=8192):
                     if chunk:
                         f.write(chunk)

--- a/tests/test_bot_player.py
+++ b/tests/test_bot_player.py
@@ -361,7 +361,12 @@ async def test_missing_dealer_up_uses_english_unknown_in_bot_insurance_prompt() 
     )
 
     await insurance_ai.decide_bot_insurance(
-        dealer_up=None, hand_repr="A♠ 10♠", bet=100, finance=finance, other_players=[]
+        dealer_cards=[],
+        dealer_up=None,
+        hand_repr="A♠ 10♠",
+        bet=100,
+        finance=finance,
+        other_players=[],
     )
 
     insurance_input = insurance_client.responses.calls[0]["input"]
@@ -384,6 +389,7 @@ async def test_decide_bot_insurance_fallback_takes_on_known_dealer_blackjack() -
     )
 
     decision = await ai.decide_bot_insurance(
+        dealer_cards=[_card(rank="K"), _card(rank="A")],
         dealer_up=_card(rank="A"),
         hand_repr="A♠ 9♠",
         bet=100,

--- a/tests/test_maplestory.py
+++ b/tests/test_maplestory.py
@@ -500,6 +500,10 @@ def test_maplestory_service_loads_searches_and_caches(service: MapleStoryService
     assert service.search_quests_by_name(query="help")
     assert service.search_maps_by_name(query="hunting")
     assert service.search_items_by_name(query="Bubble") == ["Blue Bubble", "Slime Bubble"]
+    # Non-equipment drops must resolve through their own translation category.
+    assert service.search_items_by_name(query="紅色藥水") == ["Red Potion"]
+    assert service.search_items_by_name(query="手套攻擊卷軸") == ["Scroll for Gloves for ATT"]
+    assert service.search_items_by_name(query="綠水靈泡泡") == ["Slime Bubble"]
     assert service.get_item_type(item_name="Wooden Sword") == "裝備"
     assert service.get_item_type(item_name="Scroll for Gloves for ATT") == "捲軸"
     assert service.get_item_type(item_name="Red Potion") == "消耗品"

--- a/tests/test_stock_views.py
+++ b/tests/test_stock_views.py
@@ -28,11 +28,7 @@ from discordbot.typings.stock import (
     StockSettlementResult,
     StockParticipantPositionView,
 )
-from discordbot.cogs._stock.chart import (
-    build_price_chart,
-    _render_price_chart,
-    invalidate_stock_chart_cache,
-)
+from discordbot.cogs._stock.chart import build_price_chart, _render_price_chart
 from discordbot.cogs._stock.views import (
     StockActionView,
     StockDetailView,
@@ -48,7 +44,6 @@ from discordbot.cogs._stock.presentation import (
     build_market_board_image,
     build_stock_detail_embed,
     _build_market_board_image_cached,
-    invalidate_stock_market_board_cache,
 )
 
 BCAT_SYMBOL = "BCAT"
@@ -431,7 +426,7 @@ def test_stock_market_board_handles_large_market_caps() -> None:
 
 def test_stock_market_board_image_cache_key_changes_with_quote_digest() -> None:
     """Market board renders are cached by immutable quote fields."""
-    invalidate_stock_market_board_cache()
+    _build_market_board_image_cached.cache_clear()
     quote = _quote()
 
     build_market_board_image(quotes=(quote,))
@@ -450,7 +445,7 @@ def test_stock_market_board_image_cache_key_changes_with_quote_digest() -> None:
 
 def test_stock_chart_image_cache_key_changes_with_ticks() -> None:
     """7D chart renders are cached by immutable tick rows."""
-    invalidate_stock_chart_cache()
+    _render_price_chart.cache_clear()
     first_ticks = (
         StockPriceTickView(
             symbol=BCAT_SYMBOL, price_cents=10_000, created_at=datetime(2026, 1, 1)


### PR DESCRIPTION
## Summary

Second repo-wide audit-cleanup pass driven by a multi-agent read-only review (8 subsystems + 2 cross-cutting passes, each adversarially verified). The review produced 32 confirmed findings (12 verified false positives were dropped). The codebase is already mature: DB usage is healthy, no `dataclass`, caching is sound, and no schema changes are needed.

Work is grouped into focused commits:

1. **Correctness bugs** — fix MapleStory drop-name translation only ever using the equipment category; move blocking image fetch off the event loop; supply a default prompt for attachment-only image/video; wire the tested hole-card-aware `fallback_insurance` into the bot insurance decision (removing an inline duplicate).
2. **Usage consistency** — keyword-argument and idiom fixes (`requests.get`, `extract_info`, `Path.open`, `text()`), and a docstring/code mismatch in the peak-hour window.
3. **DRY / shared logic** — shared LiteLLM client factory across cogs, a loan-decision view base class, a shared Blackjack outcome-fallback constant, and MapleStory exact-lookup getters.
4. **Caching & dead code** — de-duplicate `.stat()` syscalls, remove never-called stock cache-invalidation functions (digest-keyed caches need none) and a dead re-export.
5. **Pydantic** — populate missing `Field(description=)` across models.

## Verification

- `uv run pytest` (coverage gate 80%)
- `uv run pre-commit run -a` (ruff + mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)