### PR TITLE
feat(gen_reply): enrich pipeline logging and hint failed voice replies

### DIFF
--- a/src/discordbot/cogs/_gen_reply/attachment/anthropic_file_api.py
+++ b/src/discordbot/cogs/_gen_reply/attachment/anthropic_file_api.py
@@ -41,7 +41,11 @@ from openai.types.responses.response_input_file_param import ResponseInputFilePa
 from openai.types.responses.response_input_image_param import ResponseInputImageParam
 
 from discordbot.typings.llm import LLMConfig
-from discordbot.cogs._gen_reply.attachment.base import RenderedPart, AttachmentRenderer
+from discordbot.cogs._gen_reply.attachment.base import (
+    RenderedPart,
+    AttachmentRenderer,
+    loggable_cache_key,
+)
 from discordbot.cogs._gen_reply.attachment.loaders import (
     attachment_mime,
     load_image_bytes,
@@ -174,7 +178,7 @@ class AnthropicFileUploader(AttachmentRenderer):
                 logfire.warn(
                     "failed to load attachment bytes for upload",
                     filename=filename,
-                    cache_key=cache_key,
+                    cache_key=loggable_cache_key(cache_key=cache_key),
                     allow_dead_cache=allow_dead_cache,
                 )
                 if allow_dead_cache:

--- a/src/discordbot/cogs/_gen_reply/attachment/anthropic_file_api.py
+++ b/src/discordbot/cogs/_gen_reply/attachment/anthropic_file_api.py
@@ -26,6 +26,7 @@ as `input_text`, the rest dropped) instead of uploading every MIME and referenci
 """
 
 import io
+import time
 from typing import TYPE_CHECKING
 import asyncio
 from datetime import UTC, datetime, timedelta
@@ -119,7 +120,9 @@ class AnthropicFileUploader(AttachmentRenderer):
         mime_type = attachment_mime(attachment=attachment)
         if not mime_type:
             logfire.warn(
-                f"Skipping attachment with unknown MIME type: {attachment.filename} ({attachment.url})"
+                "skipping attachment with unknown MIME type",
+                filename=attachment.filename,
+                url=attachment.url,
             )
             return None
         uploaded = await self._resolve_file_upload(
@@ -168,7 +171,12 @@ class AnthropicFileUploader(AttachmentRenderer):
             try:
                 data, content_type = await load_data()
             except Exception:
-                logfire.warn(f"Failed to load attachment bytes for upload: {filename}")
+                logfire.warn(
+                    "failed to load attachment bytes for upload",
+                    filename=filename,
+                    cache_key=cache_key,
+                    allow_dead_cache=allow_dead_cache,
+                )
                 if allow_dead_cache:
                     self._mark_dead(cache_key=cache_key)
                 return None
@@ -184,14 +192,24 @@ class AnthropicFileUploader(AttachmentRenderer):
         the module docstring). Anthropic files have no provider expiry, so the cache window is
         a fixed synthetic TTL.
         """
+        started = time.monotonic()
+        logfire.debug(
+            "anthropic upload start", filename=filename, content_type=content_type, bytes=len(data)
+        )
         try:
             uploaded = await self.anthropic_client.beta.files.upload(
                 file=(filename, io.BytesIO(data), content_type)
             )
         except Exception:
-            logfire.warn(f"Failed to upload attachment to Anthropic Files API: {filename}")
+            logfire.warn("failed to upload attachment to Anthropic Files API", filename=filename)
             return None
         if not uploaded.id:
-            logfire.warn(f"Anthropic file upload returned no file id; dropping: {filename}")
+            logfire.warn("upload returned no file id; dropping", filename=filename)
             return None
+        logfire.debug(
+            "anthropic upload done",
+            filename=filename,
+            file_id=uploaded.id,
+            elapsed_seconds=time.monotonic() - started,
+        )
         return uploaded.id, datetime.now(tz=UTC) + ANTHROPIC_FILE_CACHE_TTL

--- a/src/discordbot/cogs/_gen_reply/attachment/base.py
+++ b/src/discordbot/cogs/_gen_reply/attachment/base.py
@@ -15,6 +15,18 @@ from openai.types.responses.response_input_image_param import ResponseInputImage
 type RenderedPart = ResponseInputTextParam | ResponseInputImageParam | ResponseInputFileParam
 
 
+def loggable_cache_key(cache_key: int | str) -> int | str:
+    """A log-safe form of an attachment cache key.
+
+    Attachment / sticker keys are ids (safe to log). An embed-image key is its source URL,
+    which can carry a signed CDN token in the query string; drop the query so a log keeps a
+    stable, correlatable identifier without leaking the token.
+    """
+    if isinstance(cache_key, str):
+        return cache_key.split("?", 1)[0]
+    return cache_key
+
+
 class AttachmentRenderer(BaseModel):
     """Strategy that turns one Discord attachment source into a Responses API content part.
 

--- a/src/discordbot/cogs/_gen_reply/attachment/gemini_file_api.py
+++ b/src/discordbot/cogs/_gen_reply/attachment/gemini_file_api.py
@@ -148,7 +148,9 @@ class GeminiFileUploader(AttachmentRenderer):
         mime_type = attachment_mime(attachment=attachment)
         if not mime_type:
             logfire.warn(
-                f"Skipping attachment with unknown MIME type: {attachment.filename} ({attachment.url})"
+                "skipping attachment with unknown MIME type",
+                filename=attachment.filename,
+                url=attachment.url,
             )
             return None
         uploaded = await self._resolve_file_upload(
@@ -207,6 +209,12 @@ class GeminiFileUploader(AttachmentRenderer):
         except Exception:
             self._pending_uploads.pop(cache_key, None)
             return False, None
+        logfire.debug(
+            "gemini pending upload repoll",
+            cache_key=cache_key,
+            state=str(uploaded.state),
+            adopted=uploaded.state == FileState.ACTIVE,
+        )
         if uploaded.state == FileState.ACTIVE:
             self._pending_uploads.pop(cache_key, None)
             return True, (pending.uri, pending.expires_at)
@@ -251,11 +259,22 @@ class GeminiFileUploader(AttachmentRenderer):
         # One media slot spans the whole download + upload (+ activation poll) for every
         # attachment type, so concurrent pipelines cannot launch dozens of CDN downloads or
         # uploads at once and buffer all their bytes while waiting for an upload slot.
+        wait_started = time.monotonic()
         async with self._media_semaphore:
+            logfire.debug(
+                "gemini media slot acquired",
+                cache_key=cache_key,
+                wait_seconds=time.monotonic() - wait_started,
+            )
             try:
                 data, content_type = await load_data()
             except Exception:
-                logfire.warn(f"Failed to load attachment bytes for upload: {filename}")
+                logfire.warn(
+                    "failed to load attachment bytes for upload",
+                    filename=filename,
+                    cache_key=cache_key,
+                    allow_dead_cache=allow_dead_cache,
+                )
                 if allow_dead_cache:
                     self._mark_dead(cache_key=cache_key)
                 return None
@@ -297,6 +316,10 @@ class GeminiFileUploader(AttachmentRenderer):
         """
         activation_timeout_seconds = 15.0
         poll_interval_seconds = 0.5
+        started = time.monotonic()
+        logfire.debug(
+            "gemini upload start", filename=filename, content_type=content_type, bytes=len(data)
+        )
         # The caller (`_resolve_file_upload`) holds the media semaphore across this whole
         # call, so the activation poll counts against the concurrency cap on purpose.
         try:
@@ -308,16 +331,17 @@ class GeminiFileUploader(AttachmentRenderer):
             # PendingUpload reuse it, and degrade explicitly if the provider ever omits it.
             file_name = uploaded.name
             if file_name is None:
-                logfire.warn(f"Gemini upload returned no resource name; dropping: {filename}")
+                logfire.warn("upload returned no resource name; dropping", filename=filename)
                 return None
             deadline = time.monotonic() + activation_timeout_seconds
             while uploaded.state == FileState.PROCESSING:
                 if time.monotonic() >= deadline:
                     logfire.warn(
-                        f"Attachment still processing; will retry on next reference: {filename}"
+                        "attachment still processing; will retry on next reference",
+                        filename=filename,
                     )
                     if uploaded.uri is None:
-                        logfire.warn(f"Pending upload has no uri; dropping: {filename}")
+                        logfire.warn("pending upload has no uri; dropping", filename=filename)
                         return None
                     # Hand back the in-flight upload so the caller can re-poll it later
                     # instead of re-uploading the same bytes from scratch.
@@ -328,16 +352,25 @@ class GeminiFileUploader(AttachmentRenderer):
                 await asyncio.sleep(poll_interval_seconds)
                 uploaded = await self.gemini_client.aio.files.get(name=file_name)
             if uploaded.state != FileState.ACTIVE:
-                logfire.warn(f"Attachment failed processing ({uploaded.state}): {filename}")
+                logfire.warn(
+                    "attachment failed processing", filename=filename, state=str(uploaded.state)
+                )
                 return None
         except Exception:
-            logfire.warn(f"Failed to upload attachment to Files API: {filename}")
+            logfire.warn("failed to upload attachment to Files API", filename=filename)
             return None
         file_uri = uploaded.uri
         if file_uri is None:
-            logfire.warn(f"Active upload has no uri; dropping: {filename}")
+            logfire.warn("active upload has no uri; dropping", filename=filename)
             return None
         # Fall back to a conservative 47h (under the ~48h lifetime) if the provider omits
         # the expiry, so a missing field never pins an unbounded cache entry.
         expires_at = uploaded.expiration_time or (datetime.now(tz=UTC) + timedelta(hours=47))
+        logfire.debug(
+            "gemini upload done",
+            filename=filename,
+            file_uri=file_uri,
+            elapsed_seconds=time.monotonic() - started,
+            state="active",
+        )
         return file_uri, expires_at

--- a/src/discordbot/cogs/_gen_reply/attachment/gemini_file_api.py
+++ b/src/discordbot/cogs/_gen_reply/attachment/gemini_file_api.py
@@ -23,7 +23,11 @@ from openai.types.responses.response_input_file_param import ResponseInputFilePa
 
 from discordbot.utils.llm import create_gemini_client
 from discordbot.typings.llm import LLMConfig
-from discordbot.cogs._gen_reply.attachment.base import RenderedPart, AttachmentRenderer
+from discordbot.cogs._gen_reply.attachment.base import (
+    RenderedPart,
+    AttachmentRenderer,
+    loggable_cache_key,
+)
 from discordbot.cogs._gen_reply.attachment.loaders import (
     attachment_mime,
     load_image_bytes,
@@ -211,7 +215,7 @@ class GeminiFileUploader(AttachmentRenderer):
             return False, None
         logfire.debug(
             "gemini pending upload repoll",
-            cache_key=cache_key,
+            cache_key=loggable_cache_key(cache_key=cache_key),
             state=str(uploaded.state),
             adopted=uploaded.state == FileState.ACTIVE,
         )
@@ -263,7 +267,7 @@ class GeminiFileUploader(AttachmentRenderer):
         async with self._media_semaphore:
             logfire.debug(
                 "gemini media slot acquired",
-                cache_key=cache_key,
+                cache_key=loggable_cache_key(cache_key=cache_key),
                 wait_seconds=time.monotonic() - wait_started,
             )
             try:
@@ -272,7 +276,7 @@ class GeminiFileUploader(AttachmentRenderer):
                 logfire.warn(
                     "failed to load attachment bytes for upload",
                     filename=filename,
-                    cache_key=cache_key,
+                    cache_key=loggable_cache_key(cache_key=cache_key),
                     allow_dead_cache=allow_dead_cache,
                 )
                 if allow_dead_cache:

--- a/src/discordbot/cogs/_gen_reply/attachment/inline.py
+++ b/src/discordbot/cogs/_gen_reply/attachment/inline.py
@@ -49,7 +49,7 @@ class InlineRenderer(AttachmentRenderer):
         try:
             file_bytes, content_type = await load_image_bytes(source=source)
         except Exception:
-            logfire.warn("Failed to convert this image")
+            logfire.warn("failed to convert this image")
             return None
         image_part = ResponseInputImageParam(
             type="input_image",
@@ -64,13 +64,15 @@ class InlineRenderer(AttachmentRenderer):
         mime_type = attachment_mime(attachment=attachment)
         if not mime_type:
             logfire.warn(
-                f"Skipping attachment with unknown MIME type: {attachment.filename} ({attachment.url})"
+                "skipping attachment with unknown MIME type",
+                filename=attachment.filename,
+                url=attachment.url,
             )
             return None
         try:
             file_bytes, _ = await load_attachment_bytes(attachment=attachment)
         except Exception:
-            logfire.warn(f"Failed to download this attachment: {attachment.url}")
+            logfire.warn("failed to download this attachment", url=attachment.url)
             return None
         return self._inline_file_part(
             filename=attachment.filename, data=file_bytes, mime_type=mime_type
@@ -96,7 +98,9 @@ class InlineRenderer(AttachmentRenderer):
             text = data.decode("utf-8")
         except UnicodeDecodeError:
             logfire.warn(
-                f"Dropping non-text, non-PDF attachment for a non-Gemini model: {filename}"
+                "dropping non-text, non-PDF attachment for a non-Gemini model",
+                filename=filename,
+                mime_type=mime_type,
             )
             return None
         text_part = ResponseInputTextParam(

--- a/src/discordbot/cogs/_gen_reply/attachment/openai_file_api.py
+++ b/src/discordbot/cogs/_gen_reply/attachment/openai_file_api.py
@@ -6,6 +6,7 @@ ready to rely on uploaded files instead of inline parts.
 """
 
 import io
+import time
 from typing import TYPE_CHECKING, Literal
 import asyncio
 from datetime import UTC, datetime, timedelta
@@ -93,7 +94,9 @@ class OpenAIFileUploader(AttachmentRenderer):
         mime_type = attachment_mime(attachment=attachment)
         if not mime_type:
             logfire.warn(
-                f"Skipping attachment with unknown MIME type: {attachment.filename} ({attachment.url})"
+                "skipping attachment with unknown MIME type",
+                filename=attachment.filename,
+                url=attachment.url,
             )
             return None
         uploaded = await self._resolve_file_upload(
@@ -144,7 +147,12 @@ class OpenAIFileUploader(AttachmentRenderer):
             try:
                 data, content_type = await load_data()
             except Exception:
-                logfire.warn(f"Failed to load attachment bytes for upload: {filename}")
+                logfire.warn(
+                    "failed to load attachment bytes for upload",
+                    filename=filename,
+                    cache_key=cache_key,
+                    allow_dead_cache=allow_dead_cache,
+                )
                 if allow_dead_cache:
                     self._mark_dead(cache_key=cache_key)
                 return None
@@ -156,6 +164,10 @@ class OpenAIFileUploader(AttachmentRenderer):
         self, filename: str, data: bytes, content_type: str, purpose: OpenAIFilePurpose
     ) -> tuple[str, datetime] | None:
         """Uploads bytes to OpenAI Files API and returns `(file_id, expires_at)`."""
+        started = time.monotonic()
+        logfire.debug(
+            "openai upload start", filename=filename, content_type=content_type, bytes=len(data)
+        )
         try:
             uploaded = await self.client.files.create(
                 file=(filename, io.BytesIO(data), content_type),
@@ -164,16 +176,22 @@ class OpenAIFileUploader(AttachmentRenderer):
                 extra_body={"model": self.model_name},
             )
         except Exception:
-            logfire.warn(f"Failed to upload attachment to OpenAI Files API: {filename}")
+            logfire.warn("failed to upload attachment to OpenAI Files API", filename=filename)
             return None
         if uploaded.status == "error":
-            logfire.warn(f"OpenAI file upload failed processing: {filename}")
+            logfire.warn("OpenAI file upload failed processing", filename=filename)
             return None
         if not uploaded.id:
-            logfire.warn(f"OpenAI file upload returned no file id; dropping: {filename}")
+            logfire.warn("upload returned no file id; dropping", filename=filename)
             return None
         if uploaded.expires_at is None:
             expires_at = datetime.now(tz=UTC) + timedelta(seconds=OPENAI_FILE_EXPIRY_SECONDS)
         else:
             expires_at = datetime.fromtimestamp(uploaded.expires_at, tz=UTC)
+        logfire.debug(
+            "openai upload done",
+            filename=filename,
+            file_id=uploaded.id,
+            elapsed_seconds=time.monotonic() - started,
+        )
         return uploaded.id, expires_at

--- a/src/discordbot/cogs/_gen_reply/attachment/openai_file_api.py
+++ b/src/discordbot/cogs/_gen_reply/attachment/openai_file_api.py
@@ -22,7 +22,11 @@ from openai.types.responses.response_input_image_param import ResponseInputImage
 
 from discordbot.utils.llm import create_litellm_client
 from discordbot.typings.llm import LLMConfig
-from discordbot.cogs._gen_reply.attachment.base import RenderedPart, AttachmentRenderer
+from discordbot.cogs._gen_reply.attachment.base import (
+    RenderedPart,
+    AttachmentRenderer,
+    loggable_cache_key,
+)
 from discordbot.cogs._gen_reply.attachment.loaders import (
     attachment_mime,
     load_image_bytes,
@@ -150,7 +154,7 @@ class OpenAIFileUploader(AttachmentRenderer):
                 logfire.warn(
                     "failed to load attachment bytes for upload",
                     filename=filename,
-                    cache_key=cache_key,
+                    cache_key=loggable_cache_key(cache_key=cache_key),
                     allow_dead_cache=allow_dead_cache,
                 )
                 if allow_dead_cache:

--- a/src/discordbot/cogs/_gen_reply/input.py
+++ b/src/discordbot/cogs/_gen_reply/input.py
@@ -247,7 +247,11 @@ class MessageInputBuilder(BaseModel):
             required = self.required_modality(content_type=source.content_type)
             if required not in modalities:
                 logfire.warn(
-                    f"Skipping {required} attachment for {model_name}: {source.cache_key}"
+                    "gen_reply skipping unsupported attachment",
+                    modality=required,
+                    model=model_name,
+                    cache_key=source.cache_key,
+                    content_type=source.content_type,
                 )
                 continue
             supported.append(source)
@@ -368,14 +372,26 @@ class MessageInputBuilder(BaseModel):
         cached = self._attachment_cache.get(cache_key)
         if cached is not None and datetime.now(tz=UTC) < cached[0] - cache_safety_margin:
             self._attachment_cache.move_to_end(cache_key)
+            logfire.debug(
+                "gen_reply attachment cache hit", message_id=message.id, source_count=len(sources)
+            )
             # Hand out per-part copies so no caller ever holds the cached dicts; the
             # values are immutable strings, so the copies stay cheap.
             return [part.copy() for part in cached[1]]
 
+        logfire.debug(
+            "gen_reply attachment render", message_id=message.id, source_count=len(sources)
+        )
         rendered = await self._render_attachment_parts(
             sources=sources, allow_dead_cache=allow_dead_cache
         )
         resolved = [item[0] for item in rendered if item is not None]
+        logfire.debug(
+            "gen_reply attachment render done",
+            message_id=message.id,
+            resolved=len(resolved),
+            dropped=len(sources) - len(resolved),
+        )
         # A None entry means a download/convert or upload failed; skip caching so the
         # next reply retries instead of pinning a degraded render. The entry's expiry is
         # the earliest across its files, so the whole entry re-renders before any handle
@@ -457,7 +473,11 @@ class MessageInputBuilder(BaseModel):
             # The route awaits this before dispatching, so a cold-start modality lookup
             # (or render) failure must degrade to empty text like process_single_message
             # does, not abort the whole reply through the generic error path.
-            logfire.warn(f"Failed to render message {message.id} for routing", _exc_info=True)
+            logfire.warn(
+                "gen_reply failed to render message for routing",
+                message_id=message.id,
+                _exc_info=True,
+            )
             return EasyInputMessageParam(role="user", content="")
 
     async def process_single_message(
@@ -484,5 +504,7 @@ class MessageInputBuilder(BaseModel):
                 has_attachments=bool(sources),
             )
         except Exception:
-            logfire.warn(f"Failed to process message {message.id}", _exc_info=True)
+            logfire.warn(
+                "gen_reply failed to process message", message_id=message.id, _exc_info=True
+            )
             return EasyInputMessageParam(role="user", content="")

--- a/src/discordbot/cogs/_gen_reply/input.py
+++ b/src/discordbot/cogs/_gen_reply/input.py
@@ -17,7 +17,11 @@ from openai.types.responses.response_input_text_param import ResponseInputTextPa
 from discordbot.typings.models import RuntimeModelCatalog
 from discordbot.utils.model_pricing import get_supported_modalities
 from discordbot.cogs._gen_reply.voice import VOICE_REPLY_FILENAME
-from discordbot.cogs._gen_reply.attachment.base import RenderedPart, AttachmentRenderer
+from discordbot.cogs._gen_reply.attachment.base import (
+    RenderedPart,
+    AttachmentRenderer,
+    loggable_cache_key,
+)
 from discordbot.cogs._gen_reply.attachment.loaders import load_image_bytes
 
 if TYPE_CHECKING:
@@ -250,7 +254,7 @@ class MessageInputBuilder(BaseModel):
                     "gen_reply skipping unsupported attachment",
                     modality=required,
                     model=model_name,
-                    cache_key=source.cache_key,
+                    cache_key=loggable_cache_key(cache_key=source.cache_key),
                     content_type=source.content_type,
                 )
                 continue

--- a/src/discordbot/cogs/_gen_reply/streaming.py
+++ b/src/discordbot/cogs/_gen_reply/streaming.py
@@ -19,9 +19,11 @@ from openai.types.responses import (
     ResponseCompletedEvent,
 )
 
+from discordbot.utils.reactions import update_reaction
 from discordbot.utils.model_pricing import get_token_rates
 from discordbot.cogs._gen_reply.voice import (
     VOICE_REPLY_FILENAME,
+    VoiceOutcome,
     VoiceSynthesizer,
     strip_voice_marker,
     speechify_discord_markup,
@@ -243,6 +245,7 @@ class ResponseStreamer(BaseModel):
                 "gen_reply first reasoning delta",
                 elapsed_seconds=time.monotonic() - self.created_at,
                 model=self.model_name,
+                message_id=self.message.id,
             )
         self.reasoning_content += delta
         self._ensure_editor_started()
@@ -258,6 +261,7 @@ class ResponseStreamer(BaseModel):
                 "gen_reply first content delta",
                 elapsed_seconds=time.monotonic() - self.created_at,
                 model=self.model_name,
+                message_id=self.message.id,
             )
         self.stored_content += delta
         self._ensure_editor_started()
@@ -324,9 +328,24 @@ class ResponseStreamer(BaseModel):
         await self._write_final_message(
             reply=self.reply, content=self.stored_content, footer=usage_footer
         )
+        reply_chars = len(self.stored_content)
+        chunked = reply_chars + len(usage_footer) > DISCORD_MESSAGE_LIMIT
         self.stored_content += usage_footer
 
         await self._maybe_attach_voice()
+        logfire.info(
+            "gen_reply reply finalized",
+            message_id=self.message.id,
+            model=self.model_name,
+            effort=self.model_effort,
+            input_tokens=self.input_tokens,
+            output_tokens=self.output_tokens,
+            cost=cost,
+            reply_chars=reply_chars,
+            voice_requested=self.voice_requested,
+            memory_lookups=len(self.memory_lookups),
+            chunked=chunked,
+        )
         return self.stored_content
 
     def _resolve_mention_name(self, *, target_id: int) -> str | None:
@@ -343,19 +362,33 @@ class ResponseStreamer(BaseModel):
         channel = guild.get_channel(target_id)
         return getattr(channel, "name", None) if channel is not None else None
 
-    async def _maybe_attach_voice(self) -> None:
+    async def _hint_voice_unavailable(self, *, emoji: str) -> None:
+        """Marks the source message so a dropped voice clip is not fully silent to the user.
+
+        The reply stays text-only and the user gets no message; this best-effort reaction is
+        the only signal. It rides on the source message as an independent reaction (no
+        `previous`), so the pipeline's status chain never removes it. Failures are suppressed
+        inside `update_reaction`.
+        """
+        await update_reaction(message=self.message, bot_user=None, emoji=emoji)
+
+    async def _maybe_attach_voice(self) -> None:  # noqa: PLR0911 -- one best-effort voice attach with several distinct degrade paths (skip / timeout / refused / oversized / attach-fail / success)
         """Renders the reply to audio and edits it onto the sent message when requested.
 
         Runs only when the answer model asked for a spoken reply and voice is enabled for
         this turn. The text reply is already on screen, so synthesis adds no latency to it;
         the clip is best-effort and any failure (or a too-long reply) leaves a text reply.
-        Every skip reason is logged so a missing voice clip is never silent.
+        Every skip reason is logged. When a clip was requested but could not be delivered the
+        source message gets a small emoji hint (⏱️ for a timeout, ⚠️ for any other failure) so
+        the user has a quiet cue; the model choosing no voice, voice being disabled, or an
+        empty reply add no hint.
         """
         if not self.voice_requested:
             # The expected common path: the answer model chose a text-only reply.
             logfire.debug("Voice not requested by the answer model", message_id=self.message.id)
             return
         if self.voice_synthesizer is None:
+            # Voice is intentionally off this turn (kill-switch), not a failure: no hint.
             logfire.info(
                 "Voice requested but disabled for this turn; replying without audio",
                 message_id=self.message.id,
@@ -366,16 +399,26 @@ class ResponseStreamer(BaseModel):
                 "Voice requested but the reply was never sent; dropping audio",
                 message_id=self.message.id,
             )
+            await self._hint_voice_unavailable(emoji="⚠️")
             return
         logfire.info(
             "Synthesizing voice reply", message_id=self.message.id, text_chars=len(self.voice_text)
         )
-        audio = await self.voice_synthesizer.synthesize(
+        clip = await self.voice_synthesizer.synthesize(
             text=self.voice_text, end_user_id=self.message.author.name
         )
-        if audio is None:
-            # synthesize() already logged the specific reason (empty input or provider error).
+        if clip.outcome is VoiceOutcome.EMPTY:
+            # Nothing to say (the reply was empty after stripping): no hint.
             return
+        if clip.outcome is VoiceOutcome.TIMEOUT:
+            # synthesize() logged the timeout; cue the user that the clip ran out of time.
+            await self._hint_voice_unavailable(emoji="⏱️")
+            return
+        if clip.audio is None:
+            # Any other synthesis failure (most often a policy refusal); synthesize() logged it.
+            await self._hint_voice_unavailable(emoji="⚠️")
+            return
+        audio = clip.audio
         # Drop a clip past the guild's upload limit so the answer model is free to choose the
         # spoken length; a DM has no guild to query, so fall back to Discord's non-Nitro base of
         # 10MB (the guild path trusts nextcord's filesize_limit, correct for boosted 50/100MB).
@@ -389,6 +432,7 @@ class ResponseStreamer(BaseModel):
                 audio_bytes=len(audio),
                 upload_limit=upload_limit,
             )
+            await self._hint_voice_unavailable(emoji="⚠️")
             return
         try:
             await self.reply.edit(file=File(fp=BytesIO(audio), filename=VOICE_REPLY_FILENAME))
@@ -399,6 +443,7 @@ class ResponseStreamer(BaseModel):
                 audio_bytes=len(audio),
                 _exc_info=True,
             )
+            await self._hint_voice_unavailable(emoji="⚠️")
             return
         logfire.info("Voice reply attached", message_id=self.message.id, audio_bytes=len(audio))
 

--- a/src/discordbot/cogs/_gen_reply/voice.py
+++ b/src/discordbot/cogs/_gen_reply/voice.py
@@ -16,9 +16,10 @@ intentionally not sent (the proxy 500s on it); the model returns WAV, hence `rep
 """
 
 import re
+from enum import StrEnum
 from typing import Protocol
 
-from openai import AsyncOpenAI
+from openai import AsyncOpenAI, APITimeoutError
 import logfire
 from pydantic import Field, BaseModel, ConfigDict, SkipValidation
 
@@ -128,12 +129,37 @@ def speechify_discord_markup(*, text: str, resolve_name: MentionNameResolver) ->
     return cleaned.strip()
 
 
+class VoiceOutcome(StrEnum):
+    """Why a spoken-clip synthesis attempt ended, so the caller can hint appropriately."""
+
+    OK = "ok"
+    EMPTY = "empty"
+    TIMEOUT = "timeout"
+    ERROR = "error"
+
+
+class VoiceClip(BaseModel):
+    """Result of one synthesis attempt: the audio (when produced) plus why it ended.
+
+    A failed attempt carries `audio=None` and a non-OK `outcome`; the caller always degrades
+    to a plain text reply and uses `outcome` to decide its best-effort failure hint.
+    """
+
+    audio: bytes | None = Field(
+        default=None, description="Rendered WAV bytes, or None when no clip was produced."
+    )
+    outcome: VoiceOutcome = Field(
+        ..., description="Why synthesis ended; drives the caller's best-effort failure hint."
+    )
+
+
 class VoiceSynthesizer(BaseModel):
     """Best-effort text-to-speech for spoken replies through the LiteLLM proxy.
 
     Holds the shared async client plus the fixed voice / style / speed config; `synthesize`
-    renders one reply to WAV bytes or returns None on over-length input, an oversized clip,
-    a timeout, or any provider error, so the caller always degrades to a plain text reply.
+    renders one reply to a `VoiceClip` carrying the WAV bytes (when produced) plus an outcome
+    (OK / EMPTY / TIMEOUT / ERROR), so the caller both degrades to a text reply and can hint
+    why the clip is missing (a timeout vs. any other provider error, e.g. a policy refusal).
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -153,12 +179,15 @@ class VoiceSynthesizer(BaseModel):
     )
     speed: float = Field(default=TTS_SPEED, description="Playback speed passed to the TTS model.")
 
-    async def synthesize(self, *, text: str, end_user_id: str) -> bytes | None:
-        """Renders reply text to WAV bytes, or None when it should be skipped or failed."""
+    async def synthesize(self, *, text: str, end_user_id: str) -> VoiceClip:
+        """Renders reply text to a VoiceClip, reporting why it ended for best-effort hinting."""
         spoken = text.strip()
         if not spoken:
-            logfire.info("Voice synthesis skipped: reply text was empty after stripping")
-            return None
+            logfire.info(
+                "Voice synthesis skipped: reply text was empty after stripping",
+                end_user_id=end_user_id,
+            )
+            return VoiceClip(outcome=VoiceOutcome.EMPTY)
         try:
             responses = await self.client.audio.speech.create(
                 input=f"{self.style_directive}\n\n{spoken}",
@@ -170,15 +199,33 @@ class VoiceSynthesizer(BaseModel):
             )
             audio = await responses.aread()
             logfire.debug(
-                "Voice synthesis succeeded", text_chars=len(spoken), audio_bytes=len(audio)
-            )
-            return audio
-        except Exception:
-            # Best-effort: a timeout or any provider error degrades to a plain text reply.
-            logfire.warn(
-                "Voice synthesis failed; replying without audio",
+                "Voice synthesis succeeded",
                 model=self.model_name,
+                speed=self.speed,
+                end_user_id=end_user_id,
+                text_chars=len(spoken),
+                audio_bytes=len(audio),
+            )
+            return VoiceClip(audio=audio, outcome=VoiceOutcome.OK)
+        except APITimeoutError:
+            # The clip took longer than VOICE_TIMEOUT_SECONDS to render. The caller marks the
+            # message with a timeout hint and still leaves a plain text reply.
+            logfire.warn(
+                "Voice synthesis timed out; replying without audio",
+                model=self.model_name,
+                end_user_id=end_user_id,
                 text_chars=len(spoken),
                 _exc_info=True,
             )
-            return None
+            return VoiceClip(outcome=VoiceOutcome.TIMEOUT)
+        except Exception:
+            # Any other provider error (most often the clip was refused, e.g. policy). The
+            # caller marks the message with a warning hint and degrades to a text reply.
+            logfire.warn(
+                "Voice synthesis failed; replying without audio",
+                model=self.model_name,
+                end_user_id=end_user_id,
+                text_chars=len(spoken),
+                _exc_info=True,
+            )
+            return VoiceClip(outcome=VoiceOutcome.ERROR)

--- a/src/discordbot/cogs/gen_reply.py
+++ b/src/discordbot/cogs/gen_reply.py
@@ -4,7 +4,7 @@ from io import BytesIO
 import re
 import time
 import base64
-from typing import TYPE_CHECKING, Literal, cast
+from typing import TYPE_CHECKING, Literal, TypedDict, cast
 import asyncio
 from functools import cached_property
 import contextlib
@@ -257,6 +257,41 @@ def _log_pre_answer_latency(started: float, decision: str) -> None:
         elapsed_seconds=time.monotonic() - started,
         decision=decision,
     )
+
+
+class _MessageLogFields(TypedDict):
+    """Exact key set for `_message_log_fields`, so `**`-spreading it into a logfire call
+    keeps statically known keys (none underscore-prefixed) and never collides with logfire's
+    `_tags` / `_exc_info` keyword-only parameters.
+    """
+
+    user_id: int
+    user_name: str
+    display_name: str
+    message_id: int
+    channel_id: int
+    guild_id: int | None
+    guild_name: str | None
+
+
+def _message_log_fields(message: Message) -> _MessageLogFields:
+    """Standard Discord identifying fields for correlating one reply's logs.
+
+    The pipeline-entry log carries the full set; every downstream log carries only
+    `message_id` as the correlation key, so a whole turn reconstructs by grepping it.
+    `user_name` is the stable handle, `display_name` the per-guild nickname;
+    `guild_id` / `guild_name` are None in a DM.
+    """
+    guild = message.guild
+    return {
+        "user_id": message.author.id,
+        "user_name": message.author.name,
+        "display_name": message.author.display_name,
+        "message_id": message.id,
+        "channel_id": message.channel.id,
+        "guild_id": guild.id if guild else None,
+        "guild_name": guild.name if guild else None,
+    }
 
 
 class ReplyGeneratorCogs(commands.Cog):
@@ -515,6 +550,8 @@ class ReplyGeneratorCogs(commands.Cog):
     async def _handle_video_reply(self, message: Message, user_prompt: str) -> None:
         """Handles video generation requests."""
         video_model = self.runtime_models.video_model
+        started = time.monotonic()
+        logfire.info("gen_reply video generation start", message_id=message.id)
         refined_prompt = await self._refine_generation_prompt(
             user_prompt=user_prompt, instructions=VIDEO_PROMPT, end_user_id=message.author.name
         )
@@ -523,19 +560,46 @@ class ReplyGeneratorCogs(commands.Cog):
             prompt=refined_prompt or "請依照訊息內容生成一段影片。",
             extra_headers={"x-litellm-end-user-id": message.author.name},
         )
+        logfire.debug(
+            "gen_reply video job created",
+            message_id=message.id,
+            video_id=video.id,
+            status=video.status,
+        )
         async with asyncio.timeout(delay=VIDEO_GENERATION_TIMEOUT_SECONDS):
             while video.status not in ("completed", "failed"):
                 await asyncio.sleep(5)
                 video = await self.client.videos.retrieve(
                     video_id=video.id, extra_headers={"x-litellm-end-user-id": message.author.name}
                 )
+                logfire.debug(
+                    "gen_reply video poll",
+                    message_id=message.id,
+                    video_id=video.id,
+                    status=video.status,
+                    poll_seconds=time.monotonic() - started,
+                )
         if video.status != "completed":
+            logfire.warn(
+                "gen_reply video generation failed",
+                message_id=message.id,
+                video_id=video.id,
+                status=video.status,
+                error=str(video.error),
+            )
             raise RuntimeError(f"Video generation failed: {video.error}")
         video_content = await self.client.videos.download_content(
             video_id=video.id, extra_headers={"x-litellm-end-user-id": message.author.name}
         )
         video_file = File(fp=BytesIO(video_content.content), filename="generated.mp4")
         await message.reply(content=f"{message.author.mention}", file=video_file)
+        logfire.info(
+            "gen_reply video delivered",
+            message_id=message.id,
+            video_id=video.id,
+            total_elapsed_seconds=time.monotonic() - started,
+            bytes=len(video_content.content),
+        )
 
     async def _handle_image_reply(
         self, message: Message, user_prompt: str, context_task: "asyncio.Task[ReplyContext]"
@@ -551,6 +615,14 @@ class ReplyGeneratorCogs(commands.Cog):
         delivered the reply is best-effort: any failure leaves the delivered image untouched.
         """
         image_model = self.runtime_models.image_model
+        started = time.monotonic()
+        logfire.info(
+            "gen_reply image generation start",
+            message_id=message.id,
+            has_source_images=bool(
+                message.reference and isinstance(message.reference.resolved, Message)
+            ),
+        )
         try:
             if message.reference and isinstance(message.reference.resolved, Message):
                 own_bytes, ref_bytes = await asyncio.gather(
@@ -599,6 +671,11 @@ class ReplyGeneratorCogs(commands.Cog):
             # conversational reply; the reply text streams onto this same message right after.
             image_file = File(fp=BytesIO(base64.b64decode(image_b64)), filename="generated.png")
             reply = await message.reply(content=message.author.mention, file=image_file)
+            logfire.info(
+                "gen_reply image delivered",
+                message_id=message.id,
+                elapsed_seconds=time.monotonic() - started,
+            )
         except Exception:
             # Generation failing IS a real error and stays on the outer error path, but the
             # speculative context must not leak when we bail before consuming it.
@@ -665,7 +742,9 @@ class ReplyGeneratorCogs(commands.Cog):
                 await streamer.stream(responses=responses)
         except Exception:
             logfire.warn(
-                "Image reply generation failed; leaving the image without a reply", _exc_info=True
+                "Image reply generation failed; leaving the image without a reply",
+                message_id=message.id,
+                _exc_info=True,
             )
 
     async def _get_reference_and_current(
@@ -742,7 +821,8 @@ class ReplyGeneratorCogs(commands.Cog):
             # The model returned no text output (e.g. safety filter, empty response);
             # model_validate_json(None) raises ValidationError before we can inspect output_parsed.
             logfire.warn(
-                "RouteClassification parse failed, model returned no text; defaulting to QA"
+                "RouteClassification parse failed, model returned no text; defaulting to QA",
+                message_id=message.id,
             )
             route = RouteClassification(decision="QA")
         # Route-call latency is logged on every path: this is the prime suspect for slow
@@ -751,6 +831,7 @@ class ReplyGeneratorCogs(commands.Cog):
             "gen_reply route done",
             elapsed_seconds=time.monotonic() - started,
             decision=route.decision,
+            message_id=message.id,
         )
         return route
 
@@ -788,11 +869,16 @@ class ReplyGeneratorCogs(commands.Cog):
             "gen_reply effort done",
             elapsed_seconds=time.monotonic() - started,
             effort=grade.effort,
+            message_id=message.id,
         )
         return grade
 
     async def _resolve_effort(
-        self, *, effort_task: "asyncio.Task[EffortGrade]", route_done: asyncio.Event
+        self,
+        *,
+        message: Message,
+        effort_task: "asyncio.Task[EffortGrade]",
+        route_done: asyncio.Event,
     ) -> Literal["low", "medium", "high"]:
         """Resolves the parallel effort grade, bounded by the route like memory selection.
 
@@ -807,16 +893,22 @@ class ReplyGeneratorCogs(commands.Cog):
             logfire.warn(
                 "Effort grading exceeded the post-route grace; defaulting to high effort",
                 grace_seconds=EFFORT_GRACE_SECONDS,
+                message_id=message.id,
             )
             return "high"
         except Exception:
-            logfire.warn("Effort grading failed; defaulting to high effort", _exc_info=True)
+            logfire.warn(
+                "Effort grading failed; defaulting to high effort",
+                message_id=message.id,
+                _exc_info=True,
+            )
             return "high"
         return grade.effort
 
     async def _resolve_threads_block(
         self,
         *,
+        message: Message,
         threads_task: "asyncio.Task[list[EasyInputMessageParam]]",
         route_done: asyncio.Event,
     ) -> list[EasyInputMessageParam]:
@@ -836,15 +928,21 @@ class ReplyGeneratorCogs(commands.Cog):
             logfire.warn(
                 "Threads context parse exceeded the post-route grace; injecting timeout notice",
                 grace_seconds=THREADS_GRACE_SECONDS,
+                message_id=message.id,
             )
             return threads_timeout_context_messages()
         except Exception:
-            logfire.warn("Threads context parse failed; answering without it", _exc_info=True)
+            logfire.warn(
+                "Threads context parse failed; answering without it",
+                message_id=message.id,
+                _exc_info=True,
+            )
             return []
         logfire.info(
             "gen_reply threads context done",
             elapsed_seconds=time.monotonic() - started,
             blocks=len(blocks),
+            message_id=message.id,
         )
         return blocks
 
@@ -908,6 +1006,7 @@ class ReplyGeneratorCogs(commands.Cog):
                 "Capping selected memories to the per-reply limit",
                 requested=len(memories),
                 kept=max_memories,
+                message_id=message.id,
             )
             memories = memories[:max_memories]
         input_tokens = responses.usage.input_tokens if responses.usage else 0
@@ -1027,7 +1126,9 @@ class ReplyGeneratorCogs(commands.Cog):
         # Covers the history fetch/render plus waiting on the shared attachment upload, so
         # the log separates pre-answer attachment cost from the route-call cost.
         logfire.info(
-            "gen_reply context build done", elapsed_seconds=time.monotonic() - build_started
+            "gen_reply context build done",
+            elapsed_seconds=time.monotonic() - build_started,
+            message_id=message.id,
         )
         hist_messages = history.rendered
 
@@ -1072,6 +1173,12 @@ class ReplyGeneratorCogs(commands.Cog):
                     memory=server_memory,
                     include_absent=_source_channel_is_public(message=message),
                 )
+            logfire.debug(
+                "gen_reply memory allowlist built",
+                allowlist_size=len(allowed),
+                widened=bool(server_memory and message.guild is not None),
+                message_id=message.id,
+            )
             if allowed:
                 # Selection runs on the text-only transcript (markers, no file ids) so it
                 # neither re-reads the uploaded files nor blocks on their upload.
@@ -1102,6 +1209,7 @@ class ReplyGeneratorCogs(commands.Cog):
                     logfire.warn(
                         "Memory selection exceeded the post-route grace; falling back to participant memory",
                         grace_seconds=MEMORY_SELECT_GRACE_SECONDS,
+                        message_id=message.id,
                     )
                     memory_block, memory_labels = self._participant_memory_fallback(
                         message=message, allowed=allowed
@@ -1109,6 +1217,7 @@ class ReplyGeneratorCogs(commands.Cog):
                 except Exception:
                     logfire.warn(
                         "Memory selection failed; falling back to participant memory",
+                        message_id=message.id,
                         _exc_info=True,
                     )
                     memory_block, memory_labels = self._participant_memory_fallback(
@@ -1124,6 +1233,10 @@ class ReplyGeneratorCogs(commands.Cog):
                         "gen_reply memory selection done",
                         elapsed_seconds=time.monotonic() - selection_started,
                         selected=len(selection.memories),
+                        selected_ids=[memory.user_id for memory in selection.memories],
+                        labels=memory_lookup_labels(memories=selection.memories),
+                        allowlist_size=len(allowed),
+                        message_id=message.id,
                     )
 
         return ReplyContext(
@@ -1247,9 +1360,22 @@ class ReplyGeneratorCogs(commands.Cog):
         has_attachment = bool(message.attachments or message.stickers)
 
         if not user_prompt and not has_attachment:
+            logfire.debug(
+                "gen_reply empty prompt; replied with ?", **_message_log_fields(message=message)
+            )
             await update_reaction(message=message, bot_user=self.bot.user, emoji="❓")
             await message.reply(content="?")
             return
+
+        logfire.info(
+            "gen_reply received",
+            **_message_log_fields(message=message),
+            prompt_chars=len(user_prompt),
+            has_attachment=has_attachment,
+            attachment_count=len(message.attachments),
+            sticker_count=len(message.stickers),
+            is_dm=is_dm,
+        )
 
         reactions = ReactionStatusChain(message=message, bot_user=self.bot.user)
         try:
@@ -1257,7 +1383,12 @@ class ReplyGeneratorCogs(commands.Cog):
                 message=message, user_prompt=user_prompt, reactions=reactions
             )
         except Exception as e:
-            logfire.error("Failed to generate reply", user_id=message.author.name, _exc_info=True)
+            logfire.error(
+                "gen_reply failed",
+                **_message_log_fields(message=message),
+                error_type=type(e).__name__,
+                _exc_info=True,
+            )
             with contextlib.suppress(Exception):
                 reactions.advance(emoji="❌")
                 error_embed = Embed(
@@ -1403,7 +1534,7 @@ class ReplyGeneratorCogs(commands.Cog):
                     )
                     parts_task = None
                     effort = await self._resolve_effort(
-                        effort_task=effort_task, route_done=route_done
+                        message=message, effort_task=effort_task, route_done=route_done
                     )
                     effort_task = None
                     pipeline_span.set_attribute(key="effort", value=effort)
@@ -1425,14 +1556,14 @@ class ReplyGeneratorCogs(commands.Cog):
                     prep_task = None
                     parts_task = None
                     effort = await self._resolve_effort(
-                        effort_task=effort_task, route_done=route_done
+                        message=message, effort_task=effort_task, route_done=route_done
                     )
                     effort_task = None
                     # The parse ran in parallel since before the route; resolve it under the
                     # same route_done gate and fold the post's blocks into the answer context.
                     if threads_task is not None:
                         threads_block = await self._resolve_threads_block(
-                            threads_task=threads_task, route_done=route_done
+                            message=message, threads_task=threads_task, route_done=route_done
                         )
                         threads_task = None
                         context = context.model_copy(update={"threads_block": threads_block})

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -57,6 +57,7 @@ from discordbot.cogs._gen_reply.memory_tool import (
 )
 from discordbot.cogs._memory.server_prompts import SERVER_PHASE1_PROMPT, SERVER_PHASE2_PROMPT
 from discordbot.cogs._parse_threads.builder import THREADS_CONTEXT_SEPARATOR
+from discordbot.cogs._gen_reply.attachment.base import loggable_cache_key
 from discordbot.cogs._gen_reply.attachment.inline import InlineRenderer
 from discordbot.cogs._gen_reply.attachment.select import build_attachment_handler
 from discordbot.cogs._gen_reply.attachment.gemini_file_api import (
@@ -1481,6 +1482,16 @@ async def test_resolve_file_upload_recovers_pending_on_next_reference(
     assert "vid" not in uploader._pending_uploads
     assert files.upload_calls == [("v.mp4", "video/mp4")]  # no second upload
     assert load_calls == 1  # adopt path did not re-download the source
+
+
+def test_loggable_cache_key_strips_url_query_token() -> None:
+    """An int key logs unchanged; a URL key drops its (possibly signed) query string."""
+    assert loggable_cache_key(cache_key=12345) == 12345
+    assert (
+        loggable_cache_key(cache_key="https://media.discordapp.net/x/y.png?ex=1&hm=secrettoken")
+        == "https://media.discordapp.net/x/y.png"
+    )
+    assert loggable_cache_key(cache_key="https://cdn.example/a.png") == "https://cdn.example/a.png"
 
 
 async def test_openai_file_uploader_renders_image_and_file_parts(

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -11,6 +11,8 @@ import asyncio
 from datetime import UTC, datetime, timedelta
 
 from PIL import Image
+import httpx
+from openai import APITimeoutError
 import pytest
 import nextcord
 from nextcord import File, Embed
@@ -34,6 +36,8 @@ from discordbot.cogs._gen_reply.input import USAGE_FOOTER_RE, MessageInputBuilde
 from discordbot.cogs._gen_reply.voice import (
     VOICE_MARKER,
     VOICE_TIMEOUT_SECONDS,
+    VoiceClip,
+    VoiceOutcome,
     VoiceSynthesizer,
     strip_voice_marker,
     speechify_discord_markup,
@@ -121,6 +125,7 @@ class FakeChannel:
         """Initializes the channel stub with its history coroutine and visibility."""
         self.history = history
         self.parent = None
+        self.id = 555
         self._view_channel = view_channel
         self.sent: list[FakeReply] = []
 
@@ -831,17 +836,20 @@ async def test_streaming_reraises_non_deletion_http_errors(economy_isolated_db: 
 
 
 class _FakeVoiceSynthesizer:
-    """Records synthesize calls and returns configurable bytes for streamer voice tests."""
+    """Records synthesize calls and returns a configurable VoiceClip for streamer voice tests."""
 
-    def __init__(self, audio: bytes | None = b"RIFFfake-wav") -> None:
-        """Stores the audio bytes to return (None to simulate failure / skip)."""
+    def __init__(
+        self, audio: bytes | None = b"RIFFfake-wav", outcome: VoiceOutcome = VoiceOutcome.OK
+    ) -> None:
+        """Stores the audio bytes (None to simulate failure) and the reported outcome."""
         self.audio = audio
+        self.outcome = outcome
         self.calls: list[dict[str, str]] = []
 
-    async def synthesize(self, *, text: str, end_user_id: str) -> bytes | None:
-        """Records the spoken-text request and returns the preset bytes."""
+    async def synthesize(self, *, text: str, end_user_id: str) -> VoiceClip:
+        """Records the spoken-text request and returns the preset VoiceClip."""
         self.calls.append({"text": text, "end_user_id": end_user_id})
-        return self.audio
+        return VoiceClip(audio=self.audio, outcome=self.outcome)
 
 
 def _voice_marker_events() -> list[SimpleNamespace]:
@@ -869,6 +877,8 @@ async def test_voice_marker_triggers_synthesis_and_strips_tag(economy_isolated_d
     assert synthesizer.calls == [{"text": "閉嘴啦白痴", "end_user_id": message.author.name}]
     assert message.replies[0].file is not None
     assert message.replies[0].file.filename == "reply.wav"
+    # A delivered clip is silent: no failure-hint reaction on the source message.
+    assert message.added_reactions == []
 
 
 async def test_voice_marker_absent_no_synthesis(economy_isolated_db: None) -> None:
@@ -883,6 +893,8 @@ async def test_voice_marker_absent_no_synthesis(economy_isolated_db: None) -> No
 
     assert synthesizer.calls == []
     assert message.replies[0].file is None
+    # The model chose no voice, so there is nothing to hint about.
+    assert message.added_reactions == []
 
 
 async def test_voice_disabled_still_strips_marker(economy_isolated_db: None) -> None:
@@ -899,10 +911,10 @@ async def test_voice_disabled_still_strips_marker(economy_isolated_db: None) -> 
 
 
 async def test_voice_synthesis_failure_leaves_text_reply(economy_isolated_db: None) -> None:
-    """A None from the synthesizer (failure / too long) leaves a clean text reply, no file."""
+    """A synthesis error leaves a clean text reply, no file, and hints with a warning emoji."""
     del economy_isolated_db
     message = FakeMessage()
-    synthesizer = _FakeVoiceSynthesizer(audio=None)
+    synthesizer = _FakeVoiceSynthesizer(audio=None, outcome=VoiceOutcome.ERROR)
 
     result = await ResponseStreamer(message=message, voice_synthesizer=synthesizer).stream(
         responses=_stream_events_from(_voice_marker_events())
@@ -910,6 +922,23 @@ async def test_voice_synthesis_failure_leaves_text_reply(economy_isolated_db: No
 
     assert VOICE_MARKER not in result
     assert message.replies[0].file is None
+    # A non-timeout failure (most often a policy refusal) hints with the warning emoji.
+    assert message.added_reactions == ["⚠️"]
+
+
+async def test_voice_synthesis_timeout_hints_with_clock(economy_isolated_db: None) -> None:
+    """A synthesis timeout leaves a text reply and hints with the clock emoji, staying silent."""
+    del economy_isolated_db
+    message = FakeMessage()
+    synthesizer = _FakeVoiceSynthesizer(audio=None, outcome=VoiceOutcome.TIMEOUT)
+
+    result = await ResponseStreamer(message=message, voice_synthesizer=synthesizer).stream(
+        responses=_stream_events_from(_voice_marker_events())
+    )
+
+    assert VOICE_MARKER not in result
+    assert message.replies[0].file is None
+    assert message.added_reactions == ["⏱️"]
 
 
 def test_strip_voice_marker_variants() -> None:
@@ -1032,9 +1061,10 @@ async def test_voice_synthesizer_prepends_style_and_returns_bytes() -> None:
     speech = _FakeSpeech(data=b"RIFFwav")
     synth = VoiceSynthesizer(client=_fake_audio_client(speech=speech))
 
-    audio = await synth.synthesize(text="閉嘴", end_user_id="tester")
+    clip = await synth.synthesize(text="閉嘴", end_user_id="tester")
 
-    assert audio == b"RIFFwav"
+    assert clip.outcome is VoiceOutcome.OK
+    assert clip.audio == b"RIFFwav"
     assert speech.calls[0]["input"].endswith("閉嘴")
     assert speech.calls[0]["input"] != "閉嘴"
     # response_format is intentionally never sent (the proxy 500s on it).
@@ -1044,11 +1074,25 @@ async def test_voice_synthesizer_prepends_style_and_returns_bytes() -> None:
 
 
 async def test_voice_synthesizer_swallows_provider_errors() -> None:
-    """A provider error degrades to None so the reply stays text-only."""
+    """A provider error reports ERROR with no audio so the reply stays text-only."""
     speech = _FakeSpeech(error=RuntimeError("boom"))
     synth = VoiceSynthesizer(client=_fake_audio_client(speech=speech))
 
-    assert await synth.synthesize(text="嗆你", end_user_id="tester") is None
+    clip = await synth.synthesize(text="嗆你", end_user_id="tester")
+
+    assert clip.audio is None
+    assert clip.outcome is VoiceOutcome.ERROR
+
+
+async def test_voice_synthesizer_reports_timeout() -> None:
+    """A request timeout is reported as TIMEOUT so the caller can hint distinctly."""
+    speech = _FakeSpeech(error=APITimeoutError(request=httpx.Request("POST", "http://proxy")))
+    synth = VoiceSynthesizer(client=_fake_audio_client(speech=speech))
+
+    clip = await synth.synthesize(text="嗆你", end_user_id="tester")
+
+    assert clip.audio is None
+    assert clip.outcome is VoiceOutcome.TIMEOUT
 
 
 async def test_voice_oversized_clip_not_attached(economy_isolated_db: None) -> None:
@@ -1064,6 +1108,8 @@ async def test_voice_oversized_clip_not_attached(economy_isolated_db: None) -> N
 
     assert VOICE_MARKER not in result
     assert message.replies[0].file is None
+    # An oversized clip is dropped for a non-timeout reason, so it hints with the warning emoji.
+    assert message.added_reactions == ["⚠️"]
 
 
 @pytest.mark.parametrize(("enabled", "expect_synth"), [(True, True), (False, False)])
@@ -1346,13 +1392,14 @@ async def test_upload_file_polls_active_and_drops_unready_files(
         is None
     )
 
-    # Never leaves PROCESSING within the bound: the timeout drops the file. Scripted
-    # times drive deadline -> under-deadline -> past-deadline; a fallback covers any
-    # extra monotonic reads (e.g. logging) so the clock never runs dry mid-call.
-    scripted_times = [0.0, 0.0, 100.0]
+    # Never leaves PROCESSING within the bound: the timeout drops the file. An auto-advancing
+    # clock jumps past the 15s bound on each read, so the deadline trips regardless of how many
+    # monotonic() calls the upload path makes (e.g. for latency logging).
+    clock = {"now": 0.0}
 
     def _fake_monotonic() -> float:
-        return scripted_times.pop(0) if scripted_times else 100.0
+        clock["now"] += 50.0
+        return clock["now"]
 
     monkeypatch.setattr(
         "discordbot.cogs._gen_reply.attachment.gemini_file_api.time.monotonic", _fake_monotonic
@@ -1385,10 +1432,14 @@ async def test_resolve_file_upload_recovers_pending_on_next_reference(
         "discordbot.cogs._gen_reply.attachment.gemini_file_api.asyncio.sleep", _no_sleep
     )
 
-    scripted_times = [0.0, 0.0, 100.0]
+    # Auto-advancing clock: each call jumps well past the 15s activation bound, so the first
+    # reference times out to PENDING regardless of how many monotonic() calls the upload path
+    # makes (e.g. for latency logging). Robust to instrumentation, unlike a hand-counted list.
+    clock = {"now": 0.0}
 
     def _fake_monotonic() -> float:
-        return scripted_times.pop(0) if scripted_times else 100.0
+        clock["now"] += 50.0
+        return clock["now"]
 
     monkeypatch.setattr(
         "discordbot.cogs._gen_reply.attachment.gemini_file_api.time.monotonic", _fake_monotonic
@@ -3434,7 +3485,12 @@ async def test_resolve_effort_returns_graded_effort_on_success() -> None:
         return EffortGrade(effort="low")
 
     effort_task = asyncio.create_task(coro=graded())
-    assert await cog._resolve_effort(effort_task=effort_task, route_done=route_done) == "low"
+    assert (
+        await cog._resolve_effort(
+            message=FakeMessage(), effort_task=effort_task, route_done=route_done
+        )
+        == "low"
+    )
 
 
 async def test_resolve_effort_defaults_high_on_error() -> None:
@@ -3448,7 +3504,12 @@ async def test_resolve_effort_defaults_high_on_error() -> None:
         raise RuntimeError("boom")
 
     effort_task = asyncio.create_task(coro=boom())
-    assert await cog._resolve_effort(effort_task=effort_task, route_done=route_done) == "high"
+    assert (
+        await cog._resolve_effort(
+            message=FakeMessage(), effort_task=effort_task, route_done=route_done
+        )
+        == "high"
+    )
 
 
 async def test_resolve_effort_defaults_high_on_grace_timeout(
@@ -3466,7 +3527,12 @@ async def test_resolve_effort_defaults_high_on_grace_timeout(
         return EffortGrade(effort="low")
 
     effort_task = asyncio.create_task(coro=slow())
-    assert await cog._resolve_effort(effort_task=effort_task, route_done=route_done) == "high"
+    assert (
+        await cog._resolve_effort(
+            message=FakeMessage(), effort_task=effort_task, route_done=route_done
+        )
+        == "high"
+    )
 
 
 async def test_on_message_cancels_effort_task_on_image_route(


### PR DESCRIPTION
## Why

The `gen_reply` pipeline carried sparse, inconsistent logs: most lines only had `elapsed_seconds`/`decision` and almost none recorded **who** triggered a reply. The one identifying error log even mislabeled the username as `user_id`. Several flows were fully silent (the video handler, the attachment uploaders' timing/cache, the answer-complete summary). Voice synthesis failures were also silent to the user with no cue that a requested clip was dropped.

## What

### Logging redesign (whole `gen_reply` surface)
- New `_message_log_fields(message)` helper (typed via a `TypedDict`) producing the standard identifying context: `user_id`, `user_name`, `display_name`, `message_id`, `channel_id`, `guild_id`, `guild_name` (None in a DM).
- Milestones carry full identity (`gen_reply received` entry log, the top-level failure log — which also fixes the `user_id` mislabel); every intermediate log carries `message_id` as the correlation key, so `grep <message_id>` reconstructs a whole turn.
- `info` stays the per-turn skeleton; deep detail (attachment cache hit / render, uploader start/done, gemini repoll + media-slot wait, video poll iterations, empty-prompt early return, memory allowlist) is `debug`.
- Filled gaps: the previously silent video handler (start / job-created / poll / delivered / failed), the image handler (start / delivered), a `reply finalized` summary (model, effort, tokens, cost, length, voice flag, chunking), and the memory-selection picks (selected ids + labels + allowlist size).
- Converted f-string log messages in `input.py` and the attachment uploaders to structured keyword arguments.
- Message content is never logged (only `prompt_chars` and metadata).

### Voice-failure hint
- `VoiceSynthesizer.synthesize` now returns a `VoiceClip` (audio + `VoiceOutcome`), splitting `APITimeoutError` from other provider errors.
- When a requested clip cannot be delivered the reply stays text-only and silent, but the source message gets a small reaction hint: `⏱️` on a timeout, `⚠️` on any other failure (most often a policy refusal, or an oversized / un-attachable clip). The model choosing no voice, voice being disabled, or an empty reply add no hint.

## Test plan
- `uv run pytest` — 876 passed.
- `uv run pre-commit run -a` — all hooks pass (ruff, mypy).
- Added/updated voice tests for the `VoiceClip` contract, the timeout vs. error split, and the emoji-hint behavior; made the gemini activation-poll tests' fake clock robust to instrumentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
