### PR TITLE
fix(docker): run container as non-root user

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ git clone https://github.com/Mai0313/discordbot.git
 cd discordbot
 cp .env.example .env
 # edit .env
+mkdir -p data
 docker compose up -d
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ cp .env.example .env
 docker compose up -d
 ```
 
+The container runs as UID 1000 so files under `data/` stay owned by your host user; if your host user has a different UID, override `user:` in `docker-compose.yaml`.
+
 ### Local
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -80,6 +80,8 @@ cp .env.example .env
 docker compose up -d
 ```
 
+容器以 UID 1000 运行,让 `data/` 下的文件保持由你的主机用户拥有;如果你的主机用户 UID 不是 1000,请在 `docker-compose.yaml` 中覆写 `user:`。
+
 ### 本地
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -77,6 +77,7 @@ git clone https://github.com/Mai0313/discordbot.git
 cd discordbot
 cp .env.example .env
 # edit .env
+mkdir -p data
 docker compose up -d
 ```
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -80,6 +80,8 @@ cp .env.example .env
 docker compose up -d
 ```
 
+容器以 UID 1000 執行,讓 `data/` 下的檔案維持由你的主機使用者擁有;如果你的主機使用者 UID 不是 1000,請在 `docker-compose.yaml` 中覆寫 `user:`。
+
 ### 本機
 
 ```bash

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -77,6 +77,7 @@ git clone https://github.com/Mai0313/discordbot.git
 cd discordbot
 cp .env.example .env
 # edit .env
+mkdir -p data
 docker compose up -d
 ```
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,9 @@ services:
       UV_NO_DEV: 1
       UV_FROZEN: 1
       UV_NO_SYNC: 1
+      # uv still initializes its cache under $HOME at startup; images without a
+      # passwd entry for UID 1000 resolve HOME to "/", which is not writable.
+      UV_CACHE_DIR: /tmp/uv-cache
     env_file:
       - .env
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
       context: .
       target: prod
       dockerfile: ./docker/Dockerfile
+    user: "1000:1000"
     command:
       - uv
       - run
@@ -12,6 +13,7 @@ services:
     environment:
       UV_NO_DEV: 1
       UV_FROZEN: 1
+      UV_NO_SYNC: 1
     env_file:
       - .env
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,12 @@ services:
     env_file:
       - .env
     volumes:
-      - ./data:/app/data
+      # Fail fast instead of letting compose create a root-owned ./data on first run.
+      - type: bind
+        source: ./data
+        target: /app/data
+        bind:
+          create_host_path: false
     network_mode: host
     restart: always
     pull_policy: always

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,3 +26,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --no-dev --frozen
+
+# Run as a non-root user so bind-mounted data/ files are not root-owned on the host.
+RUN groupadd --gid 1000 app \
+    && useradd --create-home --uid 1000 --gid 1000 app
+ENV PYTHONDONTWRITEBYTECODE=1
+USER app

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,5 +30,5 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Run as a non-root user so bind-mounted data/ files are not root-owned on the host.
 RUN groupadd --gid 1000 app \
     && useradd --create-home --uid 1000 --gid 1000 app
-ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONDONTWRITEBYTECODE=1 UV_NO_SYNC=1
 USER app

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --no-dev --frozen
 
 # Run as a non-root user so bind-mounted data/ files are not root-owned on the host.
+# Pre-create data/ owned by app so the container also starts without a mount.
 RUN groupadd --gid 1000 app \
-    && useradd --create-home --uid 1000 --gid 1000 app
+    && useradd --create-home --uid 1000 --gid 1000 app \
+    && mkdir --parents /app/data \
+    && chown app:app /app/data
 ENV PYTHONDONTWRITEBYTECODE=1 UV_NO_SYNC=1
 USER app

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -766,11 +766,8 @@ def test_runtime_model_catalog_dispatches_slow_model_by_peak_hour(
     assert before_peak[1:] == (False, False)
     assert after_peak[1:] == (False, False)
     assert weekend[1:] == (False, False)
-    assert peak_start[0].name == "gemini-pro-latest"
-    assert after_peak[0].name == "gemini-pro-latest"
-    assert peak_start[0] == peak_end[0]
-    assert before_peak[0] == after_peak[0] == weekend[0]
-    assert {peak_start[0].effort, after_peak[0].effort} == {"high"}
+    assert peak_start[0] == ModelSettings(name="gemini-pro-latest", effort="high")
+    assert peak_start[0] == peak_end[0] == before_peak[0] == after_peak[0] == weekend[0]
 
 
 async def test_handle_message_reply_injects_memory_as_assistant_note_before_current(

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -766,11 +766,10 @@ def test_runtime_model_catalog_dispatches_slow_model_by_peak_hour(
     assert before_peak[1:] == (False, False)
     assert after_peak[1:] == (False, False)
     assert weekend[1:] == (False, False)
-    assert peak_start[0].name == "gemini-flash-latest"
+    assert peak_start[0].name == "gemini-pro-latest"
     assert after_peak[0].name == "gemini-pro-latest"
     assert peak_start[0] == peak_end[0]
     assert before_peak[0] == after_peak[0] == weekend[0]
-    assert peak_start[0] != after_peak[0]
     assert {peak_start[0].effort, after_peak[0].effort} == {"high"}
 
 


### PR DESCRIPTION
## Summary

Files created by the bot inside the bind-mounted `./data` directory were owned by `root` on the host, because the container ran as root (no `USER` in the Dockerfile and no `user:` in compose). This forced manual `sudo chmod` on the host after every run.

## Changes

- `docker/Dockerfile`: create an `app` user (UID/GID 1000) in the prod stage and switch to it with `USER`, so the published image runs as non-root by default. The build itself stays root (apt needs it, and a root-owned read-only venv is the safer arrangement at runtime). `/app/data` is pre-created and chowned to `app` so the container also starts without a mount (named volumes inherit this ownership at initialization). `PYTHONDONTWRITEBYTECODE=1` avoids runtime `__pycache__` writes into the read-only `/app`, and `UV_NO_SYNC=1` is baked into the image so `uv run` never attempts to sync the root-owned venv at startup (`UV_NO_SYNC` only affects `uv run`, not the explicit `uv sync` during build).
- `docker-compose.yaml`: add `user: "1000:1000"` so the fix takes effect immediately with the current published image, `UV_NO_SYNC: 1`, and `UV_CACHE_DIR: /tmp/uv-cache` (uv initializes its cache under `$HOME` even with `--no-sync`; on images whose UID 1000 has no passwd entry, HOME resolves to `/` and startup crash-loops). The data mount uses long syntax with `bind.create_host_path: false`: Compose v2 creates a missing bind source as root-owned (verified on v2.35.1), which would mask the image's app-owned `/app/data` and crash the non-root container, so failing fast with a clear error is safer.
- READMEs: add `mkdir -p data` to the Docker quickstart so the bind source is created by the host user, and document that the container runs as UID 1000 with `user:` as the override point for hosts with a different UID.
- `tests/test_gen_reply.py`: align slow-model expectations with the peak model change from 4dbaf11 (pre-existing failure on main, unrelated to the Docker change), asserting explicitly that peak and off-peak settings are currently identical.

## Verification

- `uv run pre-commit run -a` exits 0
- `uv run pytest`: 705 passed
- New image: `id` prints `uid=1000(app) gid=1000(app)`, `HOME=/home/app`, `UV_NO_SYNC=1` present; no-mount `docker run` can create and write `data/` subdirectories
- Old published image under compose `user:` override (the window before CI publishes the new image): `uv run --no-sync` import check passes with `UV_CACHE_DIR=/tmp/uv-cache`; without it, uv crash-loops on cache init at `/.cache/uv`
- Missing `./data` with `create_host_path: false` fails fast (`bind source path does not exist`) instead of creating a root-owned directory; with the directory present, container writes land as the host user
- Live deployment restarted on this branch: bot logs in and runs as `app`, new files under `data/` owned by the host user

🤖 Generated with [Claude Code](https://claude.com/claude-code)