### PR TITLE
refactor(memory): run memory selection on fast tool_model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ make gen-docs                    # regenerate docs/ from sources
 ## AI Pipeline
 
 - Runtime LLM backend is LiteLLM Proxy behind `OPENAI_BASE_URL`; all runtime conversations use `AsyncOpenAI` and the OpenAI Responses API. Do not switch back to Chat Completions, and do not import provider-native SDKs (`google-genai`, `anthropic`) into runtime request paths; `scripts/prompt_dev.py` is the local-experimentation exception.
-- Runtime model strings live in `RuntimeModelCatalog` in `src/discordbot/typings/models.py`; keep `slow_model`'s peak-hour dispatch. Provider selection happens through LiteLLM via model strings and `extra_body`.
+- Runtime model strings live in `RuntimeModelCatalog` in `src/discordbot/typings/models.py`; keep `slow_model`'s peak-hour dispatch. The phase-1 `get_user_memory` selection runs on the fast `tool_model` (off the `slow_model` tier) since it is a lightweight critical-path decision before the answer. Provider selection happens through LiteLLM via model strings and `extra_body`.
 - Streaming SDK objects are named `responses`; loop items are named `response`.
 - AI progress is communicated with reactions on the user's message. Preserve the no-intermediate-message UX.
 - Attachment ingestion is gated by `get_supported_modalities` for the slow model; unsupported attachments are dropped before any LLM call. Images are resized and JPEG re-encoded into `input_image` data URIs; other supported attachments are sent as `input_file`.

--- a/src/discordbot/cogs/gen_reply.py
+++ b/src/discordbot/cogs/gen_reply.py
@@ -458,16 +458,16 @@ class ReplyGeneratorCogs(commands.Cog):
         server-side against the allowlist. Returns the memories plus this request's token usage
         so the reply footer and chat reward account for the selection call too.
         """
-        slow_model = self.runtime_models.slow_model
+        tool_model = self.runtime_models.tool_model
         selection_input: ResponseInputParam = [
             *message_list,
             render_callable_users_block(allowed=allowed),
         ]
         responses = await self.client.responses.create(
-            model=slow_model.name,
+            model=tool_model.name,
             instructions=MEMORY_SELECT_PROMPT,
             input=selection_input,
-            reasoning=slow_model.reasoning,
+            reasoning=tool_model.reasoning,
             tools=[GET_USER_MEMORY_TOOL],
             stream=False,
             service_tier="auto",

--- a/src/discordbot/typings/models.py
+++ b/src/discordbot/typings/models.py
@@ -113,6 +113,19 @@ class RuntimeModelCatalog(BaseModel):
         return fast_model
 
     @property
+    def tool_model(self) -> ModelSettings:
+        """The model settings for the phase-1 get_user_memory selection decision.
+
+        Callers: `_select_user_memories`.
+
+        Returns:
+            Fast settings for the "should I read whose long-term memory" tool-call
+            decision that runs on the reply critical path before the answer, kept
+            off the heavier slow_model tier so it adds minimal latency.
+        """
+        return ModelSettings(name="gemini-flash-latest", effort="none")
+
+    @property
     def slow_model(self) -> ModelSettings:
         """The model settings for full text replies and strategic reasoning.
 

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -973,6 +973,12 @@ async def test_handle_message_reply_selection_offers_tool_then_answers_with_buil
     # Two requests: selection (non-streaming) then the answer (streaming).
     assert cog.client.responses.create_streams == [False, True]
 
+    # Selection runs on the fast tool_model; only the answer pays for slow_model.
+    assert cog.client.responses.create_models == [
+        cog.runtime_models.tool_model.name,
+        cog.runtime_models.slow_model.name,
+    ]
+
     # Selection request offers only get_user_memory + a callable-users block.
     select_tools = [tool.get("name") for tool in cog.client.responses.create_tools[0]]
     assert select_tools == ["get_user_memory"]


### PR DESCRIPTION
## Why

The long-term memory read path is two-phase: phase 1 (`_select_user_memories`) lets the model pick whose stored memory to read via the `get_user_memory` function tool, then phase 2 streams the answer. Both phases were running on `slow_model` (gemini-pro-latest, effort=high).

Phase 1 is only a lightweight gating decision ("would any participant's memory help, and whose"), and it sits on the reply critical path before the answer starts streaming. Running it on the heaviest tier with high reasoning effort adds pure wait latency, which is at odds with the memory design's latency sensitivity. It is the same kind of pre-flight decision as routing (`_route_message`), which already uses a fast model.

## What

- Add a dedicated `tool_model` (gemini-flash-latest, effort=none) to `RuntimeModelCatalog`, following the catalog's one-property-per-role style.
- Point `_select_user_memories` at `tool_model`; the final answer keeps `slow_model`.

No behavior coupling: phase 1 is a single non-streaming call whose function call is resolved server-side and injected into phase 2 as a plain text block, so the two phases share no conversation state. No user-facing command or behavior surface changes.

## Verification

- `uv run pytest` — 737 passed; new assertion locks selection=tool_model, answer=slow_model.
- `uv run pre-commit run -a` — exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)