### PR TITLE
refactor: drop inaccurate web-search reaction detection

### DIFF
--- a/src/discordbot/cogs/_gen_reply/streaming.py
+++ b/src/discordbot/cogs/_gen_reply/streaming.py
@@ -14,7 +14,6 @@ from openai.types.responses import ResponseStreamEvent
 
 from discordbot.utils.avatars import guild_avatar_url
 from discordbot.typings.economy import CHAT_REWARD_MAX_PER_REPLY, CHAT_REWARD_TOKEN_DIVISOR
-from discordbot.utils.reactions import update_reaction
 from discordbot.utils.model_pricing import get_token_rates
 from discordbot.cogs._economy.database import credit_with_repayment
 from discordbot.cogs._economy.presentation import currency_text
@@ -67,9 +66,6 @@ class ResponseStreamer(BaseModel):
     )
     input_tokens: int = Field(default=0, description="Input tokens reported by the stream.")
     output_tokens: int = Field(default=0, description="Output tokens reported by the stream.")
-    used_web_search: bool = Field(
-        default=False, description="Whether the reply used a native web-search / grounding tool."
-    )
     memory_lookups: list[str] = Field(
         default_factory=list,
         description="Labels of users whose stored memory was injected, for the footer.",
@@ -224,7 +220,7 @@ class ResponseStreamer(BaseModel):
         self._ensure_editor_started()
 
     async def _consume(self, *, responses: AsyncStream[ResponseStreamEvent]) -> None:
-        """Streams the reply, accumulating text, usage, and web-search state onto the instance.
+        """Streams the reply, accumulating text and usage onto the instance.
 
         Only accumulates state; the snapshot editor task renders it to Discord, so this
         loop never blocks on a Discord edit between deltas.
@@ -238,13 +234,6 @@ class ResponseStreamer(BaseModel):
                 if response.response.usage:
                     self.input_tokens += response.response.usage.input_tokens
                     self.output_tokens += response.response.usage.output_tokens
-            elif response.type in {
-                "response.web_search_call.in_progress",
-                "response.web_search_call.searching",
-                "response.web_search_call.completed",
-                "response.output_text.annotation.added",
-            }:
-                self.used_web_search = True
             elif response.type == "response.reasoning_summary_text.delta":
                 self._on_reasoning_delta(delta=response.delta)
             elif response.type == "response.output_text.delta":
@@ -297,9 +286,6 @@ class ResponseStreamer(BaseModel):
             reply=self.reply, content=self.stored_content, footer=usage_footer
         )
         self.stored_content += usage_footer
-
-        if self.used_web_search:
-            await update_reaction(message=self.message, bot_user=None, emoji="🌐")
 
         return self.stored_content
 

--- a/src/discordbot/cogs/gen_reply.py
+++ b/src/discordbot/cogs/gen_reply.py
@@ -663,6 +663,9 @@ class ReplyGeneratorCogs(commands.Cog):
         # streams the answer with the built-in tools always available and any selected
         # memory injected as context. The allowlist (conversation authors + mentioned
         # users, minus the bot) is the permission boundary.
+        # The split is a Gemini constraint, not a hard requirement: OpenAI / Claude answer
+        # models allow mixing function and built-in tools in one request, so this stays
+        # correct (just one extra request) if the answer model is switched off Gemini.
         memory_labels: list[str] = []
         selection_input_tokens = 0
         selection_output_tokens = 0

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -614,66 +614,6 @@ async def test_handle_streaming_continues_long_reply_as_reply_chain(
     assert cog.client.responses.create_models == []
 
 
-async def test_handle_streaming_marks_web_search_from_call_event(
-    economy_isolated_db: None,
-) -> None:
-    """Verifies native web_search_call events trigger the web reaction."""
-    del economy_isolated_db
-    message = FakeMessage()
-
-    await ResponseStreamer(message=message).stream(
-        responses=_stream_events_from(
-            events=[
-                SimpleNamespace(type="response.output_text.delta", delta="answer"),
-                SimpleNamespace(type="response.web_search_call.completed"),
-                SimpleNamespace(
-                    type="response.completed",
-                    response=SimpleNamespace(
-                        model=TEST_LLM_MODEL,
-                        usage=SimpleNamespace(input_tokens=12, output_tokens=34),
-                    ),
-                ),
-            ]
-        )
-    )
-
-    assert message.added_reactions == ["🌐"]
-
-
-async def test_handle_streaming_marks_web_search_from_annotation(
-    economy_isolated_db: None,
-) -> None:
-    """Verifies any annotation event also triggers the web reaction.
-
-    LiteLLM-proxied Gemini grounds via url_citation annotations without
-    emitting web_search_call.* events, so annotation alone is treated as
-    a search signal.
-    """
-    del economy_isolated_db
-    message = FakeMessage()
-
-    await ResponseStreamer(message=message).stream(
-        responses=_stream_events_from(
-            events=[
-                SimpleNamespace(type="response.output_text.delta", delta="grounded answer"),
-                SimpleNamespace(
-                    type="response.output_text.annotation.added",
-                    annotation={"type": "url_citation", "url": "https://example.com/article"},
-                ),
-                SimpleNamespace(
-                    type="response.completed",
-                    response=SimpleNamespace(
-                        model=TEST_LLM_MODEL,
-                        usage=SimpleNamespace(input_tokens=12, output_tokens=34),
-                    ),
-                ),
-            ]
-        )
-    )
-
-    assert message.added_reactions == ["🌐"]
-
-
 def test_extract_friendly_error_prefers_nested_provider_message() -> None:
     """Verifies nested provider errors are preferred over wrapper text."""
     raw = """wrapper b'{"error": {"message": "quota exceeded"}}'"""


### PR DESCRIPTION
## Why

The 🌐 reaction that marked replies as having used native web-search / grounding is unreliable: replies that genuinely grounded on the web often did not get the marker (the streamed `web_search_call.*` / annotation events don't fire consistently through the proxy). An inaccurate signal is worse than no signal, so this removes the detection entirely.

This also removes one piece of Gemini coupling: the detection keyed on Gemini-shaped stream events, which a non-Gemini answer model would not emit the same way.

## Change

- Drop `ResponseStreamer.used_web_search`, the stream-event branch that set it, and the `🌐` reaction in `_finalize_reply` (`_gen_reply/streaming.py`). Remove the now-unused `update_reaction` import.
- Remove the two tests covering the removed reaction.
- Add a comment on the two-phase memory split (`gen_reply.py`) noting it is a Gemini constraint, not a hard requirement: OpenAI / Claude answer models allow mixing function and built-in tools in one request, so it stays correct (just one extra request) if the answer model is switched off Gemini.

The 💭 reasoning preview, the answer stream, and the memory footer are untouched.

## Testing

- `uv run pytest` — 792 passed (coverage gate 80%).
- `uv run pre-commit run -a` — clean (ruff + mypy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)