### PR TITLE
refactor(gen_reply): let attachment uploader build its own Gemini client

### DIFF
--- a/src/discordbot/cogs/_gen_reply/attachment/gemini_file_api.py
+++ b/src/discordbot/cogs/_gen_reply/attachment/gemini_file_api.py
@@ -11,6 +11,7 @@ import time
 from typing import TYPE_CHECKING
 import asyncio
 from datetime import UTC, datetime, timedelta
+from functools import cached_property
 from collections import OrderedDict
 
 from google import genai
@@ -20,6 +21,8 @@ from pydantic import Field, BaseModel, PrivateAttr, SkipValidation
 from google.genai.types import FileState
 from openai.types.responses.response_input_file_param import ResponseInputFileParam
 
+from discordbot.utils.llm import create_gemini_client
+from discordbot.typings.llm import LLMConfig
 from discordbot.cogs._gen_reply.attachment.base import RenderedPart, AttachmentRenderer
 from discordbot.cogs._gen_reply.attachment.loaders import (
     attachment_mime,
@@ -72,17 +75,13 @@ class GeminiFileUploader(AttachmentRenderer):
     """Uploads attachments to the Gemini Files API and references them by URI.
 
     Attributes:
-        gemini_client: Gemini client used to upload attachments to the Files API
-            directly, so each upload can be polled to ACTIVE before it is used; None
-            when `GEMINI_API_KEY` is unconfigured, in which case uploads are dropped.
+        config: Runtime LLM config supplying the Gemini Files API key for the lazily
+            built upload client.
     """
 
-    gemini_client: SkipValidation[genai.Client] | None = Field(
-        ...,
-        description=(
-            "Gemini client used to upload attachments to the Files API directly so each "
-            "upload can be polled to ACTIVE before use; None when GEMINI_API_KEY is unset."
-        ),
+    config: LLMConfig = Field(
+        default_factory=LLMConfig,
+        description="Runtime LLM config supplying the Gemini Files API key for the upload client.",
     )
     # Uploads that timed out while still PROCESSING, keyed by attachment source cache_key
     # (attachment/sticker id or embed url). The next reference to that source re-polls the
@@ -100,6 +99,26 @@ class GeminiFileUploader(AttachmentRenderer):
     _media_semaphore: SkipValidation[asyncio.Semaphore] = PrivateAttr(
         default_factory=lambda: asyncio.Semaphore(MEDIA_CONCURRENCY)
     )
+
+    @cached_property
+    def gemini_client(self) -> genai.Client | None:
+        """The Gemini client for direct Files API uploads, built lazily on first use.
+
+        The client uploads attachments directly (not through the LiteLLM proxy) so each
+        upload can be polled to an ACTIVE `state` before it is referenced. Built defensively:
+        `genai.Client` raises when `GEMINI_API_KEY` is unset, so a missing key degrades to
+        dropping attachment uploads (handled in `_upload_file`), never a hard failure. Built
+        here, not at the cog: this uploader is only constructed on the Gemini answer-model
+        path, so a non-Gemini deployment never builds the client nor logs the disabled warning.
+
+        Returns:
+            A Gemini client reused across uploads, or None when no key is configured.
+        """
+        try:
+            return create_gemini_client(config=self.config)
+        except Exception:
+            logfire.warn("Gemini Files API disabled: GEMINI_API_KEY not configured")
+            return None
 
     async def render_image(
         self,

--- a/src/discordbot/cogs/_gen_reply/attachment/gemini_file_api.py
+++ b/src/discordbot/cogs/_gen_reply/attachment/gemini_file_api.py
@@ -101,24 +101,20 @@ class GeminiFileUploader(AttachmentRenderer):
     )
 
     @cached_property
-    def gemini_client(self) -> genai.Client | None:
+    def gemini_client(self) -> genai.Client:
         """The Gemini client for direct Files API uploads, built lazily on first use.
 
         The client uploads attachments directly (not through the LiteLLM proxy) so each
-        upload can be polled to an ACTIVE `state` before it is referenced. Built defensively:
-        `genai.Client` raises when `GEMINI_API_KEY` is unset, so a missing key degrades to
-        dropping attachment uploads (handled in `_upload_file`), never a hard failure. Built
-        here, not at the cog: this uploader is only constructed on the Gemini answer-model
-        path, so a non-Gemini deployment never builds the client nor logs the disabled warning.
+        upload can be polled to an ACTIVE `state` before it is referenced. Built here, not
+        at the cog: this uploader is only constructed on the Gemini answer-model path, so a
+        non-Gemini deployment never builds it. A missing `GEMINI_API_KEY` does not fail
+        construction; the failure surfaces at the upload call, where `_upload_file` catches
+        it and drops the attachment while the text reply still goes out.
 
         Returns:
-            A Gemini client reused across uploads, or None when no key is configured.
+            A Gemini client reused across uploads.
         """
-        try:
-            return create_gemini_client(config=self.config)
-        except Exception:
-            logfire.warn("Gemini Files API disabled: GEMINI_API_KEY not configured")
-            return None
+        return create_gemini_client(config=self.config)
 
     async def render_image(
         self,
@@ -201,7 +197,7 @@ class GeminiFileUploader(AttachmentRenderer):
         no usable pending entry, so the caller should fall through to a fresh upload.
         """
         pending = self._pending_uploads.get(cache_key)
-        if pending is None or self.gemini_client is None:
+        if pending is None:
             return False, None
         if datetime.now(tz=UTC) >= pending.expires_at:
             self._pending_uploads.pop(cache_key, None)
@@ -299,9 +295,6 @@ class GeminiFileUploader(AttachmentRenderer):
         can reuse the handle until it actually expires (Gemini files live ~48h) instead
         of guessing a fixed TTL.
         """
-        if self.gemini_client is None:
-            logfire.warn(f"Gemini Files API unavailable; dropping attachment: {filename}")
-            return None
         activation_timeout_seconds = 15.0
         poll_interval_seconds = 0.5
         # The caller (`_resolve_file_upload`) holds the media semaphore across this whole

--- a/src/discordbot/cogs/_gen_reply/attachment/select.py
+++ b/src/discordbot/cogs/_gen_reply/attachment/select.py
@@ -1,22 +1,18 @@
 """Selects the attachment renderer that matches the current answer model's provider."""
 
-from google import genai
-
-from discordbot.typings.models import RuntimeModelCatalog
 from discordbot.cogs._gen_reply.attachment.base import AttachmentRenderer
 from discordbot.cogs._gen_reply.attachment.inline import InlineRenderer
 from discordbot.cogs._gen_reply.attachment.gemini_file_api import GeminiFileUploader
 
 
-def build_attachment_handler(
-    runtime_models: RuntimeModelCatalog, gemini_client: genai.Client | None
-) -> AttachmentRenderer:
+def build_attachment_handler(model_name: str) -> AttachmentRenderer:
     """Returns the attachment renderer matching the answer (slow) model's provider.
 
     Only Gemini resolves an uploaded Files-API URI; OpenAI / Anthropic answer models reject
     it (the proxy mistranslates it), so they inline instead. This is the single place that
     maps an answer model to its attachment handling, so adding a provider changes only here.
+    The Gemini uploader builds its own Files API client lazily, so this only needs the name.
     """
-    if "gemini" in runtime_models.slow_model.name:
-        return GeminiFileUploader(gemini_client=gemini_client)
+    if "gemini" in model_name:
+        return GeminiFileUploader()
     return InlineRenderer()

--- a/src/discordbot/cogs/gen_reply.py
+++ b/src/discordbot/cogs/gen_reply.py
@@ -9,7 +9,6 @@ import asyncio
 from functools import cached_property
 import contextlib
 
-from google import genai
 from openai import AsyncOpenAI
 import logfire
 import nextcord
@@ -20,7 +19,7 @@ from openai.types.responses.response_input_param import ResponseInputParam, Easy
 from openai.types.responses.response_input_text_param import ResponseInputTextParam
 from openai.types.responses.response_input_image_param import ResponseInputImageParam
 
-from discordbot.utils.llm import litellm_call_kwargs, create_gemini_client, create_litellm_client
+from discordbot.utils.llm import litellm_call_kwargs, create_litellm_client
 from discordbot.typings.llm import LLMConfig
 from discordbot.utils.images import convert_base64_to_data_uri
 from discordbot.typings.models import RouteDecision, RuntimeModelCatalog
@@ -223,25 +222,6 @@ class ReplyGeneratorCogs(commands.Cog):
         return create_litellm_client(config=self.config)
 
     @cached_property
-    def gemini_client(self) -> genai.Client | None:
-        """The cached Gemini client for direct Files API attachment uploads.
-
-        Built defensively: `genai.Client` raises when `GEMINI_API_KEY` is unset, so a
-        deployment that only configured the OpenAI/LiteLLM proxy still serves text and
-        non-attachment replies. A missing client degrades to dropping attachment uploads
-        (handled in `GeminiFileUploader._upload_file`), never a hard failure on the
-        `on_message` path that builds `input_builder` before it knows about attachments.
-
-        Returns:
-            A Gemini client reused across uploads, or None when no key is configured.
-        """
-        try:
-            return create_gemini_client(config=self.config)
-        except Exception:
-            logfire.warn("Gemini Files API disabled: GEMINI_API_KEY not configured")
-            return None
-
-    @cached_property
     def voice_synthesizer(self) -> VoiceSynthesizer:
         """The cached text-to-speech engine for spoken QA replies.
 
@@ -290,14 +270,14 @@ class ReplyGeneratorCogs(commands.Cog):
         """The cached Discord-message-to-Responses-API input builder.
 
         Returns:
-            A builder bound to this bot, runtime model catalog, and the Gemini
-            client that uploads attachments to the Files API.
+            A builder bound to this bot, runtime model catalog, and the attachment
+            handler matching the answer model's provider.
         """
         return MessageInputBuilder(
             bot=self.bot,
             runtime_models=self.runtime_models,
             attachment_handler=build_attachment_handler(
-                runtime_models=self.runtime_models, gemini_client=self.gemini_client
+                model_name=self.runtime_models.slow_model.name
             ),
         )
 

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -486,13 +486,26 @@ def _png_b64() -> str:
     return base64.b64encode(s=buffer.getvalue()).decode(encoding="utf-8")
 
 
+def _fake_uploader(files: FakeGeminiFiles | None = None) -> GeminiFileUploader:
+    """A GeminiFileUploader with its lazy Gemini client pre-seeded to a fake.
+
+    `gemini_client` is a cached_property, so seeding `__dict__` bypasses the real
+    factory and the upload path runs against the fake instead.
+    """
+    uploader = GeminiFileUploader()
+    uploader.__dict__["gemini_client"] = FakeGeminiClient(files=files)
+    return uploader
+
+
 def _cog(bot_user_id: int = 999) -> ReplyGeneratorCogs:
     """Builds a ReplyGeneratorCogs instance with a fake client."""
     cog = ReplyGeneratorCogs.__new__(ReplyGeneratorCogs)
     cog.bot = SimpleNamespace(user=SimpleNamespace(id=bot_user_id, name="bot"))
     cog.runtime_models = RuntimeModelCatalog()
     cog.__dict__["client"] = FakeClient()
-    cog.__dict__["gemini_client"] = FakeGeminiClient()
+    handler = cog.input_builder.attachment_handler
+    if isinstance(handler, GeminiFileUploader):
+        handler.__dict__["gemini_client"] = FakeGeminiClient()
     return cog
 
 
@@ -1048,7 +1061,7 @@ def _media_builder() -> MessageInputBuilder:
     return MessageInputBuilder(
         bot=SimpleNamespace(user=SimpleNamespace(id=999, name="bot")),
         runtime_models=RuntimeModelCatalog(),
-        attachment_handler=GeminiFileUploader(gemini_client=FakeGeminiClient()),
+        attachment_handler=_fake_uploader(),
     )
 
 
@@ -1086,7 +1099,7 @@ async def test_dead_source_skipped_within_ttl_then_retried(
     monkeypatch.setattr(
         "discordbot.cogs._gen_reply.attachment.loaders.get_image_data", _raise_get_image_data
     )
-    uploader = GeminiFileUploader(gemini_client=FakeGeminiClient())
+    uploader = _fake_uploader()
     url = "https://example.test/dead.png"
 
     assert await uploader.render_image(source=url, cache_key=url, allow_dead_cache=True) is None
@@ -1114,7 +1127,7 @@ async def test_non_history_render_does_not_dead_cache_transient_failure(
     monkeypatch.setattr(
         "discordbot.cogs._gen_reply.attachment.loaders.get_image_data", _raise_get_image_data
     )
-    uploader = GeminiFileUploader(gemini_client=FakeGeminiClient())
+    uploader = _fake_uploader()
     url = "https://example.test/fresh.png"
 
     # Default path (current/reference): each call re-attempts the fetch and never marks dead.
@@ -1130,7 +1143,7 @@ async def test_media_semaphore_bounds_media_io_concurrency() -> None:
     Counting concurrency in the byte loader proves non-image downloads (which run before the
     Gemini upload) are bounded too, so concurrent pipelines cannot buffer every file at once.
     """
-    uploader = GeminiFileUploader(gemini_client=FakeGeminiClient())
+    uploader = _fake_uploader()
     uploader._media_semaphore = asyncio.Semaphore(2)
     state = {"active": 0, "peak": 0}
 
@@ -1260,7 +1273,7 @@ async def test_upload_file_polls_active_and_drops_unready_files(
     )
 
     def _uploader(files: FakeGeminiFiles) -> GeminiFileUploader:
-        return GeminiFileUploader(gemini_client=FakeGeminiClient(files=files))
+        return _fake_uploader(files=files)
 
     # PROCESSING for two polls, then ACTIVE: the file URI and its expiry are returned.
     active = _uploader(FakeGeminiFiles(processing_rounds=2))
@@ -1303,7 +1316,8 @@ async def test_upload_file_polls_active_and_drops_unready_files(
     assert await boom._upload_file(filename="x.txt", data=b"x", content_type="text/plain") is None
 
     # No Gemini client (GEMINI_API_KEY unconfigured): the file is dropped, not a crash.
-    no_client = GeminiFileUploader(gemini_client=None)
+    no_client = GeminiFileUploader()
+    no_client.__dict__["gemini_client"] = None
     assert (
         await no_client._upload_file(filename="x.txt", data=b"x", content_type="text/plain")
         is None
@@ -1332,7 +1346,7 @@ async def test_resolve_file_upload_recovers_pending_on_next_reference(
     )
 
     files = FakeGeminiFiles(processing_rounds=99)
-    uploader = GeminiFileUploader(gemini_client=FakeGeminiClient(files=files))
+    uploader = _fake_uploader(files=files)
 
     load_calls = 0
 
@@ -1371,18 +1385,17 @@ async def test_resolve_file_upload_recovers_pending_on_next_reference(
 
 def test_gemini_client_disabled_when_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
     """A deployment without GEMINI_API_KEY gets a None client, not a hard failure."""
-    cog = _cog()
-    # Drop the injected fake so the real cached_property runs against the factory.
-    del cog.__dict__["gemini_client"]
-    cog.config = SimpleNamespace()
 
     def _raise(config: object) -> object:
         """Mimics genai.Client refusing to build without a key."""
         del config
         raise ValueError("No API key was provided.")
 
-    monkeypatch.setattr("discordbot.cogs.gen_reply.create_gemini_client", _raise)
-    assert cog.gemini_client is None
+    monkeypatch.setattr(
+        "discordbot.cogs._gen_reply.attachment.gemini_file_api.create_gemini_client", _raise
+    )
+    uploader = GeminiFileUploader()
+    assert uploader.gemini_client is None
 
 
 async def test_non_gemini_answer_model_inlines_attachments() -> None:

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -1315,14 +1315,6 @@ async def test_upload_file_polls_active_and_drops_unready_files(
     monkeypatch.setattr(boom.gemini_client.aio.files, "upload", _raise)
     assert await boom._upload_file(filename="x.txt", data=b"x", content_type="text/plain") is None
 
-    # No Gemini client (GEMINI_API_KEY unconfigured): the file is dropped, not a crash.
-    no_client = GeminiFileUploader()
-    no_client.__dict__["gemini_client"] = None
-    assert (
-        await no_client._upload_file(filename="x.txt", data=b"x", content_type="text/plain")
-        is None
-    )
-
 
 async def test_resolve_file_upload_recovers_pending_on_next_reference(
     monkeypatch: pytest.MonkeyPatch,
@@ -1381,21 +1373,6 @@ async def test_resolve_file_upload_recovers_pending_on_next_reference(
     assert "vid" not in uploader._pending_uploads
     assert files.upload_calls == [("v.mp4", "video/mp4")]  # no second upload
     assert load_calls == 1  # adopt path did not re-download the source
-
-
-def test_gemini_client_disabled_when_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A deployment without GEMINI_API_KEY gets a None client, not a hard failure."""
-
-    def _raise(config: object) -> object:
-        """Mimics genai.Client refusing to build without a key."""
-        del config
-        raise ValueError("No API key was provided.")
-
-    monkeypatch.setattr(
-        "discordbot.cogs._gen_reply.attachment.gemini_file_api.create_gemini_client", _raise
-    )
-    uploader = GeminiFileUploader()
-    assert uploader.gemini_client is None
 
 
 async def test_non_gemini_answer_model_inlines_attachments() -> None:


### PR DESCRIPTION
## What

Makes `GeminiFileUploader` self-contained and collapses `build_attachment_handler` down to a single `model_name` argument.

- `GeminiFileUploader` now holds a `config: LLMConfig` and builds its Gemini Files API client lazily via a `gemini_client` `cached_property`, instead of receiving the client from the cog.
- `build_attachment_handler(model_name: str)` replaces the old `(runtime_models, gemini_client)` signature. It only needs the answer model's name to pick a renderer.
- The cog (`ReplyGeneratorCogs`) drops its `gemini_client` property and the now-unused `genai` / `create_gemini_client` imports; `input_builder` passes `model_name=self.runtime_models.slow_model.name`.

## Why

The uploader is what actually uses the Gemini client, so building it there keeps the responsibility in one place and lets `build_attachment_handler` stay a pure name-to-renderer mapping. The uploader is only constructed on the Gemini answer-model path, so a non-Gemini deployment never builds the client at all.

## `gemini_client` is non-optional

The previous code returned `genai.Client | None` and guarded callers on `is None`, on the premise that `genai.Client` raises when `GEMINI_API_KEY` is unset. That premise is wrong: `genai.Client(api_key="")` constructs fine and only fails at the actual upload call. So the client is now non-optional and built directly. A missing key is still safe: `GEMINI_API_KEY` only feeds the direct Files API side-channel (the answer model itself routes through the LiteLLM proxy with `OPENAI_API_KEY`), and a missing key surfaces at the upload call, which `_upload_file` already catches — the attachment is dropped while the text reply still goes out. The now-dead `is None` guards and the disabled-client test were removed.

## Tests

- Adds a `_fake_uploader` test helper that seeds the `cached_property` cache so the upload path runs against the fake client.
- Drops the obsolete None-client cases; the upload-failure path stays covered by the existing "upload raises" test.
- Full suite green; `pre-commit` (ruff + mypy + secrets) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)