### PR TITLE
fix: route openai file uploads

### DIFF
--- a/src/discordbot/cogs/_gen_reply/attachment/openai_file_api.py
+++ b/src/discordbot/cogs/_gen_reply/attachment/openai_file_api.py
@@ -6,7 +6,7 @@ ready to rely on uploaded files instead of inline parts.
 """
 
 import io
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 import asyncio
 from datetime import UTC, datetime, timedelta
 from functools import cached_property
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Awaitable
 
 type FileBytesLoader = Callable[[], Awaitable[tuple[bytes, str]]]
+type OpenAIFilePurpose = Literal["user_data", "vision"]
 
 DEAD_SOURCE_TTL = timedelta(minutes=30)
 MEDIA_CONCURRENCY = 8
@@ -43,8 +44,10 @@ class OpenAIFileUploader(AttachmentRenderer):
 
     Attributes:
         config: Runtime LLM config supplying the OpenAI-compatible client settings.
+        model_name: Selected answer model name used by LiteLLM to route file uploads.
     """
 
+    model_name: str = Field(description="Selected answer model name for LiteLLM file routing.")
     config: LLMConfig = Field(
         default_factory=LLMConfig,
         description="Runtime LLM config supplying the OpenAI-compatible file upload client.",
@@ -66,7 +69,7 @@ class OpenAIFileUploader(AttachmentRenderer):
         allow_dead_cache: bool = False,
     ) -> tuple[RenderedPart, datetime] | None:
         if isinstance(source, str):
-            source_name = "image"
+            source_name = "image.jpg"
         else:
             source_name = (
                 getattr(source, "filename", None) or f"{getattr(source, 'name', 'sticker')}.png"
@@ -75,6 +78,7 @@ class OpenAIFileUploader(AttachmentRenderer):
             cache_key=cache_key,
             filename=source_name,
             load_data=lambda: load_image_bytes(source=source),
+            purpose="vision",
             allow_dead_cache=allow_dead_cache,
         )
         if uploaded is None:
@@ -96,6 +100,7 @@ class OpenAIFileUploader(AttachmentRenderer):
             cache_key=cache_key,
             filename=attachment.filename,
             load_data=lambda: load_attachment_bytes(attachment=attachment),
+            purpose="user_data",
             allow_dead_cache=allow_dead_cache,
         )
         if uploaded is None:
@@ -129,6 +134,7 @@ class OpenAIFileUploader(AttachmentRenderer):
         cache_key: int | str,
         filename: str,
         load_data: "FileBytesLoader",
+        purpose: OpenAIFilePurpose,
         allow_dead_cache: bool = False,
     ) -> tuple[str, datetime] | None:
         """Returns an uploaded OpenAI file id and its cache expiry."""
@@ -142,17 +148,20 @@ class OpenAIFileUploader(AttachmentRenderer):
                 if allow_dead_cache:
                     self._mark_dead(cache_key=cache_key)
                 return None
-            return await self._upload_file(filename=filename, data=data, content_type=content_type)
+            return await self._upload_file(
+                filename=filename, data=data, content_type=content_type, purpose=purpose
+            )
 
     async def _upload_file(
-        self, filename: str, data: bytes, content_type: str
+        self, filename: str, data: bytes, content_type: str, purpose: OpenAIFilePurpose
     ) -> tuple[str, datetime] | None:
         """Uploads bytes to OpenAI Files API and returns `(file_id, expires_at)`."""
         try:
             uploaded = await self.client.files.create(
                 file=(filename, io.BytesIO(data), content_type),
-                purpose="user_data",
+                purpose=purpose,
                 expires_after={"anchor": "created_at", "seconds": OPENAI_FILE_EXPIRY_SECONDS},
+                extra_body={"model": self.model_name},
             )
         except Exception:
             logfire.warn(f"Failed to upload attachment to OpenAI Files API: {filename}")

--- a/src/discordbot/cogs/_gen_reply/attachment/select.py
+++ b/src/discordbot/cogs/_gen_reply/attachment/select.py
@@ -18,5 +18,5 @@ def build_attachment_handler(model_name: str) -> AttachmentRenderer:
     if "gemini" in model_name:
         return GeminiFileUploader()
     # if "gpt" in model_name:
-    #     return OpenAIFileUploader()
+    #     return OpenAIFileUploader(model_name=model_name)
     return InlineRenderer()

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -483,14 +483,27 @@ class FakeOpenAIFiles:
         self.status = status
         self.file_id = file_id
         self.expires_at = expires_at
-        self.create_calls: list[tuple[str, bytes, str, dict[str, object]]] = []
+        self.create_calls: list[
+            tuple[str, bytes, str, str, dict[str, object], dict[str, object] | None]
+        ] = []
 
     async def create(
-        self, file: tuple[str, BytesIO, str], purpose: str, expires_after: dict[str, object]
+        self,
+        file: tuple[str, BytesIO, str],
+        purpose: str,
+        expires_after: dict[str, object],
+        extra_body: dict[str, object] | None = None,
     ) -> SimpleNamespace:
         """Records an upload and returns a fake OpenAI file object."""
         filename, data, content_type = file
-        self.create_calls.append((filename, data.read(), content_type, expires_after))
+        self.create_calls.append((
+            filename,
+            data.read(),
+            content_type,
+            purpose,
+            expires_after,
+            extra_body,
+        ))
         return SimpleNamespace(
             id=self.file_id, status=self.status, expires_at=self.expires_at, purpose=purpose
         )
@@ -535,7 +548,7 @@ def _fake_uploader(files: FakeGeminiFiles | None = None) -> GeminiFileUploader:
 
 def _fake_openai_uploader(files: FakeOpenAIFiles | None = None) -> OpenAIFileUploader:
     """An OpenAIFileUploader with its lazy client pre-seeded to a fake."""
-    uploader = OpenAIFileUploader()
+    uploader = OpenAIFileUploader(model_name=TEST_LLM_MODEL)
     uploader.__dict__["client"] = FakeOpenAIClient(files=files)
     return uploader
 
@@ -1418,7 +1431,9 @@ async def test_resolve_file_upload_recovers_pending_on_next_reference(
     assert load_calls == 1  # adopt path did not re-download the source
 
 
-async def test_openai_file_uploader_renders_image_and_file_parts() -> None:
+async def test_openai_file_uploader_renders_image_and_file_parts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """OpenAI uploads return file-id content parts for images and files."""
     files = FakeOpenAIFiles()
     renderer = _fake_openai_uploader(files=files)
@@ -1436,6 +1451,16 @@ async def test_openai_file_uploader_renders_image_and_file_parts() -> None:
     assert image_part["detail"] == "auto"
     assert image_expiry == datetime(2099, 1, 1, tzinfo=UTC)
 
+    url = "https://example.test/image.png"
+    monkeypatch.setattr(
+        "discordbot.cogs._gen_reply.attachment.loaders.get_image_data", lambda image_file: b"jpeg"
+    )
+    url_image_rendered = await renderer.render_image(source=url, cache_key=url)
+    assert url_image_rendered is not None
+    url_image_part, _url_image_expiry = url_image_rendered
+    assert url_image_part["type"] == "input_image"
+    assert url_image_part["file_id"] == "file-test"
+
     file_rendered = await renderer.render_file(
         attachment=FakeAttachment(
             filename="notes.txt", content_type="text/plain", payload=b"hello world"
@@ -1451,12 +1476,24 @@ async def test_openai_file_uploader_renders_image_and_file_parts() -> None:
 
     assert files.create_calls[0][0] == "pic.png"
     assert files.create_calls[0][2] == "image/jpeg"
-    assert files.create_calls[0][3] == {"anchor": "created_at", "seconds": 2_592_000}
+    assert files.create_calls[0][3] == "vision"
+    assert files.create_calls[0][4] == {"anchor": "created_at", "seconds": 2_592_000}
+    assert files.create_calls[0][5] == {"model": TEST_LLM_MODEL}
     assert files.create_calls[1] == (
+        "image.jpg",
+        b"jpeg",
+        "image/jpeg",
+        "vision",
+        {"anchor": "created_at", "seconds": 2_592_000},
+        {"model": TEST_LLM_MODEL},
+    )
+    assert files.create_calls[2] == (
         "notes.txt",
         b"hello world",
         "text/plain",
+        "user_data",
         {"anchor": "created_at", "seconds": 2_592_000},
+        {"model": TEST_LLM_MODEL},
     )
 
 
@@ -1464,20 +1501,30 @@ async def test_openai_file_uploader_drops_failed_uploads(monkeypatch: pytest.Mon
     """OpenAI upload errors degrade to a dropped attachment."""
     errored = _fake_openai_uploader(files=FakeOpenAIFiles(status="error"))
     assert (
-        await errored._upload_file(filename="bad.txt", data=b"x", content_type="text/plain")
+        await errored._upload_file(
+            filename="bad.txt", data=b"x", content_type="text/plain", purpose="user_data"
+        )
         is None
     )
 
     boom = _fake_openai_uploader(files=FakeOpenAIFiles())
 
     async def _raise(
-        file: tuple[str, BytesIO, str], purpose: str, expires_after: dict[str, object]
+        file: tuple[str, BytesIO, str],
+        purpose: str,
+        expires_after: dict[str, object],
+        extra_body: dict[str, object] | None = None,
     ) -> SimpleNamespace:
-        del file, purpose, expires_after
+        del file, purpose, expires_after, extra_body
         raise RuntimeError("upload failed")
 
     monkeypatch.setattr(boom.client.files, "create", _raise)
-    assert await boom._upload_file(filename="x.txt", data=b"x", content_type="text/plain") is None
+    assert (
+        await boom._upload_file(
+            filename="x.txt", data=b"x", content_type="text/plain", purpose="user_data"
+        )
+        is None
+    )
 
 
 def test_gpt_attachment_handler_path_stays_disabled() -> None:


### PR DESCRIPTION
## Summary
- Upload OpenAI image attachments with the `vision` purpose and non-image files with `user_data`.
- Preserve a `.jpg` filename for URL-sourced image uploads.
- Pass the selected LiteLLM model through OpenAI Files API upload requests for routing.

## Tests
- `uv run pytest tests/test_gen_reply.py -k "openai_file_uploader or gpt_attachment_handler" --no-cov`
- `uv run pre-commit run -a`
- `uv run pytest`
