### PR TITLE
test: redesign test suite around structural assertions

### DIFF
--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,7 @@
+"""Shared test helpers.
+
+Structural assertion utilities and reusable test doubles live here so individual
+test modules stop re-deriving brittle string checks and duplicating fake objects.
+Modules in this package are import-safe and carry no doctests, so the suite's
+``--doctest-modules`` collection stays clean.
+"""

--- a/tests/helpers/discord_mocks.py
+++ b/tests/helpers/discord_mocks.py
@@ -1,0 +1,166 @@
+"""Shared Discord interaction/message test doubles.
+
+Several cog test modules each grew their own ``FakeInteraction`` / ``FakeUser`` /
+``FakeResponse`` families that drifted apart. These are the unified superset:
+they satisfy the strictest consumer (the cog smoke tests) and expose the extra
+knobs lighter consumers need as optional keyword arguments. Plain classes, not
+pydantic, to match the existing test-double style and carry heterogeneous
+recorded payloads.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Unpack, TypedDict
+from datetime import UTC, datetime, timedelta
+
+if TYPE_CHECKING:
+    from nextcord import File, Embed, Attachment, AllowedMentions
+    from nextcord.ui import View
+
+
+class DiscordPayload(TypedDict, total=False):
+    """Payload captured from fake message, response, and followup sends."""
+
+    content: str | None
+    embed: Embed
+    embeds: list[Embed]
+    file: File
+    files: list[File]
+    view: View | None
+    wait: bool
+    ephemeral: bool
+    suppress: bool
+    allowed_mentions: AllowedMentions
+    attachments: list[Attachment]
+    message_id: int
+
+
+class OriginalEditPayload(TypedDict, total=False):
+    """Payload captured from fake original interaction edits."""
+
+    content: str
+    file: File
+    allowed_mentions: AllowedMentions
+
+
+class FakeUser:
+    """Minimal Discord user/member stub recording identity and avatar fields."""
+
+    def __init__(
+        self,
+        user_id: int = 1,
+        name: str = "alice",
+        display_name: str = "Alice",
+        bot: bool = False,
+        avatar_url: str = "https://example.test/avatar.png",
+    ) -> None:
+        """Initializes identity, avatar, bot flag, and account-age fields."""
+        self.id = user_id
+        self.name = name
+        self.display_name = display_name
+        self.bot = bot
+        self.mention = f"<@{user_id}>"
+        self.display_avatar = SimpleNamespace(url=avatar_url)
+        # Commands that surface snowflake-derived account age read created_at; pin
+        # it well into the past so the value is never surprising under freezegun.
+        self.created_at = datetime.now(tz=UTC) - timedelta(days=365 * 5)
+
+
+class FakeResponse:
+    """Interaction response stub that records sends, edits, and deferral."""
+
+    def __init__(self) -> None:
+        """Initializes response state records."""
+        self.deferred = False
+        self.deferred_ephemeral = False
+        self.sent: list[DiscordPayload] = []
+        self.edited: list[DiscordPayload] = []
+
+    async def defer(self, ephemeral: bool = False) -> None:
+        """Records that the interaction response was deferred."""
+        self.deferred = True
+        self.deferred_ephemeral = ephemeral
+
+    async def send_message(self, **kwargs: Unpack[DiscordPayload]) -> None:
+        """Records an interaction response message."""
+        self.sent.append(kwargs)
+
+    async def edit_message(self, **kwargs: Unpack[DiscordPayload]) -> None:
+        """Records an interaction response edit."""
+        self.edited.append(kwargs)
+
+    def is_done(self) -> bool:
+        """Returns whether the fake response has already been used."""
+        return self.deferred or bool(self.sent)
+
+
+class FakeFollowup:
+    """Interaction followup stub that records sends and edits."""
+
+    def __init__(self) -> None:
+        """Initializes recorded followup sends and edits."""
+        self.sent: list[DiscordPayload] = []
+        self.edited: list[DiscordPayload] = []
+
+    async def send(self, **kwargs: Unpack[DiscordPayload]) -> FakeDiscordMessage:
+        """Records the followup payload and returns a fake message."""
+        self.sent.append(kwargs)
+        return FakeDiscordMessage()
+
+    async def edit_message(self, **kwargs: Unpack[DiscordPayload]) -> None:
+        """Records a followup message edit payload."""
+        self.edited.append(kwargs)
+
+
+class FakeDiscordMessage:
+    """Discord message stub that records mutations."""
+
+    def __init__(self) -> None:
+        """Initializes message mutation records."""
+        self.edits: list[DiscordPayload] = []
+        self.reactions: list[str] = []
+        self.removed: list[tuple[str, FakeUser]] = []
+        self.replies: list[DiscordPayload] = []
+        self.deleted = False
+        self.suppressed = False
+
+    async def edit(self, **kwargs: Unpack[DiscordPayload]) -> None:
+        """Records an edit payload and suppress flag."""
+        if "suppress" in kwargs:
+            self.suppressed = bool(kwargs["suppress"])
+        self.edits.append(kwargs)
+
+    async def add_reaction(self, emoji: str) -> None:
+        """Records an added reaction."""
+        self.reactions.append(emoji)
+
+    async def remove_reaction(self, emoji: str, member: FakeUser) -> None:
+        """Records a removed reaction."""
+        self.removed.append((emoji, member))
+
+    async def reply(self, **kwargs: Unpack[DiscordPayload]) -> None:
+        """Records a message reply payload."""
+        self.replies.append(kwargs)
+
+    async def delete(self) -> None:
+        """Records message deletion."""
+        self.deleted = True
+
+
+class FakeInteraction:
+    """Interaction stub shared by cog command and view tests."""
+
+    def __init__(
+        self, user: FakeUser | None = None, message: FakeDiscordMessage | object | None = None
+    ) -> None:
+        """Initializes user, response, followup, message, and edit records."""
+        self.user = user or FakeUser()
+        self.message = message
+        self.response = FakeResponse()
+        self.followup = FakeFollowup()
+        self.edits: list[OriginalEditPayload] = []
+
+    async def edit_original_message(self, **kwargs: Unpack[OriginalEditPayload]) -> None:
+        """Records an edit to the deferred original response."""
+        self.edits.append(kwargs)

--- a/tests/helpers/economy_invariants.py
+++ b/tests/helpers/economy_invariants.py
@@ -1,0 +1,68 @@
+"""Accounting-invariant assertions for economy and casino state.
+
+These read production state through the real database helpers and assert the
+structural identities the economy guarantees, instead of each test re-summing
+magic numbers by hand. They return the snapshot so a caller can layer a focused
+exact check (a settlement delta that must equal a computed value) on top.
+"""
+
+from discordbot.typings.economy import AccountSnapshot, CasinoDailyStats, CasinoLedgerSnapshot
+from discordbot.cogs._economy.database import (
+    get_account,
+    get_casino_ledger,
+    get_casino_daily_stats,
+)
+
+
+async def assert_wallet_consistent(
+    user_id: int, expected_balance: int | None = None
+) -> AccountSnapshot:
+    """Asserts the wallet identity ``balance == total_earned - total_spent``.
+
+    When ``expected_balance`` is given it must match too. Returns the snapshot.
+    """
+    account = await get_account(user_id=user_id)
+    assert account is not None, f"no account for user {user_id}"
+    assert account.balance == account.total_earned - account.total_spent, (
+        f"wallet identity broken for user {user_id}: "
+        f"{account.balance} != {account.total_earned} - {account.total_spent}"
+    )
+    if expected_balance is not None:
+        assert account.balance == expected_balance, (
+            f"balance {account.balance} != expected {expected_balance}"
+        )
+    return account
+
+
+async def assert_casino_ledger_consistent(
+    expected_balance: int | None = None,
+) -> CasinoLedgerSnapshot:
+    """Asserts the casino ledger identity ``balance == total_earned - total_spent``.
+
+    When ``expected_balance`` is given it must match too. Returns the snapshot.
+    """
+    ledger = await get_casino_ledger()
+    assert ledger.balance == ledger.total_earned - ledger.total_spent, (
+        f"casino ledger identity broken: "
+        f"{ledger.balance} != {ledger.total_earned} - {ledger.total_spent}"
+    )
+    if expected_balance is not None:
+        assert ledger.balance == expected_balance, (
+            f"casino balance {ledger.balance} != expected {expected_balance}"
+        )
+    return ledger
+
+
+async def assert_daily_casino_stats(
+    user_id: int, loss: int, win: int, net: int
+) -> CasinoDailyStats:
+    """Asserts a user's daily casino counters and that ``net == win - loss``."""
+    stats = await get_casino_daily_stats(user_id=user_id)
+    assert stats.daily_net == stats.daily_win - stats.daily_loss, (
+        f"daily net identity broken for user {user_id}: "
+        f"{stats.daily_net} != {stats.daily_win} - {stats.daily_loss}"
+    )
+    assert stats.daily_loss == loss, f"daily_loss {stats.daily_loss} != {loss}"
+    assert stats.daily_win == win, f"daily_win {stats.daily_win} != {win}"
+    assert stats.daily_net == net, f"daily_net {stats.daily_net} != {net}"
+    return stats

--- a/tests/helpers/embeds.py
+++ b/tests/helpers/embeds.py
@@ -1,0 +1,26 @@
+"""Structural assertions over Discord embeds.
+
+Tests used to pin whole localized strings (full titles, footers, field copy),
+which breaks on any wording or emoji refresh even though the behavior is
+unchanged. These assert the embed's *shape* — that a named field exists, that a
+title carries its category marker — and hand the field back so the caller checks
+only the value that actually encodes behavior (an amount, a status).
+"""
+
+from nextcord import Embed
+from nextcord.embeds import EmbedProxy
+
+
+def assert_embed_has_field(embed: Embed, name: str) -> EmbedProxy:
+    """Asserts a field with the given name exists and returns it for value checks."""
+    for field in embed.fields:
+        if field.name == name:
+            return field
+    available = [field.name for field in embed.fields]
+    raise AssertionError(f"embed has no field named {name!r}; fields present: {available}")
+
+
+def assert_embed_title_prefix(embed: Embed, prefix: str) -> None:
+    """Asserts the embed title starts with the given prefix (a category marker)."""
+    title = embed.title or ""
+    assert title.startswith(prefix), f"embed title {title!r} does not start with {prefix!r}"

--- a/tests/helpers/llm_input.py
+++ b/tests/helpers/llm_input.py
@@ -1,0 +1,161 @@
+"""Structural extractors over recorded Responses API inputs.
+
+The reply pipeline records each ``responses.create`` call's ``input`` (a
+``ResponseInputParam`` list of role/content items). Tests used to assert on
+these by serializing the whole list with ``str(...)`` and substring-matching a
+magic sentinel, which is brittle and coupling to incidental ordering. These
+helpers walk the role/content structure instead, keyed on the production block
+headers and the ``[id: N]`` markers the memory blocks emit, so a test asserts on
+*which user's memory reached which role* rather than on an arbitrary literal.
+
+The block-header anchors are derived from the production renderers at import
+time, so a wording change in ``memory_tool.py`` is tracked automatically rather
+than silently breaking these extractors.
+"""
+
+import re
+from typing import Literal, Protocol
+from collections.abc import Mapping, Iterator, Sequence
+
+from openai.types.responses import ResponseInputParam
+
+from discordbot.cogs._gen_reply.memory_tool import (
+    render_server_memory_block,
+    render_callable_users_block,
+    render_memory_context_block,
+)
+
+
+class RecordedResponses(Protocol):
+    """The recording surface a fake Responses resource exposes to tests.
+
+    Mirrors the attributes the test double accumulates per ``create`` call, so
+    helpers can be typed against the recorder without importing the test module.
+    """
+
+    create_streams: list[bool]
+    create_tools: list[list[object] | None]
+    create_inputs: list[ResponseInputParam | str]
+
+
+def _content_to_text(content: object) -> str:
+    """Flattens a message item's content to plain text.
+
+    Handles both shapes the pipeline emits: a bare string, or a list of
+    ``input_text`` parts whose ``text`` fields are concatenated.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, Sequence):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, Mapping):
+                text = part.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(parts)
+    return ""
+
+
+def _header_line(block: Mapping[str, object]) -> str:
+    """Returns the first line of a rendered block's text (its stable header)."""
+    return _content_to_text(content=block.get("content")).split("\n", 1)[0]
+
+
+_PARTICIPANT_HEADER = _header_line(block=render_memory_context_block(memories=[]))
+_SERVER_HEADER = _header_line(block=render_server_memory_block(memory=""))
+_CALLABLE_HEADER = _header_line(block=render_callable_users_block(allowed={}))
+
+_ID_SECTION = re.compile(r"\[id: (\d+)\][^\n]*\n(.*?)(?=\n\n\[id: |\Z)", re.DOTALL)
+_ID_MARKER = re.compile(r"\[id: (\d+)\]")
+
+
+def iter_text_blocks(request: ResponseInputParam | str) -> Iterator[tuple[str, str]]:
+    """Yields ``(role, text)`` for each role-bearing item in a recorded input."""
+    if isinstance(request, str):
+        return
+    for item in request:
+        if not isinstance(item, Mapping):
+            continue
+        role = item.get("role")
+        if isinstance(role, str):
+            yield role, _content_to_text(content=item.get("content"))
+
+
+def extract_memory_context_block(request: ResponseInputParam | str) -> str | None:
+    """Returns the participant-memory assistant block's text, or None if absent."""
+    for role, text in iter_text_blocks(request=request):
+        if role == "assistant" and text.split("\n", 1)[0] == _PARTICIPANT_HEADER:
+            return text
+    return None
+
+
+def has_memory_context_block(request: ResponseInputParam | str) -> bool:
+    """Whether the input carries an injected participant-memory block."""
+    return extract_memory_context_block(request=request) is not None
+
+
+def extract_user_memory_blocks(request: ResponseInputParam | str) -> dict[int, str]:
+    """Maps each injected user id to its memory body within the memory block.
+
+    Empty when no memory block is present, so a leak check reads as
+    ``user_id not in extract_user_memory_blocks(request=...)``.
+    """
+    block = extract_memory_context_block(request=request)
+    if block is None:
+        return {}
+    body = block.split("\n", 1)[1] if "\n" in block else ""
+    return {int(match.group(1)): match.group(2).strip() for match in _ID_SECTION.finditer(body)}
+
+
+def extract_server_memory_block(request: ResponseInputParam | str) -> str | None:
+    """Returns the server-memory assistant block's text, or None if absent."""
+    for role, text in iter_text_blocks(request=request):
+        if role == "assistant" and text.split("\n", 1)[0] == _SERVER_HEADER:
+            return text
+    return None
+
+
+def extract_callable_user_ids(request: ResponseInputParam | str) -> set[int]:
+    """Returns the ids the selection phase offered in its callable-users block.
+
+    This is the per-request allowlist boundary: a private channel that does not
+    widen via the nickname table yields only the conversation participants here.
+    """
+    for role, text in iter_text_blocks(request=request):
+        if role == "system" and text.split("\n", 1)[0] == _CALLABLE_HEADER:
+            return {int(match) for match in _ID_MARKER.findall(text)}
+    return set()
+
+
+def tool_names_for_call(responses: RecordedResponses, n: int) -> list[str]:
+    """Returns the tool names offered on the nth recorded ``create`` call."""
+    names: list[str] = []
+    for tool in responses.create_tools[n] or []:
+        if isinstance(tool, Mapping):
+            name = tool.get("name")
+            if isinstance(name, str):
+                names.append(name)
+    return names
+
+
+def request_index(responses: RecordedResponses, phase: Literal["selection", "answer"]) -> int:
+    """Maps a semantic pipeline phase to its recorded ``create`` index.
+
+    Selection is the first non-streaming call; the answer is the last streaming
+    call. Lets tests reference phases by name instead of hardcoding positions.
+    """
+    streams = responses.create_streams
+    if phase == "selection":
+        return streams.index(False)
+    for index in range(len(streams) - 1, -1, -1):
+        if streams[index]:
+            return index
+    raise AssertionError("no streaming answer request was recorded")
+
+
+def request_input(
+    responses: RecordedResponses, phase: Literal["selection", "answer"]
+) -> ResponseInputParam | str:
+    """Returns the recorded input for a semantic pipeline phase."""
+    return responses.create_inputs[request_index(responses=responses, phase=phase)]

--- a/tests/test_cogs_smoke.py
+++ b/tests/test_cogs_smoke.py
@@ -8,7 +8,7 @@ import asyncio
 from datetime import UTC, datetime, timedelta
 
 import nextcord
-from nextcord import File, Embed, AllowedMentions
+from nextcord import Embed
 from nextcord.ext import commands
 
 from discordbot import cli
@@ -57,6 +57,14 @@ from discordbot.cogs._economy.database import (
 from discordbot.cogs._games.blackjack_views import BlackjackLobbyView
 from discordbot.cogs._games.dragon_gate_views import DragonGateLobbyView
 
+from tests.helpers.embeds import assert_embed_has_field, assert_embed_title_prefix
+from tests.helpers.discord_mocks import (
+    FakeUser,
+    DiscordPayload,
+    FakeInteraction,
+    FakeDiscordMessage,
+)
+
 TEST_DEALER_MODEL = "test-dealer-llm-model"
 
 if TYPE_CHECKING:
@@ -65,30 +73,6 @@ if TYPE_CHECKING:
 
     from openai import AsyncOpenAI
     import pytest
-    from nextcord.ui import View
-
-
-class DiscordPayload(TypedDict, total=False):
-    """Payload captured from fake Discord message and followup sends."""
-
-    content: str | None
-    embed: Embed
-    embeds: list[Embed]
-    file: File
-    files: list[File]
-    view: View | None
-    wait: bool
-    ephemeral: bool
-    suppress: bool
-    allowed_mentions: AllowedMentions
-
-
-class OriginalEditPayload(TypedDict, total=False):
-    """Payload captured from fake original interaction edits."""
-
-    content: str
-    file: File
-    allowed_mentions: AllowedMentions
 
 
 class SelfTimeoutCall(TypedDict):
@@ -96,116 +80,6 @@ class SelfTimeoutCall(TypedDict):
 
     member: SimpleNamespace
     until: datetime
-
-
-class FakeResponse:
-    """Minimal interaction response stub that records sends and deferral."""
-
-    def __init__(self) -> None:
-        """Initializes response state records."""
-        self.deferred = False
-        self.deferred_ephemeral = False
-        self.sent: list[DiscordPayload] = []
-        self.edited: list[DiscordPayload] = []
-
-    async def defer(self, ephemeral: bool = False) -> None:
-        """Records that the interaction response was deferred."""
-        self.deferred = True
-        self.deferred_ephemeral = ephemeral
-
-    async def send_message(self, **kwargs: Unpack[DiscordPayload]) -> None:
-        """Records an interaction response message."""
-        self.sent.append(kwargs)
-
-    async def edit_message(self, **kwargs: Unpack[DiscordPayload]) -> None:
-        """Records an interaction response edit."""
-        self.edited.append(kwargs)
-
-    def is_done(self) -> bool:
-        """Returns whether the fake response has already been used."""
-        return self.deferred or bool(self.sent)
-
-
-class FakeFollowup:
-    """Minimal interaction followup stub."""
-
-    def __init__(self) -> None:
-        """Initializes recorded followup sends."""
-        self.sent: list[DiscordPayload] = []
-
-    async def send(self, **kwargs: Unpack[DiscordPayload]) -> FakeDiscordMessage:
-        """Records the followup payload and returns a fake message."""
-        self.sent.append(kwargs)
-        return FakeDiscordMessage()
-
-
-class FakeInteraction:
-    """Minimal interaction stub shared by cog command tests."""
-
-    def __init__(self, user: FakeUser | None = None) -> None:
-        """Initializes user, response, followup, and edit records."""
-        self.user = user or FakeUser()
-        self.message: FakeDiscordMessage | None = None
-        self.response = FakeResponse()
-        self.followup = FakeFollowup()
-        self.edits: list[OriginalEditPayload] = []
-
-    async def edit_original_message(self, **kwargs: Unpack[OriginalEditPayload]) -> None:
-        """Records an edit to the deferred original response."""
-        self.edits.append(kwargs)
-
-
-class FakeUser:
-    """Minimal Discord user/member stub."""
-
-    def __init__(
-        self, user_id: int = 1, name: str = "alice", display_name: str = "Alice", bot: bool = False
-    ) -> None:
-        """Initializes identity, avatar, bot flag, and account age fields."""
-        self.id = user_id
-        self.name = name
-        self.display_name = display_name
-        self.bot = bot
-        self.mention = f"<@{user_id}>"
-        self.display_avatar = SimpleNamespace(url="https://example.test/avatar.png")
-        # /balance displays the snowflake-derived account age; pin it well into
-        # the past so freezegun does not make the value surprising.
-        self.created_at = datetime.now(tz=UTC) - timedelta(days=365 * 5)
-
-
-class FakeDiscordMessage:
-    """Minimal Discord message stub that records mutations."""
-
-    def __init__(self) -> None:
-        """Initializes message mutation records."""
-        self.edits: list[DiscordPayload] = []
-        self.reactions: list[str] = []
-        self.removed: list[tuple[str, FakeUser]] = []
-        self.replies: list[DiscordPayload] = []
-        self.deleted = False
-        self.suppressed = False
-
-    async def edit(self, **kwargs: Unpack[DiscordPayload]) -> None:
-        """Records an edit payload and suppress flag."""
-        if "suppress" in kwargs:
-            self.suppressed = bool(kwargs["suppress"])
-        self.edits.append(kwargs)
-
-    async def add_reaction(self, emoji: str) -> None:
-        """Records an added reaction."""
-        self.reactions.append(emoji)
-
-    async def remove_reaction(self, emoji: str, member: FakeUser) -> None:
-        """Records a removed reaction."""
-        self.removed.append((emoji, member))
-
-    async def reply(self, **kwargs: Unpack[DiscordPayload]) -> None:
-        """Records a message reply payload."""
-        self.replies.append(kwargs)
-
-    async def delete(self) -> None:
-        """Records message deletion."""
-        self.deleted = True
 
 
 class HangingResponses:
@@ -685,20 +559,17 @@ async def test_economy_commands_use_database_facade(  # noqa: PLR0915 -- command
     assert interaction.followup.sent[15].get("ephemeral") is not True
     assert interaction.followup.sent[-1].get("ephemeral") is True
     balance_embed = interaction.followup.sent[0]["embed"]
-    assert balance_embed.title == "💰 財務總覽"
-    assert "315 虛擬歡樂豆" in balance_embed.description
-    assert any(field.name == "現金" and "`150`" in field.value for field in balance_embed.fields)
-    assert any(
-        field.name == "債務" and "本金 `30`" in field.value for field in balance_embed.fields
-    )
-    assert any(
-        field.name == "股票淨值" and "`200`" in field.value for field in balance_embed.fields
-    )
-    assert any(
-        field.name == "股票部位" and "BCAT" in field.value for field in balance_embed.fields
-    )
+    # Assert the financial summary's structure and the facade values it surfaces, not the exact
+    # localized title/labels: cash 150, debt principal 30, stock net 200, total 315, BCAT position.
+    assert_embed_title_prefix(embed=balance_embed, prefix="💰")
+    assert "315" in (balance_embed.description or "")
+    assert "150" in assert_embed_has_field(embed=balance_embed, name="現金").value
+    assert "30" in assert_embed_has_field(embed=balance_embed, name="債務").value
+    assert "200" in assert_embed_has_field(embed=balance_embed, name="股票淨值").value
+    assert "BCAT" in assert_embed_has_field(embed=balance_embed, name="股票部位").value
     borrow_embed = interaction.followup.sent[8]["embed"]
-    assert borrow_embed.footer.text == "貸方可用下方按鈕批准或拒絕，發起者可取消，180 秒後自動拒絕"
+    # The footer explains the loan-decision timeout; assert the behavioral 180s, not the copy.
+    assert "180" in (borrow_embed.footer.text or "")
     borrow_view = interaction.followup.sent[8]["view"]
     assert isinstance(borrow_view, CreditLoanDecisionView)
     assert borrow_view.message is not None

--- a/tests/test_dragon_gate.py
+++ b/tests/test_dragon_gate.py
@@ -946,11 +946,12 @@ async def test_dragon_gate_view_pool_emptied_replenishes_and_finalises_without_c
     assert len(state.calls) == 1
     assert state.calls[0]["player_delta"] == 10_000
     assert view._settled is True
+    # The pool state above is the invariant; the dealer embed is rendered and well-formed but its
+    # exact replenishment copy is not pinned.
     embeds = message.edits[-1]["embeds"]
     assert isinstance(embeds, list)
     assert isinstance(embeds[1], Embed)
     assert isinstance(embeds[1].description, str)
-    assert "系統已自動補池" in embeds[1].description
     await view.wait_for_background_tasks()
 
 
@@ -1113,11 +1114,12 @@ async def test_dragon_gate_view_single_player_zero_balance_finalizes(
     assert round_state.is_active(user_id=1) is False
     assert round_state.finished is True
     assert view._settled is True
+    # The end-state above is the invariant; the dealer embed is rendered and well-formed but its
+    # exact "all players out" copy is not pinned.
     embeds = message.edits[-1]["embeds"]
     assert isinstance(embeds, list)
     assert isinstance(embeds[1], Embed)
     assert isinstance(embeds[1].description, str)
-    assert "所有玩家已離桌或餘額歸零" in embeds[1].description
     history_embed = embeds[-1]
     assert isinstance(history_embed, Embed)
     assert isinstance(history_embed.description, str)

--- a/tests/test_economy.py
+++ b/tests/test_economy.py
@@ -18,6 +18,7 @@ from discordbot.typings.games import (
     BlackjackPlayerSettlement,
 )
 from discordbot.utils.timezone import TAIWAN_TIMEZONE
+from discordbot.typings.economy import TRANSFER_TAX_BPS
 from discordbot.cogs._games.blackjack import Card, BlackjackRound, BlackjackHandState
 from discordbot.cogs._economy.database import (
     VIP_PURCHASE_COST,
@@ -28,7 +29,6 @@ from discordbot.cogs._economy.database import (
     UserAccount,
     AdminAccount,
     CasinoAccount,
-    TransferResult,
     AccountSnapshot,
     JackpotSnapshot,
     LeaderboardEntry,
@@ -68,6 +68,12 @@ from discordbot.cogs._economy.database import (
 )
 from discordbot.cogs._games.settlement import settle_wager, settle_blackjack_player
 from discordbot.cogs._games.blackjack_views import BlackjackView, build_final_embeds
+
+from tests.helpers.economy_invariants import (
+    assert_wallet_consistent,
+    assert_daily_casino_stats,
+    assert_casino_ledger_consistent,
+)
 
 pytestmark = pytest.mark.usefixtures("economy_isolated_db")
 
@@ -580,67 +586,48 @@ async def test_get_balance_unknown_user_returns_zero() -> None:
     assert await get_balance(user_id=999) == 0
 
 
-async def test_transfer_moves_currency_between_users() -> None:
-    """Successful transfer debits sender the full amount and credits the taxed net."""
-    await _add_balance(user_id=1, name="alice", amount=200)
+@pytest.mark.parametrize(
+    argnames=("sender_start", "amount"), argvalues=[(200, 80), (1_000, 1_000), (10_000, 2_500)]
+)
+async def test_transfer_taxes_and_preserves_invariant(sender_start: int, amount: int) -> None:
+    """A transfer debits the sender in full, burns the tax, and credits the taxed net.
+
+    The burned tax is derived from TRANSFER_TAX_BPS rather than hardcoded, and both wallets keep
+    the balance == total_earned - total_spent identity, so the burn truly leaves circulation.
+    """
+    await _add_balance(user_id=1, name="alice", amount=sender_start)
     result = await transfer(
-        sender_id=1, sender_name="alice", receiver_id=2, receiver_name="bob", amount=80
+        sender_id=1, sender_name="alice", receiver_id=2, receiver_name="bob", amount=amount
     )
-    # 80 transferred, 5% (4) burned, receiver nets 76.
-    assert result == TransferResult(
-        sender_balance=120, receiver_balance=76, received_amount=76, tax_amount=4
-    )
-    assert await get_balance(user_id=1) == 120
-    assert await get_balance(user_id=2) == 76
-
-
-async def test_transfer_burns_tax_and_preserves_invariant() -> None:
-    """The transfer tax removes points from circulation and keeps each side's invariant."""
-    await _add_balance(user_id=1, name="alice", amount=1_000)
-    await _add_balance(user_id=2, name="bob", amount=0)
-
-    result = await transfer(
-        sender_id=1, sender_name="alice", receiver_id=2, receiver_name="bob", amount=1_000
-    )
-
     assert result is not None
-    # 5% of 1000 is burned; receiver nets 950.
-    assert result.tax_amount == 50
-    assert result.received_amount == 950
+    expected_tax = amount * TRANSFER_TAX_BPS // 10_000
+    assert result.tax_amount == expected_tax
+    assert result.received_amount == amount - expected_tax
 
-    sender = await get_account(user_id=1)
-    receiver = await get_account(user_id=2)
-    assert sender is not None
-    assert receiver is not None
-    # Sender spent the full amount; receiver only earned the net. The 50 burned
-    # is gone from total circulation (1000 in, 950 + 0 left).
-    assert sender == AccountSnapshot(
-        name="alice", balance=0, total_earned=1_000, total_spent=1_000
-    )
-    assert receiver == AccountSnapshot(name="bob", balance=950, total_earned=950, total_spent=0)
-    assert sender.balance == sender.total_earned - sender.total_spent
-    assert receiver.balance == receiver.total_earned - receiver.total_spent
+    sender = await assert_wallet_consistent(user_id=1, expected_balance=sender_start - amount)
+    receiver = await assert_wallet_consistent(user_id=2, expected_balance=amount - expected_tax)
+    # Sender spent the full amount; receiver earned only the net, so the tax is out of circulation.
+    assert sender.total_spent == amount
+    assert receiver.total_earned == amount - expected_tax
 
 
-async def test_transfer_rejects_self() -> None:
-    """Transfers to oneself must be rejected."""
-    await _add_balance(user_id=1, name="alice", amount=100)
+@pytest.mark.parametrize(
+    argnames=("sender_start", "receiver_id", "amount"),
+    argvalues=[(100, 1, 10), (10, 2, 100)],
+    ids=["self-transfer", "insufficient-balance"],
+)
+async def test_transfer_rejects_invalid(sender_start: int, receiver_id: int, amount: int) -> None:
+    """A self-transfer or an over-balance transfer is rejected and leaves the sender untouched."""
+    await _add_balance(user_id=1, name="alice", amount=sender_start)
     result = await transfer(
-        sender_id=1, sender_name="alice", receiver_id=1, receiver_name="alice", amount=10
+        sender_id=1,
+        sender_name="alice",
+        receiver_id=receiver_id,
+        receiver_name="bob",
+        amount=amount,
     )
     assert result is None
-    assert await get_balance(user_id=1) == 100
-
-
-async def test_transfer_rejects_insufficient_balance() -> None:
-    """Transfers exceeding the sender's balance must be rejected."""
-    await _add_balance(user_id=1, name="alice", amount=10)
-    result = await transfer(
-        sender_id=1, sender_name="alice", receiver_id=2, receiver_name="bob", amount=100
-    )
-    assert result is None
-    assert await get_balance(user_id=1) == 10
-    assert await get_balance(user_id=2) == 0
+    assert await get_balance(user_id=1) == sender_start
 
 
 async def test_transfer_prevents_concurrent_double_spend() -> None:
@@ -2008,93 +1995,46 @@ async def test_settle_blackjack_player_split_offset_skips_vip_bonus() -> None:
     assert settlement.vip_bonus == 0
 
 
-async def test_settle_blackjack_player_five_card_non_21_wins_without_system_bonus() -> None:
-    """Five-card non-bust hands win normally without the five-card 21 bonus."""
-    await _add_balance(user_id=1, name="alice", amount=100_000)
+@pytest.mark.parametrize(
+    argnames=("last_card", "dealer", "dealer_21", "is_vip", "expect_outcome"),
+    argvalues=[
+        ("6", [("7", "♣"), ("7", "♦"), ("7", "♥")], True, False, "five_card_win"),
+        ("7", [("10", "♣"), ("9", "♦")], False, False, "five_card_twenty_one"),
+        ("7", [("10", "♣"), ("9", "♦")], False, True, "five_card_twenty_one"),
+        ("7", [("7", "♣"), ("7", "♦"), ("7", "♥")], True, False, "five_card_twenty_one"),
+        ("7", [("7", "♣"), ("7", "♦"), ("7", "♥")], True, True, "five_card_twenty_one"),
+    ],
+    ids=[
+        "non-21-wins-regardless-of-dealer-21",
+        "21-wins-vs-dealer-19",
+        "vip-21-wins-vs-dealer-19",
+        "21-push-vs-dealer-21",
+        "vip-21-push-vs-dealer-21",
+    ],
+)
+async def test_settle_blackjack_player_five_card(
+    last_card: str,
+    dealer: list[tuple[str, str]],
+    dealer_21: bool,
+    is_vip: bool,
+    expect_outcome: str,
+) -> None:
+    """Five-card settlement: a non-21 hand wins regardless of dealer, a 21 follows the comparison.
+
+    Every expected delta is derived from the rules -- the bet, the five-card bonus, and the VIP
+    perk -- rather than hardcoded. The house ledger and daily counters are checked through the
+    invariant helpers, proving the system-funded five-card and VIP-from-bonus payouts never move
+    /casino while the dealer-funded portion does.
+    """
+    bet = 10_000
+    starting = 100_000
+    seed = (VIP_PURCHASE_COST + starting) if is_vip else starting
+    await _add_balance(user_id=1, name="alice", amount=seed)
+    if is_vip:
+        assert await buy_vip(user_id=1, name="alice") is not None
+
     round_state = BlackjackRound.from_participants(
-        rng=SystemRandom(), participants=[_participant(bet=10_000, balance_at_start=100_000)]
-    )
-    player = round_state.players[0]
-    hand = player.hands[0]
-    hand.cards = [
-        Card(rank="2", suit="♠"),
-        Card(rank="3", suit="♥"),
-        Card(rank="4", suit="♣"),
-        Card(rank="5", suit="♦"),
-        Card(rank="6", suit="♠"),
-    ]
-    hand.finished = True
-    round_state.dealer = [
-        Card(rank="7", suit="♣"),
-        Card(rank="7", suit="♦"),
-        Card(rank="7", suit="♥"),
-    ]
-    round_state.finished = True
-    round_state.phase = "settled"
-
-    settlement = await _settle_player(round_state=round_state)
-
-    assert settlement.outcome == "five_card_win"
-    assert settlement.hands[0].five_card_twenty_one is False
-    assert settlement.hands[0].five_card_bonus == 0
-    assert settlement.base_delta == 10_000
-    assert settlement.five_card_bonus == 0
-    assert settlement.delta == 10_000
-    assert settlement.new_balance == 110_000
-    assert settlement.casino_balance == -10_000
-    _ledger = await get_casino_ledger()
-    assert _ledger.balance == -10_000
-    loss, win, net, _day_started_at = await _daily_casino_stats(user_id=1)
-    assert (loss, win, net) == (0, 10_000, 10_000)
-
-
-async def test_settle_blackjack_player_five_card_bonus_excludes_house_ledger() -> None:
-    """Five-card 21 pays the system bonus without moving the house ledger for it."""
-    await _add_balance(user_id=1, name="alice", amount=100_000)
-    round_state = BlackjackRound.from_participants(
-        rng=SystemRandom(), participants=[_participant(bet=10_000, balance_at_start=100_000)]
-    )
-    player = round_state.players[0]
-    hand = player.hands[0]
-    hand.cards = [
-        Card(rank="2", suit="♠"),
-        Card(rank="3", suit="♥"),
-        Card(rank="4", suit="♣"),
-        Card(rank="5", suit="♦"),
-        Card(rank="7", suit="♠"),
-    ]
-    hand.finished = True
-    round_state.dealer = [Card(rank="10", suit="♣"), Card(rank="9", suit="♦")]
-    round_state.finished = True
-    round_state.phase = "settled"
-
-    settlement = await _settle_player(round_state=round_state)
-
-    assert settlement.outcome == "five_card_twenty_one"
-    assert settlement.hands[0].five_card_twenty_one is True
-    assert settlement.hands[0].five_card_bonus == 10_000
-    assert settlement.base_delta == 10_000
-    assert settlement.five_card_bonus == 10_000
-    assert settlement.delta == 20_000
-    assert settlement.new_balance == 120_000
-    assert settlement.casino_balance == -10_000
-    _ledger = await get_casino_ledger()
-    assert _ledger.balance == -10_000
-    loss, win, net, _day_started_at = await _daily_casino_stats(user_id=1)
-    assert (loss, win, net) == (0, 20_000, 20_000)
-    account = await get_account(user_id=1)
-    assert account == AccountSnapshot(
-        name="alice", balance=120_000, total_earned=120_000, total_spent=0
-    )
-
-
-async def test_settle_blackjack_player_five_card_vip_keeps_system_bonus_out_of_house() -> None:
-    """VIP still boosts the regular win, while five-card bonus stays system-funded."""
-    await _add_balance(user_id=1, name="alice", amount=VIP_PURCHASE_COST + 100_000)
-    purchase = await buy_vip(user_id=1, name="alice")
-    assert purchase is not None
-    round_state = BlackjackRound.from_participants(
-        rng=SystemRandom(), participants=[_participant(bet=10_000, balance_at_start=100_000)]
+        rng=SystemRandom(), participants=[_participant(bet=bet, balance_at_start=starting)]
     )
     hand = round_state.players[0].hands[0]
     hand.cards = [
@@ -2102,100 +2042,38 @@ async def test_settle_blackjack_player_five_card_vip_keeps_system_bonus_out_of_h
         Card(rank="3", suit="♥"),
         Card(rank="4", suit="♣"),
         Card(rank="5", suit="♦"),
-        Card(rank="7", suit="♠"),
+        Card(rank=last_card, suit="♠"),
     ]
     hand.finished = True
-    round_state.dealer = [Card(rank="10", suit="♣"), Card(rank="9", suit="♦")]
+    round_state.dealer = [Card(rank=rank, suit=suit) for rank, suit in dealer]
     round_state.finished = True
     round_state.phase = "settled"
 
     settlement = await _settle_player(round_state=round_state)
 
-    assert settlement.base_delta == 10_000
-    assert settlement.vip_bonus == 2_000
-    assert settlement.five_card_bonus == 10_000
-    assert settlement.delta == 22_000
-    assert settlement.new_balance == 122_000
-    assert settlement.casino_balance == -12_000
-    _ledger = await get_casino_ledger()
-    assert _ledger.balance == -12_000
-    loss, win, net, _day_started_at = await _daily_casino_stats(user_id=1)
-    assert (loss, win, net) == (0, 22_000, 22_000)
+    is_21 = last_card == "7"
+    five_card_bonus = bet if is_21 else 0
+    # A five-card non-21 hand always wins; a five-card 21 pushes only against a dealer 21.
+    base_delta = 0 if (is_21 and dealer_21) else bet
+    # VIP perk is max(0.2x dealer-paid win, 0.2x five-card bonus); only the dealer-win share is
+    # charged to the house, the rest is system funded along with the five-card bonus itself.
+    house_vip = (base_delta * 20 // 100) if is_vip else 0
+    vip_bonus = max(base_delta * 20 // 100, five_card_bonus * 20 // 100) if is_vip else 0
+    delta = base_delta + vip_bonus + five_card_bonus
+    casino_balance = -(base_delta + house_vip)
 
-
-async def test_settle_blackjack_player_five_card_push_still_pays_bonus() -> None:
-    """Dealer 21 pushes the main hand, but the five-card bonus still pays."""
-    await _add_balance(user_id=1, name="alice", amount=100_000)
-    round_state = BlackjackRound.from_participants(
-        rng=SystemRandom(), participants=[_participant(bet=10_000, balance_at_start=100_000)]
-    )
-    hand = round_state.players[0].hands[0]
-    hand.cards = [
-        Card(rank="2", suit="♠"),
-        Card(rank="3", suit="♥"),
-        Card(rank="4", suit="♣"),
-        Card(rank="5", suit="♦"),
-        Card(rank="7", suit="♠"),
-    ]
-    hand.finished = True
-    round_state.dealer = [
-        Card(rank="7", suit="♣"),
-        Card(rank="7", suit="♦"),
-        Card(rank="7", suit="♥"),
-    ]
-    round_state.finished = True
-    round_state.phase = "settled"
-
-    settlement = await _settle_player(round_state=round_state)
-
-    assert settlement.base_delta == 0
-    assert settlement.five_card_bonus == 10_000
-    assert settlement.delta == 10_000
-    assert settlement.new_balance == 110_000
-    assert settlement.casino_balance == 0
-    _ledger = await get_casino_ledger()
-    assert _ledger.balance == 0
-    loss, win, net, _day_started_at = await _daily_casino_stats(user_id=1)
-    assert (loss, win, net) == (0, 10_000, 10_000)
-
-
-async def test_settle_blackjack_player_five_card_push_pays_vip_bonus_without_house() -> None:
-    """VIP gets its five-card bonus even when the dealer also has 21."""
-    await _add_balance(user_id=1, name="alice", amount=VIP_PURCHASE_COST + 100_000)
-    purchase = await buy_vip(user_id=1, name="alice")
-    assert purchase is not None
-    round_state = BlackjackRound.from_participants(
-        rng=SystemRandom(), participants=[_participant(bet=10_000, balance_at_start=100_000)]
-    )
-    hand = round_state.players[0].hands[0]
-    hand.cards = [
-        Card(rank="2", suit="♠"),
-        Card(rank="3", suit="♥"),
-        Card(rank="4", suit="♣"),
-        Card(rank="5", suit="♦"),
-        Card(rank="7", suit="♠"),
-    ]
-    hand.finished = True
-    round_state.dealer = [
-        Card(rank="7", suit="♣"),
-        Card(rank="7", suit="♦"),
-        Card(rank="7", suit="♥"),
-    ]
-    round_state.finished = True
-    round_state.phase = "settled"
-
-    settlement = await _settle_player(round_state=round_state)
-
-    assert settlement.base_delta == 0
-    assert settlement.vip_bonus == 2_000
-    assert settlement.five_card_bonus == 10_000
-    assert settlement.delta == 12_000
-    assert settlement.new_balance == 112_000
-    assert settlement.casino_balance == 0
-    _ledger = await get_casino_ledger()
-    assert _ledger.balance == 0
-    loss, win, net, _day_started_at = await _daily_casino_stats(user_id=1)
-    assert (loss, win, net) == (0, 12_000, 12_000)
+    assert settlement.outcome == expect_outcome
+    assert settlement.hands[0].five_card_twenty_one is is_21
+    assert settlement.hands[0].five_card_bonus == five_card_bonus
+    assert settlement.base_delta == base_delta
+    assert settlement.five_card_bonus == five_card_bonus
+    assert settlement.vip_bonus == vip_bonus
+    assert settlement.delta == delta
+    assert settlement.new_balance == starting + delta
+    assert settlement.casino_balance == casino_balance
+    await assert_casino_ledger_consistent(expected_balance=casino_balance)
+    await assert_daily_casino_stats(user_id=1, loss=0, win=delta, net=delta)
+    await assert_wallet_consistent(user_id=1, expected_balance=starting + delta)
 
 
 async def test_blackjack_final_embed_shows_five_card_bonus_metadata() -> None:

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from io import BytesIO
+import json
 from types import SimpleNamespace
 import base64
 from typing import TYPE_CHECKING, Literal
@@ -29,6 +30,7 @@ from discordbot.cogs._gen_reply.prompts import MEMORY_SELECT_PROMPT
 from discordbot.cogs._gen_reply.streaming import DISCORD_MESSAGE_LIMIT, ResponseStreamer
 from discordbot.cogs._gen_reply.exceptions import extract_friendly_error
 from discordbot.cogs._gen_reply.memory_tool import (
+    NO_STORED_MEMORY,
     parse_user_id_list,
     resolve_user_memories,
     build_memory_allowlist,
@@ -36,6 +38,16 @@ from discordbot.cogs._gen_reply.memory_tool import (
     allowlist_ids_from_server_memory,
 )
 from discordbot.cogs._memory.server_prompts import SERVER_PHASE1_PROMPT, SERVER_PHASE2_PROMPT
+
+from tests.helpers.llm_input import (
+    request_index,
+    request_input,
+    tool_names_for_call,
+    has_memory_context_block,
+    extract_callable_user_ids,
+    extract_user_memory_blocks,
+    extract_server_memory_block,
+)
 
 TEST_LLM_MODEL = "test-llm-model"
 FAKE_MESSAGE_CREATED_AT = datetime(2026, 6, 10, 3, 4, 5, tzinfo=UTC)
@@ -1522,21 +1534,28 @@ async def test_handle_message_reply_selection_offers_tool_then_answers_with_buil
         cog.runtime_models.slow_model.name,
     ]
 
-    # Selection request offers only get_user_memory + a callable-users block.
-    select_tools = [tool.get("name") for tool in cog.client.responses.create_tools[0]]
-    assert select_tools == ["get_user_memory"]
-    select_block = str(cog.client.responses.create_inputs[0][-1])
-    assert "[id: 1]" in select_block
-    assert "Tester (tester)" in select_block
-    assert cog.client.responses.create_instructions[0] == MEMORY_SELECT_PROMPT
+    # Selection request offers only get_user_memory and lists the author as callable.
+    selection_idx = request_index(responses=cog.client.responses, phase="selection")
+    assert tool_names_for_call(responses=cog.client.responses, n=selection_idx) == [
+        "get_user_memory"
+    ]
+    assert extract_callable_user_ids(
+        request=request_input(responses=cog.client.responses, phase="selection")
+    ) == {1}
+    assert cog.client.responses.create_instructions[selection_idx] == MEMORY_SELECT_PROMPT
 
-    # Answer request keeps the built-in tools (no get_user_memory) and the clean persona.
-    answer_tools = [tool.get("name") for tool in cog.client.responses.create_tools[1]]
-    assert "get_user_memory" not in answer_tools
-    _assert_runtime_time_context(
-        instructions=cog.client.responses.create_instructions[1], system_prompt="SYS"
+    # Answer request keeps the built-in tools (no get_user_memory) and the clean persona: the
+    # author declined selection, so their stored memory is not injected.
+    answer_idx = request_index(responses=cog.client.responses, phase="answer")
+    assert "get_user_memory" not in tool_names_for_call(
+        responses=cog.client.responses, n=answer_idx
     )
-    assert "喜歡簡短回覆" not in str(cog.client.responses.create_inputs[1])
+    _assert_runtime_time_context(
+        instructions=cog.client.responses.create_instructions[answer_idx], system_prompt="SYS"
+    )
+    assert not has_memory_context_block(
+        request=request_input(responses=cog.client.responses, phase="answer")
+    )
 
     # Extraction still scheduled for the author with a memory-free, tool-free list.
     scheduled_list = scheduled[0]["message_list"]
@@ -1594,13 +1613,17 @@ async def test_handle_message_reply_without_stored_memory_keeps_instructions(
 
     # The selection phase still offers the tool even when nobody has stored memory; the
     # answer phase keeps the clean persona and the built-in tools.
-    assert "get_user_memory" in [tool.get("name") for tool in cog.client.responses.create_tools[0]]
-    _assert_runtime_time_context(
-        instructions=cog.client.responses.create_instructions[-1], system_prompt="SYS"
+    selection_idx = request_index(responses=cog.client.responses, phase="selection")
+    answer_idx = request_index(responses=cog.client.responses, phase="answer")
+    assert "get_user_memory" in tool_names_for_call(
+        responses=cog.client.responses, n=selection_idx
     )
-    assert "get_user_memory" not in [
-        tool.get("name") for tool in cog.client.responses.create_tools[-1]
-    ]
+    _assert_runtime_time_context(
+        instructions=cog.client.responses.create_instructions[answer_idx], system_prompt="SYS"
+    )
+    assert "get_user_memory" not in tool_names_for_call(
+        responses=cog.client.responses, n=answer_idx
+    )
     assert scheduled == [user_scope(user_id=1), server_scope(bot_id=999, server_id=1)]
 
 
@@ -1649,9 +1672,9 @@ async def test_handle_message_reply_memory_disabled_arg_skips_user_memory(
 
     # memory_enabled=False runs no selection phase: a single answer request, no tool, no memory.
     assert cog.client.responses.create_streams == [True]
-    assert "不該被注入" not in str(cog.client.responses.create_inputs[-1])
-    assert "get_user_memory" not in str(cog.client.responses.create_tools[-1])
-    assert "get_user_memory" not in str(cog.client.responses.create_inputs[-1])
+    answer = request_input(responses=cog.client.responses, phase="answer")
+    assert not has_memory_context_block(request=answer)
+    assert "get_user_memory" not in tool_names_for_call(responses=cog.client.responses, n=0)
     # The per-user update is skipped, but the server-scope update still runs in a public guild.
     assert scheduled == [server_scope(bot_id=999, server_id=1)]
 
@@ -1742,305 +1765,107 @@ def test_resolve_user_memories_enforces_allowlist(memory_isolated_dir: object) -
     assert by_id["2"].memory == "(no stored memory for this user)"
 
 
-async def test_handle_message_reply_injects_selected_memory_into_answer(
-    economy_isolated_db: None, memory_isolated_dir: object, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(
+    (
+        "seeded",
+        "server_nick",
+        "mention_ids",
+        "reference_author_id",
+        "channel_public",
+        "select_id_lists",
+        "expected_injected",
+        "callable_includes",
+        "callable_excludes",
+    ),
+    [
+        ({1: "喜歡被叫阿狗"}, None, [], None, True, [["1"]], {1}, {1}, set()),
+        ({}, None, [], None, True, [["1"]], set(), {1}, set()),
+        ({1: "機密"}, None, [], None, True, [], set(), {1}, set()),
+        ({42: "機密外人記憶"}, None, [], None, True, [["42"]], set(), {1}, {42}),
+        ({1: "甲記憶", 2: "乙記憶"}, None, [2], None, True, [["1"], ["2"]], {1, 2}, {1, 2}, set()),
+        (
+            {uid: f"記憶{uid}" for uid in range(1, 11)},
+            None,
+            list(range(2, 11)),
+            None,
+            True,
+            [[str(uid) for uid in range(1, 11)]],
+            set(range(1, 9)),
+            {1},
+            set(),
+        ),
+        ({}, None, [], 7, True, [], set(), {1, 7}, set()),
+        ({42: "李董的祕密"}, (42, "Boss", "李董"), [], None, True, [["42"]], {42}, {42}, set()),
+        ({42: "李董的祕密"}, (42, "Boss", "李董"), [], None, False, [["42"]], set(), {1}, {42}),
+    ],
+    ids=[
+        "inject-selected-memory",
+        "no-stored-memory",
+        "selection-declines",
+        "non-allowlisted-id-dropped",
+        "multiple-selection-calls",
+        "caps-injected-memories",
+        "reference-author-callable",
+        "nickname-table-widens-public",
+        "nickname-table-no-widen-private",
+    ],
+)
+async def test_handle_message_reply_user_memory_injection(  # noqa: PLR0913 -- parametrized columns
+    economy_isolated_db: None,
+    memory_isolated_dir: object,
+    monkeypatch: pytest.MonkeyPatch,
+    seeded: dict[int, str],
+    server_nick: tuple[int, str, str] | None,
+    mention_ids: list[int],
+    reference_author_id: int | None,
+    channel_public: bool,
+    select_id_lists: list[list[str]],
+    expected_injected: set[int],
+    callable_includes: set[int],
+    callable_excludes: set[int],
 ) -> None:
-    """Selection picks a user; the answer request gets that memory as context plus a 🧠 footer."""
+    """The answer gets exactly the allowlisted, selected memories; everything else is dropped.
+
+    One matrix over the user-memory boundary: a plain selection, an empty/declined selection, an
+    id outside the conversation, multiple calls, the per-reply cap, a reference author joining the
+    allowlist, and the public-only nickname-table widening. Injection is asserted by id
+    (extract_user_memory_blocks) and the allowlist by the ids offered to the selection model
+    (extract_callable_user_ids), never by a sentinel substring over a serialized blob.
+    """
     del economy_isolated_db, memory_isolated_dir
     cog = _cog()
-    write_main_memory(
-        scope=user_scope(user_id=1),
-        content="v1\n\n## 使用者輪廓\n喜歡被叫阿狗",
-        identity="Tester (tester) [id: 1]",
-    )
-
-    captured: list[object] = []
-
-    def fake_schedule(**kwargs: object) -> None:
-        """Captures the finalized reply handed to extraction."""
-        captured.append(kwargs["full_reply"])
-
-    monkeypatch.setattr("discordbot.cogs.gen_reply.schedule_memory_update", fake_schedule)
-
-    cog.client.responses.select_queue = [
-        [_function_call_item(call_id="cid-1", arguments='{"user_id_list": ["1"]}')]
-    ]
-    cog.client.responses.stream_queue = [
-        [_text_event(delta="嗨 阿狗"), _completed_event(input_tokens=5, output_tokens=6)]
-    ]
-
-    message = FakeMessage(content="<@999> 我是誰", author=FakeAuthor(user_id=1))
-    await _reply_via_pipeline(cog=cog, message=message)
-
-    # Selection (non-streaming) then the answer (streaming).
-    assert cog.client.responses.create_streams == [False, True]
-
-    # The selected memory rides as a low-authority assistant note placed BEFORE the current
-    # user message, which stays last so the model answers it rather than the note.
-    answer_input = cog.client.responses.create_inputs[1]
-    assert answer_input[-1].get("role") == "user"
-    assert any(
-        isinstance(m, dict) and m.get("role") == "assistant" and "喜歡被叫阿狗" in str(m)
-        for m in answer_input[:-1]
-    )
-    assert "function_call_output" not in str(answer_input)
-    assert "get_user_memory" not in [
-        tool.get("name") for tool in cog.client.responses.create_tools[1]
-    ]
-
-    # The visible reply is the answer text, the answer-turn usage footer, and a 🧠 line.
-    content = message.replies[0].content or ""
-    assert content.startswith("嗨 阿狗")
-    assert "⬆ 5 ⬇ 6" in content
-    assert "\n-# 🧠 已讀取 Tester (tester) 的記憶" in content
-    assert captured[0].startswith("嗨 阿狗")
-
-
-async def test_handle_message_reply_footer_includes_selection_usage(
-    economy_isolated_db: None, memory_isolated_dir: object, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The footer token counts include the selection request, not just the answer stream."""
-    del economy_isolated_db, memory_isolated_dir
-    cog = _cog()
-    write_main_memory(
-        scope=user_scope(user_id=1),
-        content="v1\n\n## 使用者輪廓\n甲",
-        identity="Tester (tester) [id: 1]",
-    )
-
-    monkeypatch.setattr("discordbot.cogs.gen_reply.schedule_memory_update", lambda **kwargs: None)
-
-    cog.client.responses.select_queue = [
-        [_function_call_item(call_id="cid-1", arguments='{"user_id_list": ["1"]}')]
-    ]
-    cog.client.responses.select_usage = SimpleNamespace(input_tokens=100, output_tokens=20)
-    cog.client.responses.stream_queue = [
-        [_text_event(delta="好"), _completed_event(input_tokens=5, output_tokens=6)]
-    ]
-
-    message = FakeMessage(content="<@999> hi", author=FakeAuthor(user_id=1))
-    await _reply_via_pipeline(cog=cog, message=message)
-
-    # 100+5 input, 20+6 output summed across the selection and answer requests.
-    assert "⬆ 105 ⬇ 26" in (message.replies[0].content or "")
-
-
-async def test_handle_message_reply_footer_omits_users_without_memory(
-    economy_isolated_db: None, memory_isolated_dir: object, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A selection that finds no stored memory injects nothing and leaves the 🧠 line off."""
-    del economy_isolated_db, memory_isolated_dir
-    cog = _cog()  # No memory written for the author.
-
-    monkeypatch.setattr("discordbot.cogs.gen_reply.schedule_memory_update", lambda **kwargs: None)
-
-    cog.client.responses.select_queue = [
-        [_function_call_item(call_id="cid-1", arguments='{"user_id_list": ["1"]}')]
-    ]
-    cog.client.responses.stream_queue = [
-        [_text_event(delta="你好"), _completed_event(input_tokens=5, output_tokens=6)]
-    ]
-
-    message = FakeMessage(content="<@999> hi", author=FakeAuthor(user_id=1))
-    await _reply_via_pipeline(cog=cog, message=message)
-
-    # Selection ran but the user has no memory, so nothing is injected and no 🧠 line appears.
-    assert cog.client.responses.create_streams == [False, True]
-    assert "🧠" not in (message.replies[0].content or "")
-
-
-async def test_handle_message_reply_skips_memory_when_model_declines(
-    economy_isolated_db: None, memory_isolated_dir: object, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """When selection returns no call, no memory is injected and no 🧠 line is added."""
-    del economy_isolated_db, memory_isolated_dir
-    cog = _cog()
-    write_main_memory(
-        scope=user_scope(user_id=1),
-        content="v1\n\n## 使用者輪廓\n機密",
-        identity="Tester (tester) [id: 1]",
-    )
-
-    monkeypatch.setattr("discordbot.cogs.gen_reply.schedule_memory_update", lambda **kwargs: None)
-
-    # select_queue left empty: the selection model declines to call the tool.
-    cog.client.responses.stream_queue = [
-        [_text_event(delta="直接回答"), _completed_event(input_tokens=3, output_tokens=4)]
-    ]
-
-    message = FakeMessage(content="<@999> hi", author=FakeAuthor(user_id=1))
-    await _reply_via_pipeline(cog=cog, message=message)
-
-    assert cog.client.responses.create_streams == [False, True]
-    assert "機密" not in str(cog.client.responses.create_inputs)
-    assert "🧠" not in (message.replies[0].content or "")
-    assert (message.replies[0].content or "").startswith("直接回答")
-
-
-async def test_handle_message_reply_drops_memory_for_non_allowlisted_id(
-    economy_isolated_db: None, memory_isolated_dir: object, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The model asking for an id absent from the conversation gets no memory injected."""
-    del economy_isolated_db, memory_isolated_dir
-    cog = _cog()
-    # Memory exists for user 42, who never appears in the conversation.
-    write_main_memory(
-        scope=user_scope(user_id=42),
-        content="v1\n\n## 使用者輪廓\n機密外人記憶",
-        identity="Outsider (out) [id: 42]",
-    )
-
-    monkeypatch.setattr("discordbot.cogs.gen_reply.schedule_memory_update", lambda **kwargs: None)
-
-    cog.client.responses.select_queue = [
-        [_function_call_item(call_id="cid-1", arguments='{"user_id_list": ["42"]}')]
-    ]
-    cog.client.responses.stream_queue = [
-        [_text_event(delta="回覆"), _completed_event(input_tokens=5, output_tokens=6)]
-    ]
-
-    message = FakeMessage(content="<@999> 查 42 的記憶", author=FakeAuthor(user_id=1))
-    await _reply_via_pipeline(cog=cog, message=message)
-
-    # The allowlist (author 1 only) drops id 42: nothing injected, no leak, no 🧠 line.
-    assert "機密外人記憶" not in str(cog.client.responses.create_inputs)
-    assert "🧠" not in (message.replies[0].content or "")
-
-
-async def test_handle_message_reply_footer_lists_memory_owners_in_order(
-    economy_isolated_db: None, memory_isolated_dir: object, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Selected owners render in lookup order and collapse to 等 N 人 past two."""
-    del economy_isolated_db, memory_isolated_dir
-    cog = _cog()
-    for uid, ident in (
-        (1, "Tester (tester) [id: 1]"),
-        (2, "Alice (alice) [id: 2]"),
-        (3, "Bob (bob) [id: 3]"),
-    ):
-        write_main_memory(
-            scope=user_scope(user_id=uid), content=f"v1\n\n## 使用者輪廓\n{uid}", identity=ident
-        )
-
-    monkeypatch.setattr("discordbot.cogs.gen_reply.schedule_memory_update", lambda **kwargs: None)
-
-    alice = FakeAuthor(user_id=2)
-    alice.name, alice.display_name = "alice", "Alice"
-    bob = FakeAuthor(user_id=3)
-    bob.name, bob.display_name = "bob", "Bob"
-    message = FakeMessage(content="<@999> 大家的記憶", author=FakeAuthor(user_id=1))
-    message.mentions = [alice, bob]
-
-    cog.client.responses.select_queue = [
-        [_function_call_item(call_id="c", arguments='{"user_id_list": ["1", "2", "3"]}')]
-    ]
-    cog.client.responses.stream_queue = [
-        [_text_event(delta="好"), _completed_event(input_tokens=1, output_tokens=1)]
-    ]
-
-    await _reply_via_pipeline(cog=cog, message=message)
-
-    content = message.replies[0].content or ""
-    assert "\n-# 🧠 已讀取 Tester (tester), Alice (alice) 等 3 人的記憶" in content
-
-
-async def test_handle_message_reply_footer_dedupes_repeat_lookups(
-    economy_isolated_db: None, memory_isolated_dir: object, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Selecting the same user across multiple calls credits them once in the footer."""
-    del economy_isolated_db, memory_isolated_dir
-    cog = _cog()
-    write_main_memory(
-        scope=user_scope(user_id=1),
-        content="v1\n\n## 使用者輪廓\n甲",
-        identity="Tester (tester) [id: 1]",
-    )
-
-    monkeypatch.setattr("discordbot.cogs.gen_reply.schedule_memory_update", lambda **kwargs: None)
-
-    cog.client.responses.select_queue = [
-        [
-            _function_call_item(call_id="c1", arguments='{"user_id_list": ["1"]}'),
-            _function_call_item(call_id="c2", arguments='{"user_id_list": ["1"]}'),
-        ]
-    ]
-    cog.client.responses.stream_queue = [
-        [_text_event(delta="好"), _completed_event(input_tokens=1, output_tokens=1)]
-    ]
-
-    message = FakeMessage(content="<@999> hi", author=FakeAuthor(user_id=1))
-    await _reply_via_pipeline(cog=cog, message=message)
-
-    content = message.replies[0].content or ""
-    assert "\n-# 🧠 已讀取 Tester (tester) 的記憶" in content
-    assert content.count("Tester (tester)") == 1
-
-
-async def test_handle_message_reply_resolves_multiple_selection_calls(
-    economy_isolated_db: None, memory_isolated_dir: object, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Two get_user_memory calls in the selection phase each inject their resolved memory."""
-    del economy_isolated_db, memory_isolated_dir
-    cog = _cog()
-    write_main_memory(
-        scope=user_scope(user_id=1),
-        content="v1\n\n## 使用者輪廓\n甲記憶",
-        identity="Tester (tester) [id: 1]",
-    )
-    write_main_memory(
-        scope=user_scope(user_id=2),
-        content="v1\n\n## 使用者輪廓\n乙記憶",
-        identity="Alice (alice) [id: 2]",
-    )
-
-    monkeypatch.setattr("discordbot.cogs.gen_reply.schedule_memory_update", lambda **kwargs: None)
-
-    alice = FakeAuthor(user_id=2)
-    alice.name, alice.display_name = "alice", "Alice"
-    message = FakeMessage(content="<@999> 兩個人", author=FakeAuthor(user_id=1))
-    message.mentions = [alice]
-
-    cog.client.responses.select_queue = [
-        [
-            _function_call_item(call_id="cid-1", arguments='{"user_id_list": ["1"]}'),
-            _function_call_item(call_id="cid-2", arguments='{"user_id_list": ["2"]}'),
-        ]
-    ]
-    cog.client.responses.stream_queue = [
-        [_text_event(delta="好"), _completed_event(input_tokens=1, output_tokens=1)]
-    ]
-
-    await _reply_via_pipeline(cog=cog, message=message)
-
-    answer_input = str(cog.client.responses.create_inputs[1])
-    assert "甲記憶" in answer_input
-    assert "乙記憶" in answer_input
-
-
-async def test_handle_message_reply_caps_injected_memories(
-    economy_isolated_db: None, memory_isolated_dir: object, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """More selected users than the per-reply cap inject only the first few, in order."""
-    del economy_isolated_db, memory_isolated_dir
-    cog = _cog()
-    for uid in range(1, 11):
+    for uid, body in seeded.items():
         write_main_memory(
             scope=user_scope(user_id=uid),
-            content=f"v1\n\n## 使用者輪廓\n記憶內容{uid}",
+            content=f"v1\n\n## 使用者輪廓\n{body}",
             identity=f"U{uid} (u{uid}) [id: {uid}]",
         )
-
+    if server_nick is not None:
+        nick_id, nick_name, nick_alias = server_nick
+        write_main_memory(
+            scope=server_scope(bot_id=999, server_id=1),
+            content=f"v1\n\n## 成員稱呼\n* {nick_name}(社群暱稱:{nick_alias})[id: {nick_id}]",
+            identity="Test Guild [id: 1]",
+        )
     monkeypatch.setattr("discordbot.cogs.gen_reply.schedule_memory_update", lambda **kwargs: None)
+    if reference_author_id is not None:
+        monkeypatch.setattr("discordbot.cogs.gen_reply.Message", FakeMessage)
 
-    message = FakeMessage(content="<@999> 大家", author=FakeAuthor(user_id=1))
-    message.mentions = [FakeAuthor(user_id=uid) for uid in range(2, 11)]
+    message = FakeMessage(
+        content="<@999> hi", author=FakeAuthor(user_id=1), channel_public=channel_public
+    )
+    message.mentions = [FakeAuthor(user_id=uid) for uid in mention_ids]
+    if reference_author_id is not None:
+        parent_author = FakeAuthor(user_id=reference_author_id)
+        parent_author.name, parent_author.display_name = "parent", "Parent"
+        parent = FakeMessage(content="原訊息", author=parent_author)
+        parent.id = 988
+        message.reference = FakeReference(resolved=parent)
 
     cog.client.responses.select_queue = [
         [
-            _function_call_item(
-                call_id="c",
-                arguments='{"user_id_list": ["1","2","3","4","5","6","7","8","9","10"]}',
-            )
+            _function_call_item(call_id=f"c{index}", arguments=json.dumps({"user_id_list": ids}))
+            for index, ids in enumerate(select_id_lists)
         ]
     ]
     cog.client.responses.stream_queue = [
@@ -2049,37 +1874,147 @@ async def test_handle_message_reply_caps_injected_memories(
 
     await _reply_via_pipeline(cog=cog, message=message)
 
-    answer_input = str(cog.client.responses.create_inputs[1])
-    # First 8 (in selection order) are injected; the 9th and 10th are dropped.
-    assert "記憶內容8" in answer_input
-    assert "記憶內容9" not in answer_input
-    assert "記憶內容10" not in answer_input
+    answer = request_input(responses=cog.client.responses, phase="answer")
+    # An allowlisted-but-memoryless user gets a placeholder block, not a leak; the boundary is
+    # which ids' real memory reaches the model, so placeholder sections are filtered out.
+    injected = {
+        uid
+        for uid, body in extract_user_memory_blocks(request=answer).items()
+        if body != NO_STORED_MEMORY
+    }
+    assert injected == expected_injected
+    # The current user message stays last so the model answers it, and no internal selection
+    # artifact (a function_call_output) ever leaks into the answer request.
+    assert isinstance(answer, list)
+    assert answer[-1].get("role") == "user"
+    assert not any(
+        isinstance(item, dict) and item.get("type") == "function_call_output" for item in answer
+    )
+
+    callable_ids = extract_callable_user_ids(
+        request=request_input(responses=cog.client.responses, phase="selection")
+    )
+    assert callable_includes <= callable_ids
+    assert callable_excludes.isdisjoint(callable_ids)
 
 
-async def test_handle_message_reply_allowlist_includes_reference_author(
-    economy_isolated_db: None, memory_isolated_dir: object, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(
+    (
+        "seeded_ids",
+        "mentions",
+        "select_id_lists",
+        "select_usage",
+        "stream_usage",
+        "present",
+        "absent",
+        "credited_once",
+    ),
+    [
+        (
+            [1],
+            [],
+            [["1"]],
+            None,
+            (5, 6),
+            ["⬆ 5 ⬇ 6", "\n-# 🧠 已讀取 Tester (tester) 的記憶"],
+            [],
+            None,
+        ),
+        ([1], [], [["1"]], (100, 20), (5, 6), ["⬆ 105 ⬇ 26"], [], None),
+        (
+            [1, 2, 3],
+            [(2, "alice", "Alice"), (3, "bob", "Bob")],
+            [["1", "2", "3"]],
+            None,
+            (1, 1),
+            ["\n-# 🧠 已讀取 Tester (tester), Alice (alice) 等 3 人的記憶"],
+            [],
+            None,
+        ),
+        (
+            [1],
+            [],
+            [["1"], ["1"]],
+            None,
+            (1, 1),
+            ["\n-# 🧠 已讀取 Tester (tester) 的記憶"],
+            [],
+            "Tester (tester)",
+        ),
+        ([], [], [["1"]], None, (5, 6), [], ["🧠"], None),
+    ],
+    ids=[
+        "single-owner-credit",
+        "selection-usage-folded-in",
+        "owners-collapse-past-two",
+        "repeat-lookups-credited-once",
+        "no-memory-no-credit",
+    ],
+)
+async def test_handle_message_reply_memory_footer(  # noqa: PLR0913 -- parametrized columns
+    economy_isolated_db: None,
+    memory_isolated_dir: object,
+    monkeypatch: pytest.MonkeyPatch,
+    seeded_ids: list[int],
+    mentions: list[tuple[int, str, str]],
+    select_id_lists: list[list[str]],
+    select_usage: tuple[int, int] | None,
+    stream_usage: tuple[int, int],
+    present: list[str],
+    absent: list[str],
+    credited_once: str | None,
 ) -> None:
-    """A referenced message's author becomes callable in the selection request."""
+    """The footer credits the memory owners actually read and folds selection tokens into usage.
+
+    Reads the user-visible reply text (the feature's small, real output surface): the single-owner
+    credit, the selection-request token contribution, the collapse to "等 N 人" past two owners,
+    repeat-lookup de-duplication, and the no-credit case.
+    """
     del economy_isolated_db, memory_isolated_dir
     cog = _cog()
-
+    labels = {1: "Tester (tester)", 2: "Alice (alice)", 3: "Bob (bob)"}
+    for uid in seeded_ids:
+        write_main_memory(
+            scope=user_scope(user_id=uid),
+            content=f"v1\n\n## 使用者輪廓\n記憶{uid}",
+            identity=f"{labels[uid]} [id: {uid}]",
+        )
     monkeypatch.setattr("discordbot.cogs.gen_reply.schedule_memory_update", lambda **kwargs: None)
-    monkeypatch.setattr("discordbot.cogs.gen_reply.Message", FakeMessage)
 
-    parent_author = FakeAuthor(user_id=7)
-    parent_author.name, parent_author.display_name = "parent", "Parent"
-    parent = FakeMessage(content="原訊息", author=parent_author)
-    parent.id = 988
+    message = FakeMessage(content="<@999> hi", author=FakeAuthor(user_id=1))
+    mention_authors: list[FakeAuthor] = []
+    for uid, name, display in mentions:
+        author = FakeAuthor(user_id=uid)
+        author.name, author.display_name = name, display
+        mention_authors.append(author)
+    message.mentions = mention_authors
 
-    message = FakeMessage(content="<@999> 回覆他", author=FakeAuthor(user_id=1))
-    message.reference = FakeReference(resolved=parent)
+    if select_usage is not None:
+        cog.client.responses.select_usage = SimpleNamespace(
+            input_tokens=select_usage[0], output_tokens=select_usage[1]
+        )
+    cog.client.responses.select_queue = [
+        [
+            _function_call_item(call_id=f"c{index}", arguments=json.dumps({"user_id_list": ids}))
+            for index, ids in enumerate(select_id_lists)
+        ]
+    ]
+    cog.client.responses.stream_queue = [
+        [
+            _text_event(delta="好"),
+            _completed_event(input_tokens=stream_usage[0], output_tokens=stream_usage[1]),
+        ]
+    ]
 
     await _reply_via_pipeline(cog=cog, message=message)
 
-    # The selection request (first create) lists the reference author (7) as callable.
-    select_input = str(cog.client.responses.create_inputs[0])
-    assert "[id: 7] Parent (parent)" in select_input
-    assert "[id: 1] Tester (tester)" in select_input
+    content = message.replies[0].content or ""
+    for fragment in present:
+        assert fragment in content
+    for fragment in absent:
+        assert fragment not in content
+    if credited_once is not None:
+        assert content.count(credited_once) == 1
 
 
 async def test_handle_message_reply_continues_when_selection_fails(
@@ -2127,35 +2062,47 @@ def test_usage_footer_re_strips_memory_credit_second_line() -> None:
     assert USAGE_FOOTER_RE.sub("", f"{body}{single}") == body
 
 
-class _ServerMemoryResponder:
-    """Answer-phase streamer stub that returns a fixed reply."""
-
-    def __init__(
-        self,
-        message: FakeMessage,
-        memory_lookups: list[str] | None = None,
-        input_tokens: int = 0,
-        output_tokens: int = 0,
-        model_effort: str = "",
-    ) -> None:
-        """Stores the streaming target message and ignores usage seeds."""
-        del memory_lookups, input_tokens, output_tokens, model_effort
-        self.message = message
-
-    async def stream(self, *, responses: object) -> str:
-        """Returns placeholder reply content."""
-        del responses
-        return "回覆"
-
-
-async def test_handle_message_reply_injects_and_schedules_server_memory(
-    memory_isolated_dir: object, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(
+    ("memory_enabled", "has_guild", "channel_public", "expect_server_read", "expect_scopes"),
+    [
+        (True, True, True, True, ["user", "server"]),
+        (True, True, False, True, ["user"]),
+        (True, False, True, False, ["user"]),
+        (False, True, True, False, ["server"]),
+        (False, False, True, False, []),
+        (False, True, False, False, []),
+    ],
+    ids=[
+        "qa-guild-public",
+        "qa-guild-private",
+        "qa-dm",
+        "summary-guild-public",
+        "summary-dm",
+        "summary-guild-private",
+    ],
+)
+async def test_handle_message_reply_server_memory_gating(  # noqa: PLR0913 -- parametrized columns
+    economy_isolated_db: None,
+    memory_isolated_dir: object,
+    monkeypatch: pytest.MonkeyPatch,
+    memory_enabled: bool,
+    has_guild: bool,
+    channel_public: bool,
+    expect_server_read: bool,
+    expect_scopes: list[str],
 ) -> None:
-    """In a guild the bot injects the server's memory and schedules a server-scope update."""
+    """Server memory is read on a guild QA turn and written only from a public guild channel.
+
+    One matrix over (route, guild/DM, public/private): the read block rides the answer (and the
+    selection request) only on a memory-enabled guild turn; the per-user write follows
+    memory_enabled; the per-server write needs a public guild channel. Read is asserted
+    structurally via extract_server_memory_block, writes via the scheduled scopes.
+    """
+    del economy_isolated_db, memory_isolated_dir
     cog = _cog()
     write_main_memory(
         scope=server_scope(bot_id=999, server_id=1),
-        content="v1\n\n## 伺服器輪廓\n這個社群很愛嘴",
+        content="v1\n\n## 伺服器輪廓\n社群風格",
         identity="Test Guild [id: 1]",
     )
     scheduled: list[dict[str, object]] = []
@@ -2164,139 +2111,40 @@ async def test_handle_message_reply_injects_and_schedules_server_memory(
         """Records each scheduled memory update."""
         scheduled.append(kwargs)
 
-    monkeypatch.setattr("discordbot.cogs.gen_reply.ResponseStreamer", _ServerMemoryResponder)
-    monkeypatch.setattr("discordbot.cogs.gen_reply.schedule_memory_update", fake_schedule)
-
-    message = FakeMessage(content="<@999> hi", author=FakeAuthor(user_id=1))
-    await _reply_via_pipeline(cog=cog, message=message)
-
-    # The server memory rides into the answer request as background context.
-    assert "這個社群很愛嘴" in str(cog.client.responses.create_inputs[-1])
-    # The user update is scheduled first, the server update second.
-    assert len(scheduled) == 2
-    user_update, server_update = scheduled
-    assert user_update["scope"] == user_scope(user_id=1)
-    assert server_update["scope"] == server_scope(bot_id=999, server_id=1)
-    assert server_update["subject"] == "target_server_id: 1"
-    assert server_update["extractor"] is cog.server_memory_extractor
-    assert server_update["identity"] == "Test Guild [id: 1]"
-    # The server extractor drives the server-flavor prompts.
-    assert cog.server_memory_extractor.phase1_prompt is SERVER_PHASE1_PROMPT
-    assert cog.server_memory_extractor.consolidate_prompt is SERVER_PHASE2_PROMPT
-
-
-async def test_handle_message_reply_skips_server_memory_in_dm(
-    memory_isolated_dir: object, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A DM has no guild, so server memory is neither injected nor scheduled."""
-    cog = _cog()
-    write_main_memory(
-        scope=server_scope(bot_id=999, server_id=1),
-        content="v1\n\n## 伺服器輪廓\n不該出現",
-        identity="Test Guild [id: 1]",
-    )
-    scheduled: list[object] = []
-
-    def fake_schedule(**kwargs: object) -> None:
-        """Records each scheduled scope."""
-        scheduled.append(kwargs["scope"])
-
-    monkeypatch.setattr("discordbot.cogs.gen_reply.ResponseStreamer", _ServerMemoryResponder)
-    monkeypatch.setattr("discordbot.cogs.gen_reply.schedule_memory_update", fake_schedule)
-
-    message = FakeMessage(content="<@999> hi", author=FakeAuthor(user_id=1))
-    message.guild = None
-    await _reply_via_pipeline(cog=cog, message=message)
-
-    assert "不該出現" not in str(cog.client.responses.create_inputs[-1])
-    assert scheduled == [user_scope(user_id=1)]
-
-
-async def test_handle_message_reply_skips_server_write_in_private_channel(
-    memory_isolated_dir: object, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A channel @everyone cannot see never feeds the server-wide memory."""
-    cog = _cog()
-    scheduled: list[object] = []
-
-    def fake_schedule(**kwargs: object) -> None:
-        """Records each scheduled scope."""
-        scheduled.append(kwargs["scope"])
-
-    monkeypatch.setattr("discordbot.cogs.gen_reply.ResponseStreamer", _ServerMemoryResponder)
-    monkeypatch.setattr("discordbot.cogs.gen_reply.schedule_memory_update", fake_schedule)
-
-    message = FakeMessage(content="<@999> hi", author=FakeAuthor(user_id=1), channel_public=False)
-    await _reply_via_pipeline(cog=cog, message=message)
-
-    # Private channel: the per-user update still runs, but no server-scope update.
-    assert scheduled == [user_scope(user_id=1)]
-
-
-async def test_handle_message_reply_records_server_memory_on_summary_route(
-    memory_isolated_dir: object, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The SUMMARY route (memory_enabled=False) records server memory but not user memory."""
-    cog = _cog()
-    scheduled: list[dict[str, object]] = []
-
-    def fake_schedule(**kwargs: object) -> None:
-        """Records each scheduled memory update."""
-        scheduled.append(kwargs)
-
-    monkeypatch.setattr("discordbot.cogs.gen_reply.ResponseStreamer", _ServerMemoryResponder)
-    monkeypatch.setattr("discordbot.cogs.gen_reply.schedule_memory_update", fake_schedule)
-
-    message = FakeMessage(content="<@999> 總結", author=FakeAuthor(user_id=1))
-    await _reply_via_pipeline(cog=cog, message=message, memory_enabled=False)
-
-    # Only the server-scope update is scheduled; the per-user one is skipped.
-    assert [update["scope"] for update in scheduled] == [server_scope(bot_id=999, server_id=1)]
-    assert scheduled[0]["subject"] == "target_server_id: 1"
-    assert scheduled[0]["extractor"] is cog.server_memory_extractor
-
-
-async def test_handle_message_reply_summary_in_dm_records_nothing(
-    memory_isolated_dir: object, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A SUMMARY in a DM has no guild, so neither user nor server memory is recorded."""
-    cog = _cog()
-    scheduled: list[object] = []
-
-    def fake_schedule(**kwargs: object) -> None:
-        """Records each scheduled scope."""
-        scheduled.append(kwargs["scope"])
-
-    monkeypatch.setattr("discordbot.cogs.gen_reply.ResponseStreamer", _ServerMemoryResponder)
-    monkeypatch.setattr("discordbot.cogs.gen_reply.schedule_memory_update", fake_schedule)
-
-    message = FakeMessage(content="<@999> 總結", author=FakeAuthor(user_id=1))
-    message.guild = None
-    await _reply_via_pipeline(cog=cog, message=message, memory_enabled=False)
-
-    assert scheduled == []
-
-
-async def test_handle_message_reply_summary_in_private_channel_records_nothing(
-    memory_isolated_dir: object, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A SUMMARY in a non-public channel never feeds the server-wide memory."""
-    cog = _cog()
-    scheduled: list[object] = []
-
-    def fake_schedule(**kwargs: object) -> None:
-        """Records each scheduled scope."""
-        scheduled.append(kwargs["scope"])
-
-    monkeypatch.setattr("discordbot.cogs.gen_reply.ResponseStreamer", _ServerMemoryResponder)
     monkeypatch.setattr("discordbot.cogs.gen_reply.schedule_memory_update", fake_schedule)
 
     message = FakeMessage(
-        content="<@999> 總結", author=FakeAuthor(user_id=1), channel_public=False
+        content="<@999> hi", author=FakeAuthor(user_id=1), channel_public=channel_public
     )
-    await _reply_via_pipeline(cog=cog, message=message, memory_enabled=False)
+    if not has_guild:
+        message.guild = None
+    cog.client.responses.stream_queue = [
+        [_text_event(delta="好"), _completed_event(input_tokens=1, output_tokens=1)]
+    ]
 
-    assert scheduled == []
+    await _reply_via_pipeline(cog=cog, message=message, memory_enabled=memory_enabled)
+
+    answer = request_input(responses=cog.client.responses, phase="answer")
+    assert (extract_server_memory_block(request=answer) is not None) == expect_server_read
+
+    server_scope_value = server_scope(bot_id=999, server_id=1)
+    name_to_scope = {"user": user_scope(user_id=1), "server": server_scope_value}
+    assert [update["scope"] for update in scheduled] == [
+        name_to_scope[name] for name in expect_scopes
+    ]
+    for update in scheduled:
+        if update["scope"] == server_scope_value:
+            assert update["subject"] == "target_server_id: 1"
+            assert update["extractor"] is cog.server_memory_extractor
+            assert update["identity"] == "Test Guild [id: 1]"
+            assert cog.server_memory_extractor.phase1_prompt is SERVER_PHASE1_PROMPT
+            assert cog.server_memory_extractor.consolidate_prompt is SERVER_PHASE2_PROMPT
+
+    # On a memory-enabled guild turn the selection request also sees the server memory so it can
+    # resolve nicknames; non-guild or SUMMARY turns run no selection phase.
+    if memory_enabled and has_guild:
+        selection = request_input(responses=cog.client.responses, phase="selection")
+        assert extract_server_memory_block(request=selection) is not None
 
 
 def test_allowlist_ids_from_server_memory_parses_nickname_table() -> None:
@@ -2352,100 +2200,6 @@ def test_widen_allowlist_with_aliases_skips_absent_when_not_public() -> None:
     assert "李董" in allowed[123]
     # The absent member is not added, so their personal memory stays unreachable here.
     assert 456 not in allowed
-
-
-async def test_handle_message_reply_injects_server_memory_into_selection(
-    memory_isolated_dir: object, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The selection phase sees the server memory so it can resolve nicknames to ids."""
-    cog = _cog()
-    write_main_memory(
-        scope=server_scope(bot_id=999, server_id=1),
-        content="v1\n\n## 伺服器輪廓\n選擇階段也要看到",
-        identity="Test Guild [id: 1]",
-    )
-    monkeypatch.setattr("discordbot.cogs.gen_reply.ResponseStreamer", _ServerMemoryResponder)
-    monkeypatch.setattr("discordbot.cogs.gen_reply.schedule_memory_update", lambda **kwargs: None)
-
-    message = FakeMessage(content="<@999> hi", author=FakeAuthor(user_id=1))
-    await _reply_via_pipeline(cog=cog, message=message)
-
-    # Selection input carries the server memory, with the callable-users block kept last.
-    selection_input = cog.client.responses.create_inputs[0]
-    assert "選擇階段也要看到" in str(selection_input)
-    assert "[id: 1]" in str(selection_input[-1])
-    assert "Tester (tester)" in str(selection_input[-1])
-
-
-async def test_handle_message_reply_widens_allowlist_with_nickname_table(
-    economy_isolated_db: None, memory_isolated_dir: object, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A member named only in the nickname table is askable by alias."""
-    del economy_isolated_db
-    cog = _cog()
-    # User 42 never speaks in the conversation, but the server nickname table names them.
-    write_main_memory(
-        scope=user_scope(user_id=42),
-        content="v1\n\n## 使用者輪廓\n李董的祕密",
-        identity="Boss (boss) [id: 42]",
-    )
-    write_main_memory(
-        scope=server_scope(bot_id=999, server_id=1),
-        content="v1\n\n## 成員稱呼\n* Boss(社群暱稱:李董)[id: 42]",
-        identity="Test Guild [id: 1]",
-    )
-    monkeypatch.setattr("discordbot.cogs.gen_reply.schedule_memory_update", lambda **kwargs: None)
-
-    cog.client.responses.select_queue = [
-        [_function_call_item(call_id="cid-1", arguments='{"user_id_list": ["42"]}')]
-    ]
-    cog.client.responses.stream_queue = [
-        [_text_event(delta="回覆"), _completed_event(input_tokens=5, output_tokens=6)]
-    ]
-
-    message = FakeMessage(content="<@999> 李董最近怎樣", author=FakeAuthor(user_id=1))
-    await _reply_via_pipeline(cog=cog, message=message)
-
-    # The nickname-table id widened the allowlist, so the outsider's memory is injected.
-    assert "李董的祕密" in str(cog.client.responses.create_inputs[-1])
-
-
-async def test_handle_message_reply_does_not_widen_absent_member_in_private_channel(
-    economy_isolated_db: None, memory_isolated_dir: object, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A private channel must not read an absent member's personal memory via the nickname table.
-
-    The nickname table is public content, but the personal memory it would unlock is not, so
-    the allowlist stays conversation-only here: even when the selection model requests the
-    absent id, `resolve_user_memories` drops it and the secret never reaches the answer.
-    """
-    del economy_isolated_db
-    cog = _cog()
-    write_main_memory(
-        scope=user_scope(user_id=42),
-        content="v1\n\n## 使用者輪廓\n李董的祕密",
-        identity="Boss (boss) [id: 42]",
-    )
-    write_main_memory(
-        scope=server_scope(bot_id=999, server_id=1),
-        content="v1\n\n## 成員稱呼\n* Boss(社群暱稱:李董)[id: 42]",
-        identity="Test Guild [id: 1]",
-    )
-    monkeypatch.setattr("discordbot.cogs.gen_reply.schedule_memory_update", lambda **kwargs: None)
-
-    cog.client.responses.select_queue = [
-        [_function_call_item(call_id="cid-1", arguments='{"user_id_list": ["42"]}')]
-    ]
-    cog.client.responses.stream_queue = [
-        [_text_event(delta="回覆"), _completed_event(input_tokens=5, output_tokens=6)]
-    ]
-
-    message = FakeMessage(
-        content="<@999> 李董最近怎樣", author=FakeAuthor(user_id=1), channel_public=False
-    )
-    await _reply_via_pipeline(cog=cog, message=message)
-
-    assert "李董的祕密" not in str(cog.client.responses.create_inputs[-1])
 
 
 async def test_streamer_reasoning_preview_then_content_overwrites() -> None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,203 @@
+"""Tests for the shared test helpers themselves.
+
+The redesigned suite leans on these extractors and invariant asserts, so they
+are pinned here against the real production renderers and database helpers.
+"""
+
+import pytest
+import nextcord
+
+from discordbot.cogs._economy.database import adjust_balance
+from discordbot.cogs._gen_reply.memory_tool import (
+    UserMemory,
+    render_server_memory_block,
+    render_callable_users_block,
+    render_memory_context_block,
+)
+
+from tests.helpers.embeds import assert_embed_has_field, assert_embed_title_prefix
+from tests.helpers.llm_input import (
+    request_index,
+    request_input,
+    iter_text_blocks,
+    tool_names_for_call,
+    has_memory_context_block,
+    extract_callable_user_ids,
+    extract_user_memory_blocks,
+    extract_server_memory_block,
+    extract_memory_context_block,
+)
+from tests.helpers.discord_mocks import FakeUser, FakeResponse, FakeInteraction
+from tests.helpers.economy_invariants import (
+    assert_wallet_consistent,
+    assert_daily_casino_stats,
+    assert_casino_ledger_consistent,
+)
+
+
+def _answer_request(
+    memory_ids: dict[int, str] | None = None,
+    server_memory: str | None = None,
+    callable_ids: dict[int, str] | None = None,
+) -> list[object]:
+    """Builds a recorded answer input mirroring what the pipeline assembles."""
+    request: list[object] = []
+    if callable_ids is not None:
+        request.append(render_callable_users_block(allowed=callable_ids))
+    if server_memory is not None:
+        request.append(render_server_memory_block(memory=server_memory))
+    if memory_ids is not None:
+        memories = [
+            UserMemory(user_id=str(uid), username=f"u{uid}", memory=body)
+            for uid, body in memory_ids.items()
+        ]
+        request.append(render_memory_context_block(memories=memories))
+    request.append({"role": "user", "content": "hi"})
+    return request
+
+
+# --- llm_input ---------------------------------------------------------------
+
+
+def test_extract_user_memory_blocks_keys_by_id() -> None:
+    """Each injected user's memory body is recovered keyed by id."""
+    request = _answer_request(memory_ids={1: "喜歡阿狗", 42: "李董的祕密"})
+    blocks = extract_user_memory_blocks(request=request)
+    assert blocks == {1: "喜歡阿狗", 42: "李董的祕密"}
+    assert has_memory_context_block(request=request)
+
+
+def test_extract_user_memory_blocks_empty_without_block() -> None:
+    """A request with no memory block yields no injected ids."""
+    request = _answer_request()
+    assert extract_user_memory_blocks(request=request) == {}
+    assert not has_memory_context_block(request=request)
+
+
+def test_extract_user_memory_blocks_handles_bare_string_input() -> None:
+    """A bare string input has no role structure and leaks nothing."""
+    assert extract_user_memory_blocks(request="just text") == {}
+    assert extract_callable_user_ids(request="just text") == set()
+
+
+def test_extract_server_memory_block_present_and_absent() -> None:
+    """The server block is found by its production header, else None."""
+    with_server = _answer_request(server_memory="這個社群很愛嘴")
+    assert extract_server_memory_block(request=with_server) is not None
+    assert extract_server_memory_block(request=_answer_request()) is None
+
+
+def test_extract_callable_user_ids_from_selection_block() -> None:
+    """Callable ids are parsed from the selection allowlist block."""
+    request = _answer_request(callable_ids={1: "Alice (alice)", 42: "Boss (boss)"})
+    assert extract_callable_user_ids(request=request) == {1, 42}
+
+
+def test_extract_memory_context_block_returns_full_text() -> None:
+    """The raw block text is returned for callers needing the framing."""
+    request = _answer_request(memory_ids={7: "x"})
+    block = extract_memory_context_block(request=request)
+    assert block is not None
+    assert "[id: 7]" in block
+
+
+def test_iter_text_blocks_yields_role_text_pairs() -> None:
+    """Every role-bearing item flattens to a (role, text) pair."""
+    request = _answer_request(memory_ids={1: "m"})
+    roles = [role for role, _ in iter_text_blocks(request=request)]
+    assert "assistant" in roles
+    assert roles[-1] == "user"
+
+
+class _Recorder:
+    """Minimal stand-in for the recording fake Responses resource."""
+
+    def __init__(self) -> None:
+        """Initializes the recorded per-call lists."""
+        self.create_streams: list[bool] = [False, True]
+        self.create_tools: list[list[object] | None] = [
+            [{"name": "get_user_memory"}],
+            [{"type": "web_search"}],
+        ]
+        self.create_inputs: list[object] = [["selection"], ["answer"]]
+
+
+def test_request_index_maps_phase_to_position() -> None:
+    """Selection is the first non-streaming call, answer the last streaming one."""
+    recorder = _Recorder()
+    assert request_index(responses=recorder, phase="selection") == 0
+    assert request_index(responses=recorder, phase="answer") == 1
+    assert request_input(responses=recorder, phase="answer") == ["answer"]
+
+
+def test_tool_names_for_call_reads_offered_tools() -> None:
+    """Tool names are read structurally, ignoring non-function builtins."""
+    recorder = _Recorder()
+    assert tool_names_for_call(responses=recorder, n=0) == ["get_user_memory"]
+    assert tool_names_for_call(responses=recorder, n=1) == []
+
+
+# --- embeds ------------------------------------------------------------------
+
+
+def test_assert_embed_has_field_returns_field() -> None:
+    """A present field is returned so the caller can check its value."""
+    embed = nextcord.Embed(title="💰 財務總覽")
+    embed.add_field(name="現金", value="100")
+    field = assert_embed_has_field(embed=embed, name="現金")
+    assert field.value == "100"
+
+
+def test_assert_embed_has_field_raises_when_missing() -> None:
+    """A missing field raises with the available names for diagnosis."""
+    embed = nextcord.Embed(title="x")
+    with pytest.raises(AssertionError, match="現金"):
+        assert_embed_has_field(embed=embed, name="現金")
+
+
+def test_assert_embed_title_prefix_checks_marker() -> None:
+    """The title is matched on its leading category marker only."""
+    embed = nextcord.Embed(title="💰 財務總覽")
+    assert_embed_title_prefix(embed=embed, prefix="💰")
+
+
+# --- discord_mocks -----------------------------------------------------------
+
+
+async def test_fake_response_records_defer_and_send() -> None:
+    """The response double records deferral, sends, and done-state."""
+    response = FakeResponse()
+    assert not response.is_done()
+    await response.defer(ephemeral=True)
+    assert response.deferred_ephemeral is True
+    await response.send_message(content="hi", ephemeral=True)
+    assert response.is_done()
+    assert response.sent[0]["content"] == "hi"
+
+
+async def test_fake_interaction_defaults_and_followup() -> None:
+    """The interaction double defaults a user and routes followup sends."""
+    interaction = FakeInteraction(user=FakeUser(user_id=5, name="bob"))
+    assert interaction.user.id == 5
+    message = await interaction.followup.send(content="done")
+    assert interaction.followup.sent[0]["content"] == "done"
+    await message.reply(content="re")
+    assert message.replies[0]["content"] == "re"
+
+
+# --- economy_invariants ------------------------------------------------------
+
+
+async def test_assert_wallet_consistent_passes_on_clean_credit(economy_isolated_db: None) -> None:
+    """A simple credit keeps the wallet identity and matches the expected balance."""
+    del economy_isolated_db
+    await adjust_balance(user_id=1, name="alice", delta=250)
+    account = await assert_wallet_consistent(user_id=1, expected_balance=250)
+    assert account.total_earned == 250
+
+
+async def test_assert_casino_and_daily_stats_zero_baseline(economy_isolated_db: None) -> None:
+    """A fresh ledger and an inactive user satisfy the accounting identities."""
+    del economy_isolated_db
+    await assert_casino_ledger_consistent(expected_balance=0)
+    await assert_daily_casino_stats(user_id=1, loss=0, win=0, net=0)


### PR DESCRIPTION
## Why

The test suite had accumulated iteration-driven brittleness and duplication:

- **Magic-string assertions over serialized LLM input.** Memory tests wrote a sentinel into a user's memory, then checked `assert "<sentinel>" not in str(create_inputs[-1])` — a substring scan over a giant blob, coupled to incidental ordering and an arbitrary literal.
- **Exact localized UI copy** pinned in embed titles, footers, and field text, so a wording/emoji refresh broke tests with no behavior change.
- **Hardcoded magic numbers** duplicating production constants instead of deriving from them.
- **Long-hand near-duplicate families** that should be parametrized.
- **~110 lines of duplicated fake Discord objects.**

## What changed

Structural, production-derived assertions replace magic strings; duplicate families are parametrized; shared test infrastructure removes the fake-object duplication. **Coverage floor: the pre-change baseline was 83% line+branch; the redesign holds 83%** (missed 1750 vs baseline 1751).

- **M0 — foundation.** New `tests/helpers/`: `llm_input` structural extractors over recorded Responses inputs (keyed on the production block headers and `[id: N]` markers, never `str()`), unified `discord_mocks`, `economy_invariants` accounting-identity asserts, `embeds` structural asserts. Self-tested in `tests/test_helpers.py`.
- **M1 — AI path.** `test_gen_reply.py`: every `in str(create_inputs...)` / positional-index assertion replaced with extractors; the memory-boundary family (~18 overlapping tests) collapsed into three parametrized matrices — user-memory injection + allowlist, footer credit, server-memory read/write gating. The privacy boundary was mutation-verified (forcing the private-channel widening bug makes the structural leak test fail). `gen_reply.py` branch coverage is byte-identical before/after.
- **M2 — Discord copy + mock dedup.** `test_cogs_smoke.py` adopts the shared mocks and structural embed asserts (the financial-summary title/footer/field-format coupling becomes value + locator checks).
- **M3 — economy constants + consolidation.** Transfer tax derives from `TRANSFER_TAX_BPS`; the transfer family (6→3) and five-card settlement family (5→1) are parametrized and rule-derived, using the casino-ledger / daily-stats / wallet invariant helpers. `settlement.py` coverage identical.
- **M4 — games copy.** Redundant dragon-gate end-state copy assertions removed (the pool/end state they sat on is fully asserted structurally).

## Intentionally left (to avoid over-engineering / coverage risk)

- `test_memory.py` / `test_server_memory.py`: no `create_inputs` anti-pattern; their assertions verify real stored memory content, secret redaction (which needs concrete sentinels), and prompt selection.
- Stock `10_000` literals: bps denominators, wallet amounts, price-limit fixtures, or a test-local constant — not production values, so converting is cosmetic.
- The maplestory render-contract title list and the loss-leaderboard `..._copy` tests: focused, deliberate copy contracts, not the blob-substring anti-pattern.

## Verification

- `uv run pytest` green; total coverage 83% (≥ baseline).
- Per-merge branch-coverage diff on touched src modules — no covered line/branch lost.
- Mutation spot-check on the memory privacy boundary.
- `uv run pre-commit run -a` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)