### PR TITLE
fix(fishing): address Codex review follow-ups on #234

### DIFF
--- a/scripts/manage_fishing.py
+++ b/scripts/manage_fishing.py
@@ -11,6 +11,7 @@ Usage::
 """
 
 import asyncio
+from pathlib import Path
 import argparse
 from collections.abc import Sequence
 
@@ -231,6 +232,9 @@ async def _async_main(argv: Sequence[str] | None = None) -> None:
 
 def main(argv: Sequence[str] | None = None) -> None:
     """Runs the fishing catalog maintenance CLI."""
+    # data/ is gitignored and may not exist on a fresh checkout seeded before the
+    # bot's first run, so create it here like cli.py does before any DB write.
+    Path("./data").mkdir(parents=True, exist_ok=True)
     asyncio.run(main=_async_main(argv=argv))
 
 

--- a/src/discordbot/cogs/_fishing/catch.py
+++ b/src/discordbot/cogs/_fishing/catch.py
@@ -137,6 +137,11 @@ def roll_catch(  # noqa: PLR0913 -- a roll needs rng, configs, species, rod, bai
     )
     grade_choices = [config.grade for config in ordered_configs]
     grade_weights = [weights[config.grade] for config in ordered_configs]
+    # An all-disabled catalog would otherwise fall through _weighted_index's
+    # total <= 0 branch to index 0 and award that disabled grade directly.
+    if sum(grade_weights) <= 0:
+        msg = "cannot roll a catch: every grade is disabled"
+        raise ValueError(msg)
     chosen_grade = grade_choices[_weighted_index(rng=rng, weights=grade_weights)]
     chosen = _select_species(
         rng=rng, species=species, grade=chosen_grade, grade_configs=ordered_configs

--- a/src/discordbot/cogs/_fishing/catch.py
+++ b/src/discordbot/cogs/_fishing/catch.py
@@ -70,13 +70,21 @@ def _fallback_species(
 
     Defends against a mis-tuned catalog where the rolled grade has no species:
     the catch falls back to the closest grade at or below the rolled rank, or the
-    lowest populated grade when none is at or below it.
+    lowest populated grade when none is at or below it. Grades an operator disabled
+    (base weight zero) are never eligible here either, so the disabled-grade
+    contract still holds on the fallback path; if every populated grade is disabled
+    the roll fails rather than awarding a disabled grade.
     """
     rank_by_grade = {config.grade: config.order_index for config in grade_configs}
+    disabled = {config.grade for config in grade_configs if config.weight <= 0}
     target_rank = rank_by_grade.get(grade, 0)
     populated = sorted(
-        {item.grade for item in species}, key=lambda candidate: rank_by_grade.get(candidate, 0)
+        {item.grade for item in species if item.grade not in disabled},
+        key=lambda candidate: rank_by_grade.get(candidate, 0),
     )
+    if not populated:
+        msg = "cannot roll a catch: every populated grade is disabled"
+        raise ValueError(msg)
     lower_or_equal = [
         candidate for candidate in populated if rank_by_grade.get(candidate, 0) <= target_rank
     ]

--- a/src/discordbot/cogs/_fishing/catch.py
+++ b/src/discordbot/cogs/_fishing/catch.py
@@ -45,11 +45,16 @@ def compose_grade_weights(
     moves roll mass monotonically from common grades toward rare ones. The factor
     is clamped to `[LUCK_FACTOR_MIN_BPS, LUCK_FACTOR_MAX_BPS]` so no gear
     combination can suppress or inflate a grade past those bounds. The most
-    common grade (rank 0) is never affected.
+    common grade (rank 0) is never affected. A grade whose base weight is zero
+    stays disabled; the floor-to-1 below only protects a positive weight from
+    rounding away, it must not resurrect a grade an operator removed.
     """
     total_shift = rod_rarity_shift_bps + bait_rarity_shift_bps
     adjusted: dict[FishGrade, int] = {}
     for config in grade_configs:
+        if config.weight <= 0:
+            adjusted[config.grade] = 0
+            continue
         raw_factor = FISHING_BPS_DENOMINATOR + total_shift * config.order_index
         factor = max(LUCK_FACTOR_MIN_BPS, min(LUCK_FACTOR_MAX_BPS, raw_factor))
         adjusted[config.grade] = max(1, config.weight * factor // FISHING_BPS_DENOMINATOR)

--- a/src/discordbot/cogs/_fishing/views.py
+++ b/src/discordbot/cogs/_fishing/views.py
@@ -220,6 +220,9 @@ class FishingShopView(FishingPublicView):
                 log_message="Failed to send fishing empty-rod notice",
             )
             return
+        # Ack before the wallet debit and shop refresh so a slow DB write cannot
+        # blow Discord's interaction window, mirroring the bait purchase path.
+        await interaction.response.defer()
         self.stop()
         await _purchase_and_refresh_shop(
             interaction=interaction, owner_id=self.owner_id, gear_id=value, quantity=1

--- a/tests/test_fishing_catch.py
+++ b/tests/test_fishing_catch.py
@@ -367,3 +367,26 @@ def test_fallback_raises_when_all_populated_grades_disabled() -> None:
             bait=_bait(),
             max_value=100_000,
         )
+
+
+def test_all_zero_catalog_raises_before_awarding() -> None:
+    """A fully disabled catalog fails instead of awarding the index-0 grade directly."""
+    grades = (
+        FishGradeConfigView(
+            grade=FishGrade.N, weight=0, color=0, emoji="⚪", label="普通", order_index=0
+        ),
+        FishGradeConfigView(
+            grade=FishGrade.UR, weight=0, color=0, emoji="🔴", label="神話", order_index=4
+        ),
+    )
+    # The rank-0 disabled grade has species, so without the guard _weighted_index's
+    # total<=0 branch would return index 0 and award it directly.
+    with pytest.raises(ValueError, match="every grade is disabled"):
+        roll_catch(
+            rng=Random(0),
+            grade_configs=grades,
+            species=(_fish(species_id="common", grade=FishGrade.N),),
+            rod=_rod(),
+            bait=_bait(),
+            max_value=100_000,
+        )

--- a/tests/test_fishing_catch.py
+++ b/tests/test_fishing_catch.py
@@ -107,6 +107,23 @@ def test_compose_grade_weights_clamps_extreme_negative_shift() -> None:
             assert weights[config.grade] == expected
 
 
+def test_compose_grade_weights_honors_zero_weight() -> None:
+    """A grade an operator zeroed out stays disabled instead of clamping back to 1."""
+    grades = (
+        FishGradeConfigView(
+            grade=FishGrade.N, weight=100, color=0, emoji="⚪", label="普通", order_index=0
+        ),
+        FishGradeConfigView(
+            grade=FishGrade.SSR, weight=0, color=0, emoji="🟡", label="傳說", order_index=3
+        ),
+    )
+    weights = compose_grade_weights(
+        grade_configs=grades, rod_rarity_shift_bps=400, bait_rarity_shift_bps=400
+    )
+    assert weights[FishGrade.N] == 100
+    assert weights[FishGrade.SSR] == 0
+
+
 def test_roll_catch_is_deterministic_under_seed() -> None:
     """The same seed and inputs always produce an identical roll."""
     catalog = build_default_catalog()

--- a/tests/test_fishing_catch.py
+++ b/tests/test_fishing_catch.py
@@ -301,3 +301,69 @@ def test_empty_catalog_raises() -> None:
             bait=_bait(),
             max_value=100_000,
         )
+
+
+def _fish(species_id: str, grade: FishGrade) -> FishSpeciesView:
+    """Builds a fixed-size, fixed-value test species in a grade."""
+    return FishSpeciesView(
+        species_id=species_id,
+        name=species_id,
+        grade=grade,
+        emoji="🐟",
+        intra_grade_weight=1,
+        base_value=1,
+        size_min_bps=10_000,
+        size_max_bps=10_000,
+    )
+
+
+def test_fallback_skips_disabled_grade_with_species() -> None:
+    """The empty-grade fallback never awards a grade an operator disabled."""
+    grades = (
+        FishGradeConfigView(
+            grade=FishGrade.N, weight=100, color=0, emoji="⚪", label="普通", order_index=0
+        ),
+        FishGradeConfigView(
+            grade=FishGrade.SSR, weight=0, color=0, emoji="🟡", label="傳說", order_index=3
+        ),
+        FishGradeConfigView(
+            grade=FishGrade.UR, weight=10_000, color=0, emoji="🔴", label="神話", order_index=4
+        ),
+    )
+    species = (
+        _fish(species_id="common", grade=FishGrade.N),
+        _fish(species_id="legend", grade=FishGrade.SSR),
+    )
+    # UR dominates the draw but has no species, so most rolls hit the fallback; it
+    # must land on enabled N, never disabled SSR even though SSR has species.
+    for seed in range(50):
+        roll = roll_catch(
+            rng=Random(seed),
+            grade_configs=grades,
+            species=species,
+            rod=_rod(),
+            bait=_bait(),
+            max_value=100_000,
+        )
+        assert roll.species_id == "common"
+
+
+def test_fallback_raises_when_all_populated_grades_disabled() -> None:
+    """If every grade with species is disabled, the roll fails instead of awarding one."""
+    grades = (
+        FishGradeConfigView(
+            grade=FishGrade.N, weight=0, color=0, emoji="⚪", label="普通", order_index=0
+        ),
+        FishGradeConfigView(
+            grade=FishGrade.UR, weight=10_000, color=0, emoji="🔴", label="神話", order_index=4
+        ),
+    )
+    with pytest.raises(ValueError, match="every populated grade is disabled"):
+        roll_catch(
+            rng=Random(0),
+            grade_configs=grades,
+            species=(_fish(species_id="only_common", grade=FishGrade.N),),
+            rod=_rod(),
+            bait=_bait(),
+            max_value=100_000,
+        )


### PR DESCRIPTION
## Summary

Follow-up fixes for the actionable Codex review threads left on #234 (already merged). Three of the four suggestions were real and are addressed here; the fourth is intentional by design and is answered on the thread instead of changed.

## Changes

- **Keep zero-weight grades disabled when reweighting luck** (`_fishing/catch.py`). The catalog tooling allows a grade weight of `0` (`ge=0`), but `compose_grade_weights` clamped every result with `max(1, ...)`, so a grade an operator zeroed out was silently rolled back to weight `1` whenever it had species rows. Weight `0` now stays disabled; the floor-to-1 still protects a positive weight from rounding away. Adds a regression test.
- **Defer the rod purchase interaction before settlement** (`_fishing/views.py`). The rod select acknowledged the interaction only after the wallet debit, grant, and shop refresh, so a slow DB write could blow Discord's interaction window. It now defers first, matching the bait purchase path.
- **Create `data/` before seeding the catalog** (`scripts/manage_fishing.py`). `data/` is gitignored and may not exist on a fresh checkout seeded before the bot's first run, which made the documented `seed-defaults` command fail with `unable to open database file`. The CLI now creates the directory up front, mirroring `cli.py`.

## Not changed (answered on the thread)

- **Persist deferred fishing payouts** is intentional per `CLAUDE.md`: a payout that fails after the catch is logged returns `PAYOUT_DEFERRED`, is never rolled back, and is only ever more deflationary, sharing the accepted non-atomicity of casino / jackpot settlement with no operation-lifecycle table. No retry worker or reconciliation row is added.

## Test plan

- `uv run pre-commit run -a` — ruff, mdformat, and mypy all pass.
- `uv run pytest` — full suite green (641 passed), coverage 85.84%.
- `uv run python scripts/simulate_fishing.py` — every rod + bait combo still reports as net-deflationary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
