### PR TITLE
feat(gen_reply): add disabled Anthropic Files API attachment renderer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -127,6 +127,7 @@ repos:
           - "Types-urllib3"
           - "openai"
           - "google-genai"
+          - "anthropic"
           - "sqlalchemy[asyncio]"
           - "pydantic-settings"
           - "pillow"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ dependencies = [
     "nextcord[speed,voice]>=3.2.0",
     "openai>=2.30.0",
     "google-genai>=2.7.0",
+    "anthropic>=0.109.2",
     "pillow>=12.2.0",
     "pydantic>=2.12.5",
     "pydantic-settings>=2.13.1",
@@ -95,7 +96,6 @@ update = "discordbot.cli:update"
 
 [dependency-groups]
 dev = [
-    "anthropic",
     "boto3",
     "botocore",
     "google-antigravity",

--- a/src/discordbot/cogs/_gen_reply/attachment/anthropic_file_api.py
+++ b/src/discordbot/cogs/_gen_reply/attachment/anthropic_file_api.py
@@ -64,11 +64,10 @@ class AnthropicFileUploader(AttachmentRenderer):
     def anthropic_client(self) -> AsyncAnthropic:
         """The Anthropic client for direct Files API uploads, built lazily on first use.
 
-        Built here rather than via a shared `utils/llm.py` factory on purpose: `anthropic` is
-        a dev-only dependency today, so keeping the import inside this disabled module keeps it
-        out of the live request-path module graph (`utils/llm.py` is imported there). Promote
-        `anthropic` to a runtime dependency and wire this into `select.py` together. A missing
-        key does not fail construction; it surfaces at the upload call.
+        Built inside this module rather than via a shared `utils/llm.py` factory while the
+        renderer is still disabled in `select.py`: that keeps the `anthropic` import out of the
+        live request-path module graph (`utils/llm.py` is imported there) until the Claude path
+        is wired on. A missing key does not fail construction; it surfaces at the upload call.
 
         Returns:
             An Anthropic client reused across uploads.

--- a/src/discordbot/cogs/_gen_reply/attachment/anthropic_file_api.py
+++ b/src/discordbot/cogs/_gen_reply/attachment/anthropic_file_api.py
@@ -1,0 +1,182 @@
+"""Anthropic Files API attachment renderer for Claude answer models.
+
+Uploads attachment bytes through the Anthropic SDK (a direct side-channel, not the LiteLLM
+proxy) and references the returned file id in Responses API content parts. Kept disabled in
+`select.py` until the proxy's reference-translation path for Claude is verified; today
+non-Gemini answer models inline instead (`InlineRenderer`).
+
+Simpler than the Gemini uploader: Anthropic files are usable the moment `beta.files.upload`
+returns (no PROCESSING/ACTIVE poll) and persist until deleted (no provider expiry), so there
+is no pending-upload re-poll machinery and the render cache uses a fixed synthetic TTL.
+"""
+
+import io
+from typing import TYPE_CHECKING
+import asyncio
+from datetime import UTC, datetime, timedelta
+from functools import cached_property
+from collections import OrderedDict
+
+import logfire
+from nextcord import Attachment, StickerItem
+from pydantic import Field, PrivateAttr, SkipValidation
+from anthropic import AsyncAnthropic
+from openai.types.responses.response_input_file_param import ResponseInputFileParam
+from openai.types.responses.response_input_image_param import ResponseInputImageParam
+
+from discordbot.typings.llm import LLMConfig
+from discordbot.cogs._gen_reply.attachment.base import RenderedPart, AttachmentRenderer
+from discordbot.cogs._gen_reply.attachment.loaders import (
+    attachment_mime,
+    load_image_bytes,
+    load_attachment_bytes,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Awaitable
+
+type FileBytesLoader = Callable[[], Awaitable[tuple[bytes, str]]]
+
+DEAD_SOURCE_TTL = timedelta(minutes=30)
+MEDIA_CONCURRENCY = 8
+# Anthropic Files API entries persist until explicitly deleted (no provider expiry), so the
+# per-message render cache reuses an upload for a fixed window as a cheap CDN-rehost safety net.
+ANTHROPIC_FILE_CACHE_TTL = timedelta(hours=12)
+
+
+class AnthropicFileUploader(AttachmentRenderer):
+    """Uploads attachments to the Anthropic Files API and references them by file id.
+
+    Attributes:
+        config: Runtime LLM config supplying the Anthropic Files API key for the upload client.
+    """
+
+    config: LLMConfig = Field(
+        default_factory=LLMConfig,
+        description="Runtime LLM config supplying the Anthropic Files API upload client key.",
+    )
+    _dead_sources: OrderedDict[int | str, datetime] = PrivateAttr(default_factory=OrderedDict)
+    _media_semaphore: SkipValidation[asyncio.Semaphore] = PrivateAttr(
+        default_factory=lambda: asyncio.Semaphore(MEDIA_CONCURRENCY)
+    )
+
+    @cached_property
+    def anthropic_client(self) -> AsyncAnthropic:
+        """The Anthropic client for direct Files API uploads, built lazily on first use.
+
+        Built here rather than via a shared `utils/llm.py` factory on purpose: `anthropic` is
+        a dev-only dependency today, so keeping the import inside this disabled module keeps it
+        out of the live request-path module graph (`utils/llm.py` is imported there). Promote
+        `anthropic` to a runtime dependency and wire this into `select.py` together. A missing
+        key does not fail construction; it surfaces at the upload call.
+
+        Returns:
+            An Anthropic client reused across uploads.
+        """
+        return AsyncAnthropic(api_key=self.config.anthropic_api_key)
+
+    async def render_image(
+        self,
+        source: Attachment | StickerItem | str,
+        cache_key: int | str,
+        allow_dead_cache: bool = False,
+    ) -> tuple[RenderedPart, datetime] | None:
+        if isinstance(source, str):
+            source_name = "image.jpg"
+        else:
+            source_name = (
+                getattr(source, "filename", None) or f"{getattr(source, 'name', 'sticker')}.png"
+            )
+        uploaded = await self._resolve_file_upload(
+            cache_key=cache_key,
+            filename=source_name,
+            load_data=lambda: load_image_bytes(source=source),
+            allow_dead_cache=allow_dead_cache,
+        )
+        if uploaded is None:
+            return None
+        file_id, expires_at = uploaded
+        part = ResponseInputImageParam(type="input_image", file_id=file_id, detail="auto")
+        return part, expires_at
+
+    async def render_file(
+        self, attachment: Attachment, cache_key: int | str, allow_dead_cache: bool = False
+    ) -> tuple[RenderedPart, datetime] | None:
+        mime_type = attachment_mime(attachment=attachment)
+        if not mime_type:
+            logfire.warn(
+                f"Skipping attachment with unknown MIME type: {attachment.filename} ({attachment.url})"
+            )
+            return None
+        uploaded = await self._resolve_file_upload(
+            cache_key=cache_key,
+            filename=attachment.filename,
+            load_data=lambda: load_attachment_bytes(attachment=attachment),
+            allow_dead_cache=allow_dead_cache,
+        )
+        if uploaded is None:
+            return None
+        file_id, expires_at = uploaded
+        part = ResponseInputFileParam(
+            type="input_file", file_id=file_id, filename=attachment.filename
+        )
+        return part, expires_at
+
+    def _is_known_dead(self, cache_key: int | str) -> bool:
+        """Whether a source's fetch failed recently enough to skip re-fetching it."""
+        dead_at = self._dead_sources.get(cache_key)
+        if dead_at is None:
+            return False
+        if datetime.now(tz=UTC) - dead_at < DEAD_SOURCE_TTL:
+            self._dead_sources.move_to_end(cache_key)
+            return True
+        self._dead_sources.pop(cache_key, None)
+        return False
+
+    def _mark_dead(self, cache_key: int | str) -> None:
+        """Records a source's fetch failure so history scrollback stays cheap."""
+        self._dead_sources[cache_key] = datetime.now(tz=UTC)
+        self._dead_sources.move_to_end(cache_key)
+        if len(self._dead_sources) > 128:
+            self._dead_sources.popitem(last=False)
+
+    async def _resolve_file_upload(
+        self,
+        cache_key: int | str,
+        filename: str,
+        load_data: "FileBytesLoader",
+        allow_dead_cache: bool = False,
+    ) -> tuple[str, datetime] | None:
+        """Returns an uploaded Anthropic file id and its synthetic cache expiry."""
+        if allow_dead_cache and self._is_known_dead(cache_key=cache_key):
+            return None
+        async with self._media_semaphore:
+            try:
+                data, content_type = await load_data()
+            except Exception:
+                logfire.warn(f"Failed to load attachment bytes for upload: {filename}")
+                if allow_dead_cache:
+                    self._mark_dead(cache_key=cache_key)
+                return None
+            return await self._upload_file(filename=filename, data=data, content_type=content_type)
+
+    async def _upload_file(
+        self, filename: str, data: bytes, content_type: str
+    ) -> tuple[str, datetime] | None:
+        """Uploads bytes to the Anthropic Files API and returns `(file_id, expires_at)`.
+
+        The SDK sets the required `files-api-2025-04-14` beta header for `beta.files`
+        automatically. Anthropic files have no provider expiry, so the cache window is a
+        fixed synthetic TTL.
+        """
+        try:
+            uploaded = await self.anthropic_client.beta.files.upload(
+                file=(filename, io.BytesIO(data), content_type)
+            )
+        except Exception:
+            logfire.warn(f"Failed to upload attachment to Anthropic Files API: {filename}")
+            return None
+        if not uploaded.id:
+            logfire.warn(f"Anthropic file upload returned no file id; dropping: {filename}")
+            return None
+        return uploaded.id, datetime.now(tz=UTC) + ANTHROPIC_FILE_CACHE_TTL

--- a/src/discordbot/cogs/_gen_reply/attachment/anthropic_file_api.py
+++ b/src/discordbot/cogs/_gen_reply/attachment/anthropic_file_api.py
@@ -7,7 +7,13 @@ non-Gemini answer models inline instead (`InlineRenderer`).
 
 Simpler than the Gemini uploader: Anthropic files are usable the moment `beta.files.upload`
 returns (no PROCESSING/ACTIVE poll) and persist until deleted (no provider expiry), so there
-is no pending-upload re-poll machinery and the render cache uses a fixed synthetic TTL.
+is no pending-upload re-poll machinery and the render cache uses a fixed synthetic TTL. That
+persistence cuts both ways: the synthetic TTL only evicts the local render cache, never the
+remote file, and Anthropic files never auto-expire (unlike Gemini's ~48h), so enabling this
+renderer needs a deletion / periodic-sweep strategy or active channels accumulate uploads
+toward the org storage quota. Evicting-then-deleting is not enough on its own: a file can
+still be referenced in scrollback after its cache entry is gone, so the cleanup policy is an
+enable-time design decision, not something this disabled scaffold settles.
 """
 
 import io

--- a/src/discordbot/cogs/_gen_reply/attachment/anthropic_file_api.py
+++ b/src/discordbot/cogs/_gen_reply/attachment/anthropic_file_api.py
@@ -14,6 +14,15 @@ renderer needs a deletion / periodic-sweep strategy or active channels accumulat
 toward the org storage quota. Evicting-then-deleting is not enough on its own: a file can
 still be referenced in scrollback after its cache entry is gone, so the cleanup policy is an
 enable-time design decision, not something this disabled scaffold settles.
+
+Reference-path prerequisites before uncommenting the `select.py` branch (the answer request,
+not this renderer, builds the message that cites the file): the answer request must send
+`anthropic-beta: files-api-2025-04-14` when it references an uploaded file, since LiteLLM does
+not auto-add that header for file references; LiteLLM's Anthropic mapper needs the file format,
+not a bare `file_id`, to emit a `document` block rather than a code-execution `container_upload`,
+so PDF / text references must preserve their MIME; and Anthropic document blocks only cover
+PDF / plain text / images, so keep the type narrowing `InlineRenderer` does today (UTF-8 files
+as `input_text`, the rest dropped) instead of uploading every MIME and referencing it blindly.
 """
 
 import io
@@ -170,9 +179,10 @@ class AnthropicFileUploader(AttachmentRenderer):
     ) -> tuple[str, datetime] | None:
         """Uploads bytes to the Anthropic Files API and returns `(file_id, expires_at)`.
 
-        The SDK sets the required `files-api-2025-04-14` beta header for `beta.files`
-        automatically. Anthropic files have no provider expiry, so the cache window is a
-        fixed synthetic TTL.
+        The SDK sets `files-api-2025-04-14` for this upload call automatically; the separate
+        answer request that later references the file must send that beta header itself (see
+        the module docstring). Anthropic files have no provider expiry, so the cache window is
+        a fixed synthetic TTL.
         """
         try:
             uploaded = await self.anthropic_client.beta.files.upload(

--- a/src/discordbot/cogs/_gen_reply/attachment/select.py
+++ b/src/discordbot/cogs/_gen_reply/attachment/select.py
@@ -5,18 +5,23 @@ from discordbot.cogs._gen_reply.attachment.inline import InlineRenderer
 from discordbot.cogs._gen_reply.attachment.gemini_file_api import GeminiFileUploader
 
 # from discordbot.cogs._gen_reply.attachment.openai_file_api import OpenAIFileUploader
+# from discordbot.cogs._gen_reply.attachment.anthropic_file_api import AnthropicFileUploader
 
 
 def build_attachment_handler(model_name: str) -> AttachmentRenderer:
     """Returns the attachment renderer matching the answer (slow) model's provider.
 
     Only Gemini resolves an uploaded Files-API URI; OpenAI / Anthropic answer models reject
-    it (the proxy mistranslates it), so they inline instead. This is the single place that
-    maps an answer model to its attachment handling, so adding a provider changes only here.
-    The Gemini uploader builds its own Files API client lazily, so this only needs the name.
+    it (the proxy mistranslates it), so they inline instead. The OpenAI and Anthropic Files-API
+    uploaders are scaffolded behind the commented branches below until their proxy reference
+    path is verified. This is the single place that maps an answer model to its attachment
+    handling, so adding a provider changes only here. Each uploader builds its own Files API
+    client lazily, so this only needs the name.
     """
     if "gemini" in model_name:
         return GeminiFileUploader()
     # if "gpt" in model_name:
     #     return OpenAIFileUploader(model_name=model_name)
+    # if "claude" in model_name:
+    #     return AnthropicFileUploader()
     return InlineRenderer()

--- a/src/discordbot/typings/llm.py
+++ b/src/discordbot/typings/llm.py
@@ -13,6 +13,8 @@ class LLMConfig(BaseSettings):
         api_key: The API key for authentication.
         gemini_api_key: The Google AI Studio key used to upload attachments to
             the Gemini Files API directly, so uploads can be polled to ACTIVE.
+        anthropic_api_key: The Anthropic key used to upload attachments to the
+            Anthropic Files API directly (the side-channel for Claude answer models).
         voice_reply_enabled: Kill-switch for spoken QA replies; when false the answer
             model's voice marker is still stripped but no audio clip is synthesized.
     """
@@ -37,6 +39,12 @@ class LLMConfig(BaseSettings):
         description="The Google AI Studio key for direct Gemini Files API uploads.",
         examples=["AIza..."],
         validation_alias=AliasChoices("GEMINI_API_KEY"),
+    )
+    anthropic_api_key: str = Field(
+        default="",
+        description="The Anthropic API key for direct Anthropic Files API uploads.",
+        examples=["sk-ant-..."],
+        validation_alias=AliasChoices("ANTHROPIC_API_KEY"),
     )
     voice_reply_enabled: bool = Field(
         default=True,

--- a/uv.lock
+++ b/uv.lock
@@ -24,7 +24,7 @@ name = "aiodns"
 version = "4.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycares" },
+    { name = "pycares", marker = "python_full_version < '3.13' or python_full_version >= '4' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9b/22/a2d928e0e42baad0471d12ec44c71152ac870486e8298dddb2893b888c29/aiodns-4.0.4.tar.gz", hash = "sha256:cb10e0c0d2591636716ad2fe402e977c16d71bdaf76bb8cb49e8a6633596f736", size = 29918, upload-time = "2026-05-20T01:54:15.557Z" }
 wheels = [
@@ -902,6 +902,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
+    { name = "anthropic" },
     { name = "google-genai" },
     { name = "logfire" },
     { name = "nextcord", extra = ["speed", "voice"] },
@@ -917,7 +918,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "anthropic" },
     { name = "boto3" },
     { name = "botocore" },
     { name = "google-antigravity" },
@@ -951,6 +951,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
+    { name = "anthropic", specifier = ">=0.109.2" },
     { name = "google-genai", specifier = ">=2.7.0" },
     { name = "logfire", specifier = ">=4.33.0" },
     { name = "nextcord", extras = ["speed", "voice"], specifier = ">=3.2.0" },
@@ -966,7 +967,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "anthropic" },
     { name = "boto3" },
     { name = "botocore" },
     { name = "google-antigravity" },
@@ -3097,7 +3097,7 @@ name = "pycares"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi" },
+    { name = "cffi", marker = "python_full_version < '3.13' or python_full_version >= '4' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/a0/9c823651872e6a0face3f0311de2a40c8bbcb9c8dcb15680bd019ac56ac7/pycares-5.0.1.tar.gz", hash = "sha256:5a3c249c830432631439815f9a818463416f2a8cbdb1e988e78757de9ae75081", size = 652222, upload-time = "2026-01-01T12:37:00.604Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Adds an `AnthropicFileUploader` attachment renderer for Claude answer models, modeled on the existing `GeminiFileUploader` / `OpenAIFileUploader`, and wires it into `build_attachment_handler` **behind a commented branch (disabled)**.

This is forward-looking scaffold. Today non-Gemini answer models fall through to `InlineRenderer`, because the LiteLLM proxy reference-translation path for uploaded files is not verified for Claude. The renderer is in place and tested-clean so the Claude Files-API path can be turned on later once that path is confirmed.

## Details

- New module `cogs/_gen_reply/attachment/anthropic_file_api.py`. Simpler than the Gemini uploader: Anthropic files are usable the moment `beta.files.upload` returns (no PROCESSING/ACTIVE poll) and persist until deleted (no provider expiry), so there is no pending-upload re-poll machinery and the render cache uses a fixed synthetic TTL. Keeps the shared dead-source cache + media semaphore for download robustness.
- Builds its own `AsyncAnthropic` side-channel client inside the module (not via a `utils/llm.py` factory) on purpose: while the renderer is disabled, this keeps the `anthropic` import out of the live request-path module graph until the Claude path is wired on.
- `LLMConfig` gains an `anthropic_api_key` field (default empty, `ANTHROPIC_API_KEY` alias), mirroring `gemini_api_key`.
- `select.py` adds the commented import and `# if "claude" in model_name:` branch, mirroring the `OpenAIFileUploader` wiring.
- Adds `anthropic` to the mypy pre-commit hook deps for real types.
- Promotes `anthropic` from the `dev` group to a runtime dependency (`>=0.109.2`) so the renderer can be enabled without a follow-up dependency change.

## Why it stays safe while disabled

`anthropic_file_api.py` is only reachable via the commented import in `select.py`; the package `__init__.py` is empty and the cog loader globs only `cogs/*.py`, so the module is never imported in production while disabled. `utils/llm.py` is untouched, so the live request-path import graph never references `anthropic`.

## To enable later (out of scope, documented in the module docstring)

Before uncommenting the `select.py` branch, resolve these (all flagged in review):

1. **Reference-side beta header** — the answer request (not this renderer) must send `anthropic-beta: files-api-2025-04-14` when it references an uploaded file; LiteLLM does not auto-add it for file references.
2. **Preserve MIME on reference** — LiteLLM's Anthropic mapper needs the file format, not a bare `file_id`, to emit a `document` block instead of a code-execution `container_upload`.
3. **Keep type narrowing** — Anthropic document blocks only cover PDF / plain text / images, so retain `InlineRenderer`'s narrowing (UTF-8 files as `input_text`, others dropped) instead of uploading every MIME.
4. **File lifecycle** — Anthropic files never auto-expire and this renderer never deletes them, so add a deletion / periodic-sweep strategy (the synthetic cache TTL only evicts the local render cache, not the remote file).

## Testing

- `uv run pre-commit run -a` — passes (exit 0, no autofix changes).
- `uv run pytest` — 874 passed, coverage gate held. Behavior is unchanged: the new branch is commented, so dispatch still returns `GeminiFileUploader` for Gemini and `InlineRenderer` for everything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016X3LDEEYsr1sSr7qTDZRc9
