### PR TITLE
fix(gen_reply): limit dead-source skip to history renders

### DIFF
--- a/src/discordbot/cogs/_gen_reply/input.py
+++ b/src/discordbot/cogs/_gen_reply/input.py
@@ -372,7 +372,11 @@ class MessageInputBuilder(BaseModel):
         return False, None
 
     async def _resolve_file_upload(
-        self, cache_key: int | str, filename: str, load_data: "FileBytesLoader"
+        self,
+        cache_key: int | str,
+        filename: str,
+        load_data: "FileBytesLoader",
+        allow_dead_cache: bool = False,
     ) -> tuple[str, datetime] | None:
         """Returns an ACTIVE file (uri, expiry), re-polling a prior pending upload first.
 
@@ -392,7 +396,10 @@ class MessageInputBuilder(BaseModel):
         handled, adopted = await self._repoll_pending_upload(cache_key=cache_key)
         if handled:
             return adopted
-        if self._is_known_dead(cache_key=cache_key):
+        # The dead-source skip is for history scrollback only (an expired CDN url that
+        # re-fails every turn); current/reference renders never opt in, so one transient
+        # failure on a just-posted attachment is not poisoned for the next reply.
+        if allow_dead_cache and self._is_known_dead(cache_key=cache_key):
             return None
         # One media slot spans the whole download + upload (+ activation poll) for every
         # attachment type, so concurrent pipelines cannot launch dozens of CDN downloads or
@@ -402,7 +409,8 @@ class MessageInputBuilder(BaseModel):
                 data, content_type = await load_data()
             except Exception:
                 logfire.warn(f"Failed to load attachment bytes for upload: {filename}")
-                self._mark_dead(cache_key=cache_key)
+                if allow_dead_cache:
+                    self._mark_dead(cache_key=cache_key)
                 return None
             result = await self._upload_file(
                 filename=filename, data=data, content_type=content_type
@@ -534,7 +542,10 @@ class MessageInputBuilder(BaseModel):
         return f"data:{mime_type};base64,{base64.b64encode(data).decode()}"
 
     async def image_to_part(
-        self, source: Attachment | StickerItem | str, cache_key: int | str
+        self,
+        source: Attachment | StickerItem | str,
+        cache_key: int | str,
+        allow_dead_cache: bool = False,
     ) -> tuple[RenderedPart, datetime] | None:
         """Converts an image source to a content part plus its cache expiry.
 
@@ -553,6 +564,7 @@ class MessageInputBuilder(BaseModel):
                 cache_key=cache_key,
                 filename=source_name,
                 load_data=lambda: self._load_image_bytes(source=source),
+                allow_dead_cache=allow_dead_cache,
             )
             if uploaded is None:
                 return None
@@ -574,7 +586,7 @@ class MessageInputBuilder(BaseModel):
         return image_part, self._inline_expiry()
 
     async def attachment_to_part(
-        self, attachment: Attachment, cache_key: int | str
+        self, attachment: Attachment, cache_key: int | str, allow_dead_cache: bool = False
     ) -> tuple[RenderedPart, datetime] | None:
         """Converts a file attachment to a content part plus its cache expiry.
 
@@ -596,7 +608,10 @@ class MessageInputBuilder(BaseModel):
 
         if self._answer_model_is_gemini():
             uploaded = await self._resolve_file_upload(
-                cache_key=cache_key, filename=attachment.filename, load_data=_load
+                cache_key=cache_key,
+                filename=attachment.filename,
+                load_data=_load,
+                allow_dead_cache=allow_dead_cache,
             )
             if uploaded is None:
                 return None
@@ -700,7 +715,7 @@ class MessageInputBuilder(BaseModel):
         return "image"
 
     async def _render_attachment_parts(
-        self, sources: list[AttachmentSource]
+        self, sources: list[AttachmentSource], allow_dead_cache: bool = False
     ) -> list[tuple[RenderedPart, datetime] | None]:
         """Renders every supported source to a content part + expiry; failures stay None.
 
@@ -710,23 +725,35 @@ class MessageInputBuilder(BaseModel):
         tasks: list[Coroutine[object, object, tuple[RenderedPart, datetime] | None]] = []
         for source in sources:
             if source.kind == "image":
-                tasks.append(self.image_to_part(source=source.handle, cache_key=source.cache_key))
+                tasks.append(
+                    self.image_to_part(
+                        source=source.handle,
+                        cache_key=source.cache_key,
+                        allow_dead_cache=allow_dead_cache,
+                    )
+                )
             else:
                 # Only attachments are ever classified as files; stickers and embeds are images.
                 tasks.append(
                     self.attachment_to_part(
-                        attachment=cast("Attachment", source.handle), cache_key=source.cache_key
+                        attachment=cast("Attachment", source.handle),
+                        cache_key=source.cache_key,
+                        allow_dead_cache=allow_dead_cache,
                     )
                 )
         return list(await asyncio.gather(*tasks))
 
     async def get_attachment_parts(
-        self, message: Message, sources: list[AttachmentSource] | None = None
+        self,
+        message: Message,
+        sources: list[AttachmentSource] | None = None,
+        allow_dead_cache: bool = False,
     ) -> list[RenderedPart]:
         """Extracts attachment content parts from a message, with a per-message cache.
 
         Pass the pre-collected supported `sources` to avoid re-collecting; when omitted
-        they are collected and gated here so direct callers keep working.
+        they are collected and gated here so direct callers keep working. `allow_dead_cache`
+        is opt-in for history scrollback only (see `_resolve_file_upload`).
         """
         if sources is None:
             sources = self._supported_sources(
@@ -749,7 +776,9 @@ class MessageInputBuilder(BaseModel):
             # values are immutable strings, so the copies stay cheap.
             return [part.copy() for part in cached[1]]
 
-        rendered = await self._render_attachment_parts(sources=sources)
+        rendered = await self._render_attachment_parts(
+            sources=sources, allow_dead_cache=allow_dead_cache
+        )
         resolved = [item[0] for item in rendered if item is not None]
         # A None entry means a download/convert or upload failed; skip caching so the
         # next reply retries instead of pinning a degraded render. The entry's expiry is
@@ -835,14 +864,23 @@ class MessageInputBuilder(BaseModel):
             logfire.warn(f"Failed to render message {message.id} for routing", _exc_info=True)
             return EasyInputMessageParam(role="user", content="")
 
-    async def process_single_message(self, message: Message) -> EasyInputMessageParam:
-        """Processes a single Discord message into a Responses API input message."""
+    async def process_single_message(
+        self, message: Message, allow_dead_cache: bool = False
+    ) -> EasyInputMessageParam:
+        """Processes a single Discord message into a Responses API input message.
+
+        `allow_dead_cache` is set only for history scrollback, where an expired CDN source
+        re-fails every turn; current/reference renders leave it off so a transient failure
+        on a just-posted attachment is retried on the next reply.
+        """
         try:
             content = await self.get_cleaned_content(message=message)
             sources = self._supported_sources(
                 sources=self.collect_attachment_sources(message=message)
             )
-            attachment_parts = await self.get_attachment_parts(message=message, sources=sources)
+            attachment_parts = await self.get_attachment_parts(
+                message=message, sources=sources, allow_dead_cache=allow_dead_cache
+            )
             return self._assemble_input_message(
                 message=message,
                 content=content,

--- a/src/discordbot/cogs/gen_reply.py
+++ b/src/discordbot/cogs/gen_reply.py
@@ -304,7 +304,14 @@ class ReplyGeneratorCogs(commands.Cog):
         if hist_messages:
             full_tasks: list[Awaitable[EasyInputMessageParam]] = []
             for hist_msg in hist_messages:
-                full_tasks.append(self.input_builder.process_single_message(message=hist_msg))
+                # History is the only render that opts into the dead-source skip: an expired
+                # CDN attachment here re-fails every turn. Current/reference do not (see
+                # MessageInputBuilder._resolve_file_upload).
+                full_tasks.append(
+                    self.input_builder.process_single_message(
+                        message=hist_msg, allow_dead_cache=True
+                    )
+                )
             text_tasks: list[Awaitable[EasyInputMessageParam]] = []
             if with_text_only:
                 for hist_msg in hist_messages:

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -747,15 +747,37 @@ async def test_dead_source_skipped_within_ttl_then_retried(
     builder = _media_builder()
     url = "https://example.test/dead.png"
 
-    assert await builder.image_to_part(source=url, cache_key=url) is None
+    assert await builder.image_to_part(source=url, cache_key=url, allow_dead_cache=True) is None
     assert calls["n"] == 1
     # Within the TTL the source is skipped without another fetch.
-    assert await builder.image_to_part(source=url, cache_key=url) is None
+    assert await builder.image_to_part(source=url, cache_key=url, allow_dead_cache=True) is None
     assert calls["n"] == 1
     # Backdating the marker past the TTL retries the fetch exactly once (self-heal).
     builder._dead_sources[url] = datetime.now(tz=UTC) - DEAD_SOURCE_TTL - timedelta(seconds=1)
+    assert await builder.image_to_part(source=url, cache_key=url, allow_dead_cache=True) is None
+    assert calls["n"] == 2
+
+
+async def test_non_history_render_does_not_dead_cache_transient_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Current/reference renders (allow_dead_cache off) retry a transient failure, not poison it."""
+    calls = {"n": 0}
+
+    def _raise_get_image_data(image_file: str) -> bytes:
+        del image_file
+        calls["n"] += 1
+        raise RuntimeError("transient blip")
+
+    monkeypatch.setattr("discordbot.cogs._gen_reply.input.get_image_data", _raise_get_image_data)
+    builder = _media_builder()
+    url = "https://example.test/fresh.png"
+
+    # Default path (current/reference): each call re-attempts the fetch and never marks dead.
+    assert await builder.image_to_part(source=url, cache_key=url) is None
     assert await builder.image_to_part(source=url, cache_key=url) is None
     assert calls["n"] == 2
+    assert url not in builder._dead_sources
 
 
 async def test_media_semaphore_bounds_media_io_concurrency() -> None:
@@ -2594,10 +2616,10 @@ async def test_attachment_cache_refreshes_on_embed_url_swap(
     rendered_urls: list[str] = []
 
     async def fake_image_to_part(
-        self: object, source: object, cache_key: object
+        self: object, source: object, cache_key: object, allow_dead_cache: bool = False
     ) -> tuple[dict[str, str], datetime]:
         """Records each rendered source instead of hitting the network."""
-        del self, cache_key
+        del self, cache_key, allow_dead_cache
         rendered_urls.append(str(source))
         return {"type": "input_image", "image_url": str(source)}, datetime(2099, 1, 1, tzinfo=UTC)
 


### PR DESCRIPTION
## Context

Follow-up to #280, addressing a Codex review comment on the dead-source cache.

The dead-source skip (`_mark_dead` / `_is_known_dead`) was added to stop an expired-CDN attachment sitting in history scrollback from being re-fetched and re-warned on every reply. But `_resolve_file_upload` is shared by every render path, so it also applied to the **current and referenced** messages. A single transient failure (e.g. an embed/sticker image URL hitting the 10s fetch timeout) on a just-posted attachment would mark it dead for 30 minutes, so a user replying "try again" to the same message would silently lose the attachment even after the CDN recovered.

## Change

Make the dead-source skip opt-in for history scrollback only. A new `allow_dead_cache` flag (default off) threads from `process_single_message` down through `get_attachment_parts` / `_render_attachment_parts` / `image_to_part` / `attachment_to_part` to `_resolve_file_upload`, gating both the `_is_known_dead` read and the `_mark_dead` write. Only the history render opts in; current/reference renders always retry a transient failure on the next reply.

History keeps its benefit (an expired CDN source is still skipped after the first failure); current/reference no longer poison a fresh attachment.

## Tests

- Updated the dead-source test to opt in explicitly.
- Added a test proving a non-history render retries a transient failure and never marks the source dead.
- Full suite green (820 passed), coverage gate met, `pre-commit run -a` clean.