### PR TITLE
feat: add openai file uploader

### DIFF
--- a/src/discordbot/cogs/_gen_reply/attachment/openai_file_api.py
+++ b/src/discordbot/cogs/_gen_reply/attachment/openai_file_api.py
@@ -1,0 +1,170 @@
+"""OpenAI Files API attachment renderer for OpenAI answer models.
+
+Uploads attachment bytes through the OpenAI SDK and references the returned file id in
+Responses API content parts. Kept disabled in `select.py` until the OpenAI model path is
+ready to rely on uploaded files instead of inline parts.
+"""
+
+import io
+from typing import TYPE_CHECKING
+import asyncio
+from datetime import UTC, datetime, timedelta
+from functools import cached_property
+from collections import OrderedDict
+
+from openai import AsyncOpenAI
+import logfire
+from nextcord import Attachment, StickerItem
+from pydantic import Field, PrivateAttr, SkipValidation
+from openai.types.responses.response_input_file_param import ResponseInputFileParam
+from openai.types.responses.response_input_image_param import ResponseInputImageParam
+
+from discordbot.utils.llm import create_litellm_client
+from discordbot.typings.llm import LLMConfig
+from discordbot.cogs._gen_reply.attachment.base import RenderedPart, AttachmentRenderer
+from discordbot.cogs._gen_reply.attachment.loaders import (
+    attachment_mime,
+    load_image_bytes,
+    load_attachment_bytes,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Awaitable
+
+type FileBytesLoader = Callable[[], Awaitable[tuple[bytes, str]]]
+
+DEAD_SOURCE_TTL = timedelta(minutes=30)
+MEDIA_CONCURRENCY = 8
+OPENAI_FILE_EXPIRY_SECONDS = 2_592_000
+
+
+class OpenAIFileUploader(AttachmentRenderer):
+    """Uploads attachments to OpenAI Files API and references them by file id.
+
+    Attributes:
+        config: Runtime LLM config supplying the OpenAI-compatible client settings.
+    """
+
+    config: LLMConfig = Field(
+        default_factory=LLMConfig,
+        description="Runtime LLM config supplying the OpenAI-compatible file upload client.",
+    )
+    _dead_sources: OrderedDict[int | str, datetime] = PrivateAttr(default_factory=OrderedDict)
+    _media_semaphore: SkipValidation[asyncio.Semaphore] = PrivateAttr(
+        default_factory=lambda: asyncio.Semaphore(MEDIA_CONCURRENCY)
+    )
+
+    @cached_property
+    def client(self) -> AsyncOpenAI:
+        """The OpenAI-compatible client used for Files API uploads."""
+        return create_litellm_client(config=self.config)
+
+    async def render_image(
+        self,
+        source: Attachment | StickerItem | str,
+        cache_key: int | str,
+        allow_dead_cache: bool = False,
+    ) -> tuple[RenderedPart, datetime] | None:
+        if isinstance(source, str):
+            source_name = "image"
+        else:
+            source_name = (
+                getattr(source, "filename", None) or f"{getattr(source, 'name', 'sticker')}.png"
+            )
+        uploaded = await self._resolve_file_upload(
+            cache_key=cache_key,
+            filename=source_name,
+            load_data=lambda: load_image_bytes(source=source),
+            allow_dead_cache=allow_dead_cache,
+        )
+        if uploaded is None:
+            return None
+        file_id, expires_at = uploaded
+        part = ResponseInputImageParam(type="input_image", file_id=file_id, detail="auto")
+        return part, expires_at
+
+    async def render_file(
+        self, attachment: Attachment, cache_key: int | str, allow_dead_cache: bool = False
+    ) -> tuple[RenderedPart, datetime] | None:
+        mime_type = attachment_mime(attachment=attachment)
+        if not mime_type:
+            logfire.warn(
+                f"Skipping attachment with unknown MIME type: {attachment.filename} ({attachment.url})"
+            )
+            return None
+        uploaded = await self._resolve_file_upload(
+            cache_key=cache_key,
+            filename=attachment.filename,
+            load_data=lambda: load_attachment_bytes(attachment=attachment),
+            allow_dead_cache=allow_dead_cache,
+        )
+        if uploaded is None:
+            return None
+        file_id, expires_at = uploaded
+        part = ResponseInputFileParam(
+            type="input_file", file_id=file_id, filename=attachment.filename
+        )
+        return part, expires_at
+
+    def _is_known_dead(self, cache_key: int | str) -> bool:
+        """Whether a source's fetch failed recently enough to skip re-fetching it."""
+        dead_at = self._dead_sources.get(cache_key)
+        if dead_at is None:
+            return False
+        if datetime.now(tz=UTC) - dead_at < DEAD_SOURCE_TTL:
+            self._dead_sources.move_to_end(cache_key)
+            return True
+        self._dead_sources.pop(cache_key, None)
+        return False
+
+    def _mark_dead(self, cache_key: int | str) -> None:
+        """Records a source's fetch failure so history scrollback stays cheap."""
+        self._dead_sources[cache_key] = datetime.now(tz=UTC)
+        self._dead_sources.move_to_end(cache_key)
+        if len(self._dead_sources) > 128:
+            self._dead_sources.popitem(last=False)
+
+    async def _resolve_file_upload(
+        self,
+        cache_key: int | str,
+        filename: str,
+        load_data: "FileBytesLoader",
+        allow_dead_cache: bool = False,
+    ) -> tuple[str, datetime] | None:
+        """Returns an uploaded OpenAI file id and its cache expiry."""
+        if allow_dead_cache and self._is_known_dead(cache_key=cache_key):
+            return None
+        async with self._media_semaphore:
+            try:
+                data, content_type = await load_data()
+            except Exception:
+                logfire.warn(f"Failed to load attachment bytes for upload: {filename}")
+                if allow_dead_cache:
+                    self._mark_dead(cache_key=cache_key)
+                return None
+            return await self._upload_file(filename=filename, data=data, content_type=content_type)
+
+    async def _upload_file(
+        self, filename: str, data: bytes, content_type: str
+    ) -> tuple[str, datetime] | None:
+        """Uploads bytes to OpenAI Files API and returns `(file_id, expires_at)`."""
+        try:
+            uploaded = await self.client.files.create(
+                file=(filename, io.BytesIO(data), content_type),
+                purpose="user_data",
+                expires_after={"anchor": "created_at", "seconds": OPENAI_FILE_EXPIRY_SECONDS},
+            )
+        except Exception:
+            logfire.warn(f"Failed to upload attachment to OpenAI Files API: {filename}")
+            return None
+        if uploaded.status == "error":
+            logfire.warn(f"OpenAI file upload failed processing: {filename}")
+            return None
+        if not uploaded.id:
+            logfire.warn(f"OpenAI file upload returned no file id; dropping: {filename}")
+            return None
+        if uploaded.expires_at is None:
+            expires_at = datetime.now(tz=UTC) + timedelta(seconds=OPENAI_FILE_EXPIRY_SECONDS)
+        else:
+            expires_at = datetime.fromtimestamp(uploaded.expires_at, tz=UTC)
+        return uploaded.id, expires_at

--- a/src/discordbot/cogs/_gen_reply/attachment/select.py
+++ b/src/discordbot/cogs/_gen_reply/attachment/select.py
@@ -4,6 +4,8 @@ from discordbot.cogs._gen_reply.attachment.base import AttachmentRenderer
 from discordbot.cogs._gen_reply.attachment.inline import InlineRenderer
 from discordbot.cogs._gen_reply.attachment.gemini_file_api import GeminiFileUploader
 
+# from discordbot.cogs._gen_reply.attachment.openai_file_api import OpenAIFileUploader
+
 
 def build_attachment_handler(model_name: str) -> AttachmentRenderer:
     """Returns the attachment renderer matching the answer (slow) model's provider.
@@ -15,4 +17,6 @@ def build_attachment_handler(model_name: str) -> AttachmentRenderer:
     """
     if "gemini" in model_name:
         return GeminiFileUploader()
+    # if "gpt" in model_name:
+    #     return OpenAIFileUploader()
     return InlineRenderer()

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -48,11 +48,13 @@ from discordbot.cogs._gen_reply.memory_tool import (
 )
 from discordbot.cogs._memory.server_prompts import SERVER_PHASE1_PROMPT, SERVER_PHASE2_PROMPT
 from discordbot.cogs._gen_reply.attachment.inline import InlineRenderer
+from discordbot.cogs._gen_reply.attachment.select import build_attachment_handler
 from discordbot.cogs._gen_reply.attachment.gemini_file_api import (
     DEAD_SOURCE_TTL,
     PendingUpload,
     GeminiFileUploader,
 )
+from discordbot.cogs._gen_reply.attachment.openai_file_api import OpenAIFileUploader
 
 from tests.helpers.llm_input import (
     request_index,
@@ -468,6 +470,40 @@ class FakeGeminiClient:
         self.aio = SimpleNamespace(files=files or FakeGeminiFiles())
 
 
+class FakeOpenAIFiles:
+    """Fake OpenAI Files API resource that records uploads."""
+
+    def __init__(
+        self,
+        status: str = "uploaded",
+        file_id: str = "file-test",
+        expires_at: int | None = 4_070_908_800,
+    ) -> None:
+        """Initializes fake upload output fields."""
+        self.status = status
+        self.file_id = file_id
+        self.expires_at = expires_at
+        self.create_calls: list[tuple[str, bytes, str, dict[str, object]]] = []
+
+    async def create(
+        self, file: tuple[str, BytesIO, str], purpose: str, expires_after: dict[str, object]
+    ) -> SimpleNamespace:
+        """Records an upload and returns a fake OpenAI file object."""
+        filename, data, content_type = file
+        self.create_calls.append((filename, data.read(), content_type, expires_after))
+        return SimpleNamespace(
+            id=self.file_id, status=self.status, expires_at=self.expires_at, purpose=purpose
+        )
+
+
+class FakeOpenAIClient:
+    """Fake OpenAI client exposing the async Files API used by OpenAIFileUploader."""
+
+    def __init__(self, files: FakeOpenAIFiles | None = None) -> None:
+        """Initializes the file resource."""
+        self.files = files or FakeOpenAIFiles()
+
+
 class FakeClient:
     """Fake OpenAI client with responses, images, and videos resources."""
 
@@ -494,6 +530,13 @@ def _fake_uploader(files: FakeGeminiFiles | None = None) -> GeminiFileUploader:
     """
     uploader = GeminiFileUploader()
     uploader.__dict__["gemini_client"] = FakeGeminiClient(files=files)
+    return uploader
+
+
+def _fake_openai_uploader(files: FakeOpenAIFiles | None = None) -> OpenAIFileUploader:
+    """An OpenAIFileUploader with its lazy client pre-seeded to a fake."""
+    uploader = OpenAIFileUploader()
+    uploader.__dict__["client"] = FakeOpenAIClient(files=files)
     return uploader
 
 
@@ -1373,6 +1416,73 @@ async def test_resolve_file_upload_recovers_pending_on_next_reference(
     assert "vid" not in uploader._pending_uploads
     assert files.upload_calls == [("v.mp4", "video/mp4")]  # no second upload
     assert load_calls == 1  # adopt path did not re-download the source
+
+
+async def test_openai_file_uploader_renders_image_and_file_parts() -> None:
+    """OpenAI uploads return file-id content parts for images and files."""
+    files = FakeOpenAIFiles()
+    renderer = _fake_openai_uploader(files=files)
+
+    image_rendered = await renderer.render_image(
+        source=FakeAttachment(
+            filename="pic.png", content_type="image/png", payload=base64.b64decode(_png_b64())
+        ),
+        cache_key="pic.png",
+    )
+    assert image_rendered is not None
+    image_part, image_expiry = image_rendered
+    assert image_part["type"] == "input_image"
+    assert image_part["file_id"] == "file-test"
+    assert image_part["detail"] == "auto"
+    assert image_expiry == datetime(2099, 1, 1, tzinfo=UTC)
+
+    file_rendered = await renderer.render_file(
+        attachment=FakeAttachment(
+            filename="notes.txt", content_type="text/plain", payload=b"hello world"
+        ),
+        cache_key="notes.txt",
+    )
+    assert file_rendered is not None
+    file_part, file_expiry = file_rendered
+    assert file_part["type"] == "input_file"
+    assert file_part["file_id"] == "file-test"
+    assert file_part["filename"] == "notes.txt"
+    assert file_expiry == datetime(2099, 1, 1, tzinfo=UTC)
+
+    assert files.create_calls[0][0] == "pic.png"
+    assert files.create_calls[0][2] == "image/jpeg"
+    assert files.create_calls[0][3] == {"anchor": "created_at", "seconds": 2_592_000}
+    assert files.create_calls[1] == (
+        "notes.txt",
+        b"hello world",
+        "text/plain",
+        {"anchor": "created_at", "seconds": 2_592_000},
+    )
+
+
+async def test_openai_file_uploader_drops_failed_uploads(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OpenAI upload errors degrade to a dropped attachment."""
+    errored = _fake_openai_uploader(files=FakeOpenAIFiles(status="error"))
+    assert (
+        await errored._upload_file(filename="bad.txt", data=b"x", content_type="text/plain")
+        is None
+    )
+
+    boom = _fake_openai_uploader(files=FakeOpenAIFiles())
+
+    async def _raise(
+        file: tuple[str, BytesIO, str], purpose: str, expires_after: dict[str, object]
+    ) -> SimpleNamespace:
+        del file, purpose, expires_after
+        raise RuntimeError("upload failed")
+
+    monkeypatch.setattr(boom.client.files, "create", _raise)
+    assert await boom._upload_file(filename="x.txt", data=b"x", content_type="text/plain") is None
+
+
+def test_gpt_attachment_handler_path_stays_disabled() -> None:
+    """GPT models still use inline attachments until the OpenAI uploader branch is enabled."""
+    assert isinstance(build_attachment_handler(model_name="gpt-5.1"), InlineRenderer)
 
 
 async def test_non_gemini_answer_model_inlines_attachments() -> None:


### PR DESCRIPTION
## Summary
- Add an OpenAI Files API attachment renderer that uploads images and files through the existing OpenAI-compatible SDK client.
- Return Responses API `input_image` or `input_file` parts backed by uploaded `file_id` handles.
- Add the GPT/OpenAI selector branch in `build_attachment_handler` as commented code only, so runtime behavior stays unchanged.

## Tests
- `uv run pytest tests/test_gen_reply.py --no-cov`
- `uv run pre-commit run -a`
- `uvx pre-commit run -a`
- `uv run pytest`