### PR TITLE
docs: mention git worktree for parallel branch work

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,7 @@ make gen-docs
 ## Workflow
 
 - Create a focused branch such as `feature/your-change`, `fix/your-bug`, `docs/your-doc-change`, or `chore/your-maintenance-task`.
+- For parallel work across branches, `git worktree add ../discordbot-<branch> -b <branch>` checks out a branch in a separate directory that shares the same `.git`, so the main checkout stays untouched.
 - Keep PRs scoped. Avoid unrelated refactors.
 - Use Conventional Commits for commit messages and PR titles:
 


### PR DESCRIPTION
## Summary

Adds a one-line note to the Workflow section of `CONTRIBUTING.md` describing how `git worktree add` lets you check out a branch in a separate directory that shares the same `.git`, leaving the main checkout untouched.

> Note: this is a throwaway demonstration PR (created to show the worktree + GitHub flow). Safe to close without merging.

## Changes

- `CONTRIBUTING.md`: new bullet under **Workflow** about using `git worktree` for parallel branch work.

## Checks

- `uv run pre-commit run --files CONTRIBUTING.md` passed (mdformat, codespell, gitleaks, file hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)