### PR TITLE
refactor: post-audit code-quality sweep

### DIFF
--- a/src/discordbot/cogs/gen_reply.py
+++ b/src/discordbot/cogs/gen_reply.py
@@ -254,14 +254,18 @@ class ReplyGeneratorCogs(commands.Cog):
         final_content = f"{message.author.mention} {image_description}"
         await message.reply(content=final_content, file=image_file)
 
-    async def _route_message(self, message: Message) -> Literal["IMAGE", "QA", "SUMMARY", "VIDEO"]:
-        """Routes the message to the appropriate handler."""
-        message_list: list[EasyInputMessageParam] = []
+    async def _route_message(
+        self,
+        message: Message,
+        reference_messages: list[EasyInputMessageParam],
+        current_message: list[EasyInputMessageParam],
+    ) -> Literal["IMAGE", "QA", "SUMMARY", "VIDEO"]:
+        """Routes the message to the appropriate handler.
 
-        reference_messages, current_message = await asyncio.gather(
-            self._get_reference_message(message=message),
-            self._get_current_message(message=message),
-        )
+        The reference and current message inputs are built once by the caller and
+        reused for generation, so attachments are not downloaded/encoded twice.
+        """
+        message_list: list[EasyInputMessageParam] = []
         message_list.extend(reference_messages)
         message_list.extend(current_message)
 
@@ -287,16 +291,21 @@ class ReplyGeneratorCogs(commands.Cog):
             return "QA"
 
     async def _handle_message_reply(
-        self, message: Message, system_prompt: str, history_limit: int
+        self,
+        message: Message,
+        system_prompt: str,
+        history_limit: int,
+        reference_messages: list[EasyInputMessageParam],
+        current_message: list[EasyInputMessageParam],
     ) -> None:
-        """Handles generating text replies using history and context."""
+        """Handles generating text replies using history and context.
+
+        The reference and current message inputs are passed in already built (and
+        already used for routing) so their attachments are not re-downloaded here.
+        """
         message_list: list[EasyInputMessageParam] = []
 
-        hist_messages, reference_messages, current_message = await asyncio.gather(
-            self._get_history_message(message=message, limit=history_limit),
-            self._get_reference_message(message=message),
-            self._get_current_message(message=message),
-        )
+        hist_messages = await self._get_history_message(message=message, limit=history_limit)
         message_list.extend(hist_messages)
         message_list.extend(reference_messages)
         message_list.extend(current_message)
@@ -348,7 +357,15 @@ class ReplyGeneratorCogs(commands.Cog):
             current_emoji = await update_reaction(
                 message=message, bot_user=self.bot.user, emoji="🔀"
             )
-            route = await self._route_message(message=message)
+            reference_messages, current_message = await asyncio.gather(
+                self._get_reference_message(message=message),
+                self._get_current_message(message=message),
+            )
+            route = await self._route_message(
+                message=message,
+                reference_messages=reference_messages,
+                current_message=current_message,
+            )
             if route == "IMAGE":
                 current_emoji = await update_reaction(
                     message=message, bot_user=self.bot.user, emoji="🎨", previous=current_emoji
@@ -364,14 +381,22 @@ class ReplyGeneratorCogs(commands.Cog):
                     message=message, bot_user=self.bot.user, emoji="📖", previous=current_emoji
                 )
                 await self._handle_message_reply(
-                    message=message, system_prompt=SUMMARY_PROMPT, history_limit=100
+                    message=message,
+                    system_prompt=SUMMARY_PROMPT,
+                    history_limit=100,
+                    reference_messages=reference_messages,
+                    current_message=current_message,
                 )
             else:
                 current_emoji = await update_reaction(
                     message=message, bot_user=self.bot.user, emoji="❓", previous=current_emoji
                 )
                 await self._handle_message_reply(
-                    message=message, system_prompt=REPLY_PROMPT, history_limit=30
+                    message=message,
+                    system_prompt=REPLY_PROMPT,
+                    history_limit=30,
+                    reference_messages=reference_messages,
+                    current_message=current_message,
                 )
             await update_reaction(
                 message=message, bot_user=self.bot.user, emoji="🆗", previous=current_emoji

--- a/src/discordbot/utils/model_pricing.py
+++ b/src/discordbot/utils/model_pricing.py
@@ -7,7 +7,6 @@ on first use and memoizes it for the rest of the process. Returns
 `$0.00000000` instead of an estimate.
 """
 
-from functools import cache
 from collections.abc import Mapping
 
 import logfire
@@ -40,9 +39,20 @@ def _fetch_upstream() -> dict[str, object]:
     return data if isinstance(data, dict) else {}
 
 
-@cache
+_price_table_cache: dict[str, dict[str, ModelPriceEntry]] = {}
+
+
 def _load_model_prices() -> dict[str, ModelPriceEntry]:
-    """Returns the validated price table, fetched once per process."""
+    """Returns the validated price table, fetched once per process.
+
+    A successful (non-empty) fetch is memoized for the rest of the process. A
+    transient fetch failure yields an empty table that is deliberately NOT
+    memoized, so a later lookup retries upstream instead of permanently
+    degrading every model to the `{"text", "image"}` modality fallback.
+    """
+    cached = _price_table_cache.get("table")
+    if cached:
+        return cached
     prices: dict[str, ModelPriceEntry] = {}
     for name, entry in _fetch_upstream().items():
         if not isinstance(entry, Mapping):
@@ -51,6 +61,8 @@ def _load_model_prices() -> dict[str, ModelPriceEntry]:
             prices[name] = ModelPriceEntry.model_validate(obj=entry)
         except ValidationError as exc:
             logfire.warn(f"Skipping malformed model price entry {name}: {exc!s}")
+    if prices:
+        _price_table_cache["table"] = prices
     return prices
 
 
@@ -78,7 +90,12 @@ def warm_pricing_cache() -> None:
     `get_token_rates` / `get_supported_modalities` lookup from blocking on the
     upstream HTTP fetch during a live interaction.
     """
-    _load_model_prices()
+    if not _load_model_prices():
+        logfire.warn(
+            "Model pricing table is empty after the warm fetch; token-cost display and "
+            "slow-model attachment modality detection fall back to defaults until a later "
+            "lookup successfully refetches upstream."
+        )
 
 
 def get_supported_modalities(model_name: str) -> set[str]:

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -592,7 +592,14 @@ async def test_gen_reply_routes_and_handlers_without_api(monkeypatch: pytest.Mon
     """Verifies route, video, image, and slow-reply handlers using fake APIs."""
     cog = _cog()
     message = FakeMessage(content="make a summary", author=FakeAuthor(user_id=1))
-    assert await cog._route_message(message=message) == "SUMMARY"
+    reference_messages = await cog._get_reference_message(message=message)
+    current_message = await cog._get_current_message(message=message)
+    assert (
+        await cog._route_message(
+            message=message, reference_messages=reference_messages, current_message=current_message
+        )
+        == "SUMMARY"
+    )
     assert cog.client.responses.parse_models[0] == cog.runtime_models.fast_model.name
 
     async def fake_sleep(delay: float) -> None:
@@ -623,7 +630,13 @@ async def test_gen_reply_routes_and_handlers_without_api(monkeypatch: pytest.Mon
             return "done"
 
     monkeypatch.setattr("discordbot.cogs.gen_reply.ResponseStreamer", FakeResponder)
-    await cog._handle_message_reply(message=message, system_prompt="system", history_limit=2)
+    await cog._handle_message_reply(
+        message=message,
+        system_prompt="system",
+        history_limit=2,
+        reference_messages=reference_messages,
+        current_message=current_message,
+    )
     assert cog.client.responses.create_streams[-1] is True
     assert streamed[-1] is message
 
@@ -644,9 +657,19 @@ async def test_gen_reply_on_message_dispatches_routes(
     cog = _cog()
     calls: list[str] = []
 
-    async def fake_route(message: FakeMessage) -> str:
+    async def fake_route(
+        message: FakeMessage, reference_messages: list[object], current_message: list[object]
+    ) -> str:
         """Returns the parametrized route."""
         return route
+
+    async def fake_get_reference(message: FakeMessage) -> list[object]:
+        """Skips real reference-message building in the dispatch test."""
+        return []
+
+    async def fake_get_current(message: FakeMessage) -> list[object]:
+        """Skips real current-message building in the dispatch test."""
+        return []
 
     async def fake_reaction(
         message: FakeMessage, bot_user: object, emoji: str, previous: str | None = None
@@ -664,12 +687,18 @@ async def test_gen_reply_on_message_dispatches_routes(
         calls.append("_handle_video_reply")
 
     async def fake_message_handler(
-        message: FakeMessage, system_prompt: str, history_limit: int
+        message: FakeMessage,
+        system_prompt: str,
+        history_limit: int,
+        reference_messages: list[object],
+        current_message: list[object],
     ) -> None:
         """Records slow message handler dispatch."""
         calls.append("_handle_message_reply")
 
     monkeypatch.setattr(cog, "_route_message", fake_route)
+    monkeypatch.setattr(cog, "_get_reference_message", fake_get_reference)
+    monkeypatch.setattr(cog, "_get_current_message", fake_get_current)
     monkeypatch.setattr("discordbot.cogs.gen_reply.update_reaction", fake_reaction)
     monkeypatch.setattr(cog, "_handle_image_reply", fake_image_handler)
     monkeypatch.setattr(cog, "_handle_video_reply", fake_video_handler)

--- a/tests/test_model_pricing.py
+++ b/tests/test_model_pricing.py
@@ -10,9 +10,9 @@ from discordbot.utils import model_pricing
 @pytest.fixture(autouse=True)
 def clear_model_price_cache() -> Iterator[None]:
     """Clears the process-level model price cache around each test."""
-    model_pricing._load_model_prices.cache_clear()
+    model_pricing._price_table_cache.clear()
     yield
-    model_pricing._load_model_prices.cache_clear()
+    model_pricing._price_table_cache.clear()
 
 
 def test_model_pricing_parses_typed_rates_and_modalities(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -73,3 +73,25 @@ def test_model_pricing_handles_empty_fetch(monkeypatch: pytest.MonkeyPatch) -> N
 
     assert model_pricing.get_token_rates(model_name="any-model") == (0.0, 0.0)
     assert model_pricing.get_supported_modalities(model_name="any-model") == {"text", "image"}
+
+
+def test_model_pricing_retries_after_transient_empty_fetch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient empty fetch is not memoized; a later successful fetch populates."""
+    monkeypatch.setattr(target=model_pricing, name="_fetch_upstream", value=lambda: {})
+    assert model_pricing.get_supported_modalities(model_name="late-model") == {"text", "image"}
+
+    recovered = {
+        "late-model": {
+            "input_cost_per_token": 0.1,
+            "output_cost_per_token": 0.2,
+            "supported_modalities": ["text", "image", "audio"],
+        }
+    }
+    monkeypatch.setattr(target=model_pricing, name="_fetch_upstream", value=lambda: recovered)
+    assert model_pricing.get_supported_modalities(model_name="late-model") == {
+        "text",
+        "image",
+        "audio",
+    }


### PR DESCRIPTION
## Summary

Follow-up to a full multi-agent audit of the repo. Lands the two real-runtime fixes first, then sweeps cross-cutting duplication, dead code, and stale docs. No DB schema changes. Each batch is a separate commit for review.

## Batches

- [x] **Runtime fixes**
  - `model_pricing`: stop negatively memoizing a transient startup fetch failure (otherwise audio/video/file attachments are silently dropped for the whole session after a boot-time network blip).
  - `gen_reply`: process current + reference messages once per reply instead of twice, removing doubled attachment downloads/encoding on the latency-critical path.
- [ ] **Dead code + stale docs** (no behavior change)
- [ ] **Shared SQLite plumbing** extracted to `utils` (connect hooks, schema bootstrap, StoredInteger desc-order); route `log_msg` + `message_cleanup` through the canonical helper.
- [ ] **DRY consolidation** (boundary number parser, semantic embed colors, owner-locked view base, table-edit kwargs, signed-percent/plain-amount, game labels, video upload budget).

## Verification

- `uv run pre-commit run -a`
- `uv run pytest` (coverage gate 80%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)