### PR TITLE
feat(memory): exclude personal-attack labels from stored memory

### DIFF
--- a/src/discordbot/cogs/_memory/prompts.py
+++ b/src/discordbot/cogs/_memory/prompts.py
@@ -45,12 +45,13 @@ WHAT NOT TO REMEMBER:
 * The bot's own suggestions or jokes, unless the user clearly adopted them.
 * Long verbatim copies of messages.
 * Display names as facts; only record a name or nickname the user explicitly asked to be called.
+* Personal-attack labels and slurs aimed at a person — the user, the bot, or anyone else (e.g. 廢物 / 白嫖仔 / 傻逼 / 狗逼). Recording that the user gives or enjoys harsh, profane banter IS in scope, but state it as a general tolerance or style ("偏好高強度的粗口互嗆"); never reproduce, list, or quote the specific demeaning labels themselves.
 
 EVIDENCE RULES:
 * User messages are the primary evidence. Read much more into user messages than bot replies.
 * Stable preferences and stable interests require explicit target-user evidence: repeated behavior, a correction, enforcement, or a direct statement of preference.
 * A single joke, hypothetical, one-time mood, or one-time topic mention is not a stable preference or interest.
-* Preserve one short verbatim fragment in `evidence_quote` when possible.
+* Preserve one short verbatim fragment in `evidence_quote` when possible, but never choose a fragment that is itself a personal attack or slur; pick neutral wording, paraphrase it, or omit the quote instead.
 * Use `normalized_key` as a stable dedupe key, e.g. `preference.reply_language.zh_tw` or `recent.project.discordbot_memory`.
 
 SAFETY:
@@ -73,6 +74,7 @@ Bias:
 * Do not promote a one-off mention into an interest.
 * Do not treat a request for a friend, a hypothetical, an example, a joke, or another participant's message as the target user's preference.
 * Do not preserve duplicate observations. Keep the clearest version for each `normalized_key`.
+* Strip personal-attack labels and slurs from any observation you keep: preserve the behavioral signal (e.g. high tolerance for profane banter) but remove the specific demeaning labels, and drop any `evidence_quote` whose content is itself an insult.
 
 Promotion rules:
 * Stable preferences, stable facts, interaction style, and recurring patterns need high confidence and target-user evidence.
@@ -107,6 +109,7 @@ HOW TO MERGE:
 * For `recent_context`, use the raw entry timestamp plus `ttl_days` against `today`; drop expired context unless newer evidence repeats it or clearly promotes it into durable memory.
 * Treat existing memory as provisional. Drop or demote existing bullets that are only supported by weak, one-off, casual, hypothetical, bot-originated, or misattributed evidence.
 * Structured raw entries include `promotion_eligible`, `confidence`, `durability`, `evidence_kind`, `ttl_days`, and `normalized_key`; use these fields as hard evidence gates, not decorative metadata.
+* Never carry personal-attack labels or slurs into the consolidated file: keep the interaction-style signal (tolerance for harsh, profane banter) as a general statement, but do not reproduce, list, or quote the specific demeaning labels aimed at the user, the bot, or anyone, and rephrase any existing bullet that still does.
 
 SIZE AND FORMAT:
 * There is no hard length target. Never sacrifice well-supported durable preferences or facts for brevity; unsupported or weak items should be dropped, not preserved.

--- a/src/discordbot/cogs/_memory/server_prompts.py
+++ b/src/discordbot/cogs/_memory/server_prompts.py
@@ -58,11 +58,12 @@ WHAT NOT TO REMEMBER:
 * The bot's own suggestions or jokes, unless the community adopted them.
 * Personal or private information about any individual member.
 * Long verbatim copies of messages.
+* Personal-attack labels and slurs aimed at a person — any member, the bot, or anyone else (e.g. 廢物 / 白嫖仔 / 傻逼 / 狗逼). Recording the community's tolerance for harsh, profane banter IS in scope, but state it as a general culture trait ("社群慣於高強度的粗口互嗆"); never reproduce, list, or quote the specific demeaning labels. This does NOT apply to the `## 成員稱呼` alias table, which holds community-used nicknames, not attacks.
 
 EVIDENCE RULES:
 * A recurring community pattern requires evidence that it recurs across the conversation, not a single instance.
 * A single joke, hypothetical, or one-time topic mention is not a stable community trait.
-* Preserve one short verbatim fragment in `evidence_quote` when possible.
+* Preserve one short verbatim fragment in `evidence_quote` when possible, but never choose a fragment that is itself a personal attack or slur; pick neutral wording, paraphrase it, or omit the quote instead.
 * Use `normalized_key` as a stable dedupe key, e.g. `culture.banter_tolerance.high` or `recent.event.server_tournament`.
 
 SAFETY:
@@ -86,6 +87,7 @@ Bias:
 * Do not keep anything that is really a personal fact about one individual member; that belongs to per-user memory, not server memory.
 * EXCEPTION: a member's commonly-used community nickname/alias (the name↔member mapping with its `[id: USER_ID]`) IS community vocabulary and should be kept; only the member's actual personal facts are dropped.
 * Do not preserve duplicate observations. Keep the clearest version for each `normalized_key`.
+* Strip personal-attack labels and slurs from any observation you keep: preserve the behavioral signal (e.g. the community's tolerance for profane banter) but remove the specific demeaning labels, and drop any `evidence_quote` whose content is itself an insult.
 
 Promotion rules:
 * Community culture, recurring topics, server norms, and stable server facts need high confidence and evidence that they characterize the server as a whole.
@@ -119,6 +121,7 @@ HOW TO MERGE:
 * For `recent_context`, use the raw entry timestamp plus `ttl_days` against `today`; drop expired context unless newer evidence repeats it.
 * Treat existing memory as provisional. Drop or demote bullets supported only by weak, one-off, casual, hypothetical, bot-originated, or individual-scoped evidence.
 * Structured raw entries include `promotion_eligible`, `confidence`, `durability`, `evidence_kind`, `ttl_days`, and `normalized_key`; use these fields as hard evidence gates, not decorative metadata.
+* Never carry personal-attack labels or slurs into the consolidated file: keep the culture signal (the community's tolerance for harsh, profane banter) as a general statement, but do not reproduce, list, or quote the specific demeaning labels aimed at any member, the bot, or anyone. This does NOT apply to the `## 成員稱呼` alias table.
 
 SIZE AND FORMAT:
 * There is no hard length target. Never sacrifice well-supported durable community traits for brevity; unsupported or weak items should be dropped, not preserved.


### PR DESCRIPTION
## Summary
- Stop the memory pipeline from recording personal-attack labels and slurs (e.g. 廢物 / 白嫖仔 / 傻逼 / 狗逼) in extracted, evaluated, and consolidated memory, for both per-user and per-server memory.
- The interaction-style signal (a user's or community's tolerance for harsh, profane banter) is still recorded, but stated as a general trait instead of reproducing the specific demeaning labels.
- The `## 成員稱呼` community alias table is explicitly out of scope.

## Changes
- `cogs/_memory/prompts.py`: add rules to PHASE1 extraction (what-not-to-remember and evidence_quote), the PHASE1 evaluator, and PHASE2 consolidation.
- `cogs/_memory/server_prompts.py`: mirror the same rules for per-server (community) memory.

## Notes
- Prompts are module-level constants, so the running bot must restart to load the new rules.
- This is a soft, prompt-level constraint, not a deterministic filter.

## Testing
- `uv run pre-commit run --files ...` (ruff, mypy, codespell, secret scan) passed
- `uv run pytest tests/test_memory.py tests/test_server_memory.py` 116 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)