### PR TITLE
refactor(llm): inline proxy call kwargs instead of a spread helper

### DIFF
--- a/src/discordbot/cogs/gen_reply.py
+++ b/src/discordbot/cogs/gen_reply.py
@@ -19,7 +19,7 @@ from openai.types.responses.response_input_param import ResponseInputParam, Easy
 from openai.types.responses.response_input_text_param import ResponseInputTextParam
 from openai.types.responses.response_input_image_param import ResponseInputImageParam
 
-from discordbot.utils.llm import litellm_call_kwargs, create_litellm_client
+from discordbot.utils.llm import create_litellm_client
 from discordbot.typings.llm import LLMConfig
 from discordbot.utils.images import convert_base64_to_data_uri
 from discordbot.typings.models import EffortGrade, RouteClassification, RuntimeModelCatalog
@@ -73,7 +73,6 @@ from discordbot.cogs._gen_reply.attachment.select import build_attachment_handle
 if TYPE_CHECKING:
     from collections.abc import Awaitable
 
-    from openai.types.responses import ResponseFunctionToolCall
     from openai.types.responses.response_input_file_param import ResponseInputFileParam
 
 
@@ -467,7 +466,9 @@ class ReplyGeneratorCogs(commands.Cog):
                     input=cast("ResponseInputParam", director_input),
                     reasoning=prompt_model.reasoning,
                     tools=list(prompt_model.tools),
-                    **litellm_call_kwargs(end_user_id=end_user_id),
+                    service_tier="auto",
+                    extra_headers={"x-litellm-end-user-id": end_user_id},
+                    extra_body={"mock_testing_fallbacks": False},
                 )
             refined = (responses.output_text or "").strip()
         except Exception:
@@ -579,7 +580,9 @@ class ReplyGeneratorCogs(commands.Cog):
                 instructions=DESCRIPTION_PROMPT,
                 input=cast("ResponseInputParam", image_description_input),
                 reasoning=fast_model.reasoning,
-                **litellm_call_kwargs(end_user_id=message.author.name),
+                service_tier="auto",
+                extra_headers={"x-litellm-end-user-id": message.author.name},
+                extra_body={"mock_testing_fallbacks": False},
             )
             image_description = (image_responses.output_text or "").strip()
         except Exception:
@@ -646,7 +649,9 @@ class ReplyGeneratorCogs(commands.Cog):
                     input=cast("ResponseInputParam", message_list),
                     text_format=RouteClassification,
                     reasoning=route_model.reasoning,
-                    **litellm_call_kwargs(end_user_id=message.author.name),
+                    service_tier="auto",
+                    extra_headers={"x-litellm-end-user-id": message.author.name},
+                    extra_body={"mock_testing_fallbacks": False},
                 )
             parsed = responses.output_parsed
             if parsed is None:
@@ -697,7 +702,9 @@ class ReplyGeneratorCogs(commands.Cog):
                 input=cast("ResponseInputParam", message_list),
                 text_format=EffortGrade,
                 reasoning=effort_model.reasoning,
-                **litellm_call_kwargs(end_user_id=message.author.name),
+                service_tier="auto",
+                extra_headers={"x-litellm-end-user-id": message.author.name},
+                extra_body={"mock_testing_fallbacks": False},
             )
         parsed = responses.output_parsed
         grade = parsed if parsed is not None else EffortGrade(effort="high")
@@ -765,18 +772,19 @@ class ReplyGeneratorCogs(commands.Cog):
             reasoning=tool_model.reasoning,
             tools=[GET_USER_MEMORY_TOOL],
             stream=False,
-            **litellm_call_kwargs(end_user_id=message.author.name),
+            service_tier="auto",
+            extra_headers={"x-litellm-end-user-id": message.author.name},
+            extra_body={"mock_testing_fallbacks": False},
         )
         memories: list[UserMemory] = []
         seen: set[str] = set()
         for item in responses.output:
             if item.type != "function_call":
                 continue
-            call = cast("ResponseFunctionToolCall", item)
-            if call.name != "get_user_memory":
+            if item.name != "get_user_memory":
                 continue
             for memory in resolve_user_memories(
-                user_id_list=parse_user_id_list(arguments=call.arguments), allowed=allowed
+                user_id_list=parse_user_id_list(arguments=item.arguments), allowed=allowed
             ):
                 if memory.user_id not in seen:
                     seen.add(memory.user_id)
@@ -1070,7 +1078,9 @@ class ReplyGeneratorCogs(commands.Cog):
                 reasoning=slow_model.reasoning,
                 tools=list(slow_model.tools),
                 stream=True,
-                **litellm_call_kwargs(end_user_id=message.author.name),
+                service_tier="auto",
+                extra_headers={"x-litellm-end-user-id": message.author.name},
+                extra_body={"mock_testing_fallbacks": False},
             )
             full_reply = await streamer.stream(responses=responses)
         if memory_enabled:

--- a/src/discordbot/utils/llm.py
+++ b/src/discordbot/utils/llm.py
@@ -1,6 +1,6 @@
 """Factories for the runtime LiteLLM-proxy OpenAI client and the Gemini upload client."""
 
-from typing import Any, cast
+from typing import cast
 import asyncio
 
 from google import genai
@@ -11,23 +11,6 @@ from openai.types.responses.response_input_param import ResponseInputParam, Easy
 
 from discordbot.typings.llm import LLMConfig
 from discordbot.typings.models import ModelSettings
-
-
-def litellm_call_kwargs(end_user_id: str) -> dict[str, Any]:
-    """Returns the shared kwargs every runtime Responses call passes to the LiteLLM proxy.
-
-    Centralizes the auto service tier, the per-end-user header LiteLLM keys spend and
-    rate-limit tracking on, and the flag that disables the proxy's mock fallbacks, so a
-    proxy-wide change lives here instead of being re-typed at every `responses.*` call site.
-    Spread it as `**litellm_call_kwargs(end_user_id=...)` next to the per-call model,
-    instructions, input, and reasoning. Returns a fresh dict each call so a caller can never
-    mutate shared state.
-    """
-    return {
-        "service_tier": "auto",
-        "extra_headers": {"x-litellm-end-user-id": end_user_id},
-        "extra_body": {"mock_testing_fallbacks": False},
-    }
 
 
 async def parse_responses_or_none[StructuredT: BaseModel](  # noqa: PLR0913 -- shared best-effort call surface; all params are per-call inputs
@@ -42,10 +25,10 @@ async def parse_responses_or_none[StructuredT: BaseModel](  # noqa: PLR0913 -- s
 ) -> StructuredT | None:
     """Runs one best-effort structured Responses.parse call, returning None on any failure.
 
-    Owns the shared call surface (`litellm_call_kwargs`), the timeout, and the failure
-    handling so each caller only maps None to its own fallback: a timeout, an empty or
-    refused output (`ValidationError` from parsing no text), an incomplete (truncated)
-    response, or any other error all degrade to None.
+    Owns the shared proxy call surface, the timeout, and the failure handling so each caller
+    only maps None to its own fallback: a timeout, an empty or refused output
+    (`ValidationError` from parsing no text), an incomplete (truncated) response, or any
+    other error all degrade to None.
     """
     try:
         async with asyncio.timeout(delay=timeout_seconds):
@@ -57,7 +40,9 @@ async def parse_responses_or_none[StructuredT: BaseModel](  # noqa: PLR0913 -- s
                 ),
                 text_format=text_format,
                 reasoning=model.reasoning,
-                **litellm_call_kwargs(end_user_id=end_user_id),
+                service_tier="auto",
+                extra_headers={"x-litellm-end-user-id": end_user_id},
+                extra_body={"mock_testing_fallbacks": False},
             )
     except TimeoutError:
         logfire.warn(
@@ -95,9 +80,9 @@ async def create_text_or_none(  # noqa: PLR0913 -- shared best-effort call surfa
 ) -> str | None:
     """Runs one best-effort text Responses.create call, returning None on any failure.
 
-    Mirrors `parse_responses_or_none` for the non-structured callers: owns the shared call
-    surface, the timeout, and the failure handling, and returns the trimmed output text (or
-    None on timeout / any error) so each caller maps None to its own fallback line.
+    Mirrors `parse_responses_or_none` for the non-structured callers: owns the shared proxy
+    call surface, the timeout, and the failure handling, and returns the trimmed output text
+    (or None on timeout / any error) so each caller maps None to its own fallback line.
     """
     try:
         async with asyncio.timeout(delay=timeout_seconds):
@@ -108,7 +93,9 @@ async def create_text_or_none(  # noqa: PLR0913 -- shared best-effort call surfa
                     "ResponseInputParam", [EasyInputMessageParam(role="user", content=user_text)]
                 ),
                 reasoning=model.reasoning,
-                **litellm_call_kwargs(end_user_id=end_user_id),
+                service_tier="auto",
+                extra_headers={"x-litellm-end-user-id": end_user_id},
+                extra_body={"mock_testing_fallbacks": False},
             )
     except TimeoutError:
         logfire.warn(


### PR DESCRIPTION
## Why

`litellm_call_kwargs(end_user_id)` returned `dict[str, Any]` and was spread as `**litellm_call_kwargs(...)` into `client.responses.create` / `client.responses.parse`. Those SDK methods are heavily `@overload`ed (`stream=True`/`stream=False`, structured `text_format`, etc.), so spreading an untyped dict prevented the type checker from resolving an overload and degraded the whole call to `Any`. That cascaded onto `responses.output_text` / `output_parsed` / `output` and the streamer, and made the linter flag the call surface.

## What

- Remove the `litellm_call_kwargs` helper from `utils/llm.py`.
- Pass `service_tier`, `extra_headers`, `extra_body` as explicit named arguments at each Responses call site (2 in `utils/llm.py`, 6 in `cogs/gen_reply.py`). These are real SDK parameters, so overloads now resolve and return types are concrete again.
- Drop a now-redundant `cast("ResponseFunctionToolCall", ...)` in `_select_user_memories` (and its unused import): with the call result properly typed, the discriminated-union narrowing on `item.type` is enough.

## Trade-off

This gives up the single-point-of-change centralization in exchange for type correctness, as requested. The proxy kwargs are identical literals at every site, constructed fresh per call (same semantics as before).

## Verification

- `uv run pre-commit run -a` — ruff + mypy clean (exit 0).
- `uv run pytest` — 850 passed; existing fake `create`/`parse` mocks already declare the named params, so no test changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)