### PR TITLE
fix(memory): loosen background operational limits

### DIFF
--- a/src/discordbot/cogs/_memory/constants.py
+++ b/src/discordbot/cogs/_memory/constants.py
@@ -13,36 +13,38 @@ RAW_CONSOLIDATION_MAX_BYTES = 16_384
 # unbounded; the oldest entries are evicted into the detail file first.
 RAW_FILE_MAX_BYTES = 65_536
 
-# Minimum gap between entry-count-triggered consolidations per user. Recorded
-# at attempt time so repeated LLM failures are rate-limited too; the raw byte
-# trigger above ignores the cooldown so a burst still consolidates.
-MEMORY_CONSOLIDATION_COOLDOWN_SECONDS = 600.0
+# Minimum gap between entry-count-triggered consolidations per user. Not a cost
+# guard: it batches the lossy whole-file rewrite so main.md (the only tier
+# injected into replies) does not drift from rewriting on every other message,
+# and, recorded at attempt time, it also rate-limits a failing consolidation's
+# retries. No data is lost while it waits (raw keeps accumulating, detail.md
+# keeps verbatim evidence, and the raw byte trigger above bypasses it for a
+# burst), so it stays short enough that new facts reach replies promptly.
+MEMORY_CONSOLIDATION_COOLDOWN_SECONDS = 300.0
 
 # Minimum gap between user-requested main-file regenerations. Recorded at
 # attempt time like the consolidation cooldown, and tracked separately so a
 # manual regeneration never delays the automatic consolidation or vice versa.
 MEMORY_REGENERATION_COOLDOWN_SECONDS = 600.0
 
-# Process-wide cap on concurrent background memory updates so a busy server
-# cannot fan out unbounded whole-file rewrites against the shared LiteLLM
-# proxy and starve the reply path (mirrors codex's stage-1 concurrency limit).
-MEMORY_GLOBAL_CONCURRENCY = 8
+# Process-wide cap on concurrent background memory updates. The constraint is
+# not cost but proxy contention: unbounded fan-out of whole-file rewrites
+# against the shared LiteLLM proxy would compete with the latency-critical
+# reply path for throughput and rate limits. Kept generous because the proxy
+# can absorb it; lower it only if background memory work starts adding reply
+# latency.
+MEMORY_GLOBAL_CONCURRENCY = 24
 
 # The main file has no hard size clamp. Past the trigger, consolidation runs a
 # deep-summarization (compaction) pass aiming at roughly the target size. The
-# bound exists because consolidation rewrites the whole file in one response,
-# so the ceiling is the model's output-token limit (~65k tokens on Gemini
-# Flash), not the 1M-token input window. Compaction summarizes low-signal and
-# stale content; it never drops durable memory outright, and fine-grained
-# evidence survives in the detail file regardless.
+# bound exists because consolidation rewrites the whole file in one response, so
+# the ceiling is the answer model's own output-token limit (~64k tokens on
+# Gemini Pro), not the 1M-token input window. The memory calls no longer set a
+# lower explicit cap, so the trigger sits well inside that ceiling. Compaction
+# summarizes low-signal and stale content; it never drops durable memory
+# outright, and fine-grained evidence survives in the detail file regardless.
 MAIN_COMPACTION_TRIGGER_CHARS = 30_000
 MAIN_COMPACTION_TARGET_CHARS = 15_000
-
-# Explicit output budget for both memory LLM calls. Far above any legitimate
-# memory rewrite (~15k zh-TW chars, roughly 10k tokens) plus reasoning room, but
-# below the provider ceiling so a runaway response fails as a detectable
-# `incomplete` status instead of silently exhausting the provider limit.
-MEMORY_MAX_OUTPUT_TOKENS = 32_768
 
 # Tail window of the detail file fed to consolidation as low-trust provenance.
 # Effectively the whole evidence log for any realistic user: this bot injects
@@ -74,9 +76,12 @@ MEMORY_TRANSCRIPT_MAX_CHARS = 100_000
 # user message right before it.
 MEMORY_REPLY_MAX_CHARS = 8_000
 
-# Background LLM call timeouts. The memory models run with high reasoning
-# effort (possibly on a Pro tier) and consolidation rewrites the whole main
-# file, so these are looser than interactive paths but still bounded so a
-# stuck call cannot pin the in-flight de-dupe slot forever.
-MEMORY_EXTRACT_TIMEOUT_SECONDS = 180.0
-MEMORY_CONSOLIDATE_TIMEOUT_SECONDS = 180.0
+# Background LLM call timeouts, kept purely as a liveness backstop rather than
+# a latency or cost guard (a slow background update is harmless). A genuinely
+# stuck call would otherwise hold the scope's lock and a global-concurrency
+# permit forever, so that user/server would never get another memory update.
+# The memory models run at high reasoning effort on a Pro tier and
+# consolidation rewrites the whole main file, so the bound stays well above a
+# legitimately slow rewrite (minutes) and only fires on a truly hung call.
+MEMORY_EXTRACT_TIMEOUT_SECONDS = 600.0
+MEMORY_CONSOLIDATE_TIMEOUT_SECONDS = 600.0

--- a/src/discordbot/cogs/_memory/extraction.py
+++ b/src/discordbot/cogs/_memory/extraction.py
@@ -19,7 +19,6 @@ from discordbot.cogs._memory.prompts import (
 from discordbot.cogs._gen_reply.input import USAGE_FOOTER_RE
 from discordbot.cogs._memory.constants import (
     MEMORY_REPLY_MAX_CHARS,
-    MEMORY_MAX_OUTPUT_TOKENS,
     MEMORY_TRANSCRIPT_MAX_CHARS,
     MEMORY_EXTRACT_TIMEOUT_SECONDS,
     MEMORY_CONSOLIDATE_TIMEOUT_SECONDS,
@@ -265,7 +264,6 @@ class MemoryExtractorAI(BaseModel):
                     ),
                     text_format=text_format,
                     reasoning=model.reasoning,
-                    max_output_tokens=MEMORY_MAX_OUTPUT_TOKENS,
                     service_tier="auto",
                     extra_headers={"x-litellm-end-user-id": end_user_label},
                     extra_body={"mock_testing_fallbacks": False},
@@ -290,7 +288,8 @@ class MemoryExtractorAI(BaseModel):
             )
             return None
         if responses.status == "incomplete":
-            # The response hit the output-token budget. A truncated JSON body
+            # The response hit the answer model's own output-token ceiling (the
+            # memory calls set no explicit lower cap). A truncated JSON body
             # already fails parsing above, but a model that closed the JSON
             # early can still pass the `v1` header check downstream with a
             # silently amputated memory file; refuse it so raw entries are

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -48,7 +48,6 @@ from discordbot.cogs._memory.prompts import (
 )
 from discordbot.cogs._gen_reply.input import render_author_identity
 from discordbot.cogs._memory.constants import (
-    MEMORY_MAX_OUTPUT_TOKENS,
     MAIN_COMPACTION_TARGET_CHARS,
     MEMORY_CONSOLIDATION_COOLDOWN_SECONDS,
 )
@@ -131,7 +130,7 @@ class FakeMemoryResponses:
         self.parse_models: list[str] = []
         self.parse_instructions: list[str] = []
         self.parse_inputs: list[list[dict[str, str]]] = []
-        self.parse_max_output_tokens: list[int] = []
+        self.parse_extra_kwargs: list[dict[str, object]] = []
         self.output_parsed: BaseModel | None = None
         self.status: str = "completed"
         self.raises: Exception | None = None
@@ -143,17 +142,22 @@ class FakeMemoryResponses:
         input: list[dict[str, str]],  # noqa: A002 -- SDK parameter
         text_format: type[BaseModel],
         reasoning: dict[str, str],
-        max_output_tokens: int,
         service_tier: str,
         extra_headers: dict[str, str],
         extra_body: dict[str, bool],
+        **unexpected: object,
     ) -> SimpleNamespace:
-        """Records the call and returns or raises the configured result."""
+        """Records the call and returns or raises the configured result.
+
+        `**unexpected` captures any kwarg the memory calls are not expected to
+        pass (e.g. a reintroduced `max_output_tokens`) so a test can assert the
+        memory path leaves the output budget to the backend.
+        """
         del text_format, reasoning, service_tier, extra_headers, extra_body
         self.parse_models.append(model)
         self.parse_instructions.append(instructions)
         self.parse_inputs.append(input)
-        self.parse_max_output_tokens.append(max_output_tokens)
+        self.parse_extra_kwargs.append(unexpected)
         if self.raises is not None:
             raise self.raises
         return SimpleNamespace(
@@ -1895,7 +1899,9 @@ async def test_extract_returns_none_on_incomplete_response() -> None:
     assert await extractor.extract(subject=f"target_user_id: {USER_ID}", transcript="hi") is None
 
 
-async def test_memory_calls_set_max_output_tokens() -> None:
+async def test_memory_calls_omit_max_output_tokens() -> None:
+    # The memory calls intentionally set no explicit output cap so the backend
+    # uses the model's own ceiling; only the `incomplete` guard bounds output.
     extractor, fake_client = _extractor()
     fake_client.responses.output_parsed = _no_signal()
     await extractor.extract(subject=f"target_user_id: {USER_ID}", transcript="hi")
@@ -1903,10 +1909,7 @@ async def test_memory_calls_set_max_output_tokens() -> None:
     await extractor.consolidate(
         existing_main="", raw_entries="x", recent_detail="", today="2026-06-06", compact=False
     )
-    assert fake_client.responses.parse_max_output_tokens == [
-        MEMORY_MAX_OUTPUT_TOKENS,
-        MEMORY_MAX_OUTPUT_TOKENS,
-    ]
+    assert fake_client.responses.parse_extra_kwargs == [{}, {}]
 
 
 async def test_pipeline_rejects_drastically_shrunken_rewrite(


### PR DESCRIPTION
## Why

The memory pipeline is fire-and-forget background work running on a strong model (`gemini-pro-latest` at `high` effort), and we do not care about its cost. Several operational limits were tuned conservatively for a cheaper, faster tier and now work against that setup. None of them govern *what* gets recorded (that is the extraction gates and evaluator, intentionally left untouched here); they only bound how the background job runs.

The headline issue: `max_output_tokens` was capped at 32,768 for both memory calls. On the Responses API that budget includes reasoning tokens, and consolidation rewrites the whole `main.md` in a single response. As `main.md` approaches the compaction trigger, a high-effort Pro rewrite can exceed 32k, come back `incomplete`, and get refused, so consolidation silently stops making progress.

## What

- **Output budget**: stop sending an explicit `max_output_tokens` on the memory calls and let the backend use the model's own ceiling. The `incomplete`-response guard stays load-bearing (it still protects good memory from being overwritten by a truncated rewrite); it now only fires if the model's own ceiling is hit.
- **Timeouts** (`MEMORY_EXTRACT_TIMEOUT_SECONDS` / `MEMORY_CONSOLIDATE_TIMEOUT_SECONDS`): 180s → 600s. Reframed as a pure liveness backstop. A hung call would otherwise pin the scope lock and a concurrency permit forever; the bound only needs to clear a legitimately slow rewrite and fire on a truly stuck call.
- **Concurrency** (`MEMORY_GLOBAL_CONCURRENCY`): 8 → 24. The real constraint is proxy contention with the latency-critical reply path, not cost; kept a cap so background work cannot starve replies.
- **Consolidation cooldown** (`MEMORY_CONSOLIDATION_COOLDOWN_SECONDS`): 600s → 300s, so new facts reach `main.md` (the only tier injected into replies) sooner. Not zeroed: it still batches the lossy rewrite to limit drift and rate-limits failure retries; no data is lost while it waits.
- Content-selection precision (extraction gates, phase-1.5 evaluator, prompts) and disk/integrity bounds are deliberately unchanged.

## Verification

- `uv run pytest` — full suite green, coverage gate met.
- `uv run pre-commit run -a` — ruff + mypy clean.
- In production, watch the existing `Memory LLM response incomplete` warn: it should trend to zero. If it appears, the backend injected a conservative default with no explicit cap and we would set an explicit model-max cap instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)