### PR TITLE
fix: harden deep research plan lifecycle and restart resume

### DIFF
--- a/src/discordbot/cogs/_research/agent.py
+++ b/src/discordbot/cogs/_research/agent.py
@@ -237,6 +237,7 @@ async def start_plan(
         input=brief,
         system_instruction=system_instruction,
         agent_config=_deep_research_agent_config(collaborative_planning=True),
+        tools=RESEARCH_TOOLS,
         background=True,
         store=True,
     )
@@ -269,6 +270,7 @@ async def refine_plan(
         previous_interaction_id=previous_interaction_id,
         system_instruction=system_instruction,
         agent_config=_deep_research_agent_config(collaborative_planning=True),
+        tools=RESEARCH_TOOLS,
         background=True,
         store=True,
     )

--- a/src/discordbot/cogs/_research/database.py
+++ b/src/discordbot/cogs/_research/database.py
@@ -245,7 +245,7 @@ async def set_phase(*, thread_id: int, phase: ResearchPhase) -> None:
         await session.commit()
 
 
-async def claim_research(*, thread_id: int) -> bool:
+async def claim_research(*, thread_id: int, plan_interaction_id: str) -> bool:
     """Atomically claims a planning row for the full research run.
 
     Transitions `planning` -> `researching` and clears the stale plan `interaction_id` in one
@@ -253,6 +253,10 @@ async def claim_research(*, thread_id: int) -> bool:
     「接受並開始」 clicks launch at most one paid run. Clearing the id means a restart in the
     window before the real run id is stored cannot resume the completed plan and deliver its
     text as a report (`list_resumable` keeps it, but `_resume_one` sees no id and fails it).
+
+    Guarded on `interaction_id` so only the plan the clicked button belongs to can be claimed: a
+    stale approval view left over from a refine flow (its `plan_interaction_id` no longer matches
+    the row) loses the claim instead of launching research from the superseded plan.
     """
     await _ensure_schema()
     now = _database_now()
@@ -260,7 +264,9 @@ async def claim_research(*, thread_id: int) -> bool:
         result = await session.execute(
             statement=update(ResearchSessionRow)
             .where(
-                ResearchSessionRow.thread_id == thread_id, ResearchSessionRow.phase == "planning"
+                ResearchSessionRow.thread_id == thread_id,
+                ResearchSessionRow.phase == "planning",
+                ResearchSessionRow.interaction_id == plan_interaction_id,
             )
             .values(phase="researching", interaction_id=None, updated_at=now)
         )

--- a/src/discordbot/cogs/research.py
+++ b/src/discordbot/cogs/research.py
@@ -102,6 +102,9 @@ class ResearchCogs(commands.Cog):
         # Thread ids the cog is actively driving; `gen_reply` checks this so QA does not
         # double-handle a message typed inside a research thread.
         self._active_threads: set[int] = set()
+        # Thread ids whose modify flow is awaiting owner feedback; guards `on_modify_plan` against a
+        # double-click installing two `wait_for` listeners (competing refine plans).
+        self._pending_modify: set[int] = set()
         self._resume_started = False
 
     @cached_property
@@ -597,7 +600,7 @@ class ResearchCogs(commands.Cog):
         for chunk in split_report(text=plan.plan_text.strip() or "(沒有收到計畫內容)"):
             await self._safe_send(thread=thread, content=chunk)
         owner_id = _owner_id_from_mention(mention=owner_mention)
-        await self._safe_send(
+        posted = await self._safe_send(
             thread=thread,
             content=f"{owner_mention} 📋 接受就開始研究(會花時間與成本),或點「修改計畫」直接打字告訴我要調整什麼",
             view=PlanApprovalView(
@@ -608,6 +611,32 @@ class ResearchCogs(commands.Cog):
                 thread_id=thread.id,
             ),
             allowed_mentions=_owner_allowed_mentions(owner_id=owner_id),
+        )
+        if posted is None:
+            # The approval view never reached Discord, so no buttons exist and no view timeout is
+            # registered to free the slot. Cancel this plan and release the owner instead of
+            # blocking them behind an un-actable `planning` row until a restart sweep.
+            await self._cancel_unposted_plan(
+                thread=thread, owner_mention=owner_mention, plan_interaction_id=plan.interaction_id
+            )
+
+    async def _cancel_unposted_plan(
+        self, *, thread: "Thread", owner_mention: str, plan_interaction_id: str
+    ) -> None:
+        """Frees the owner when a plan's approval view could not be posted (best-effort).
+
+        Guarded on the plan's `interaction_id` (via `cancel_stale_plan`) so it only cancels the
+        plan that failed to post, never a fresher one.
+        """
+        if not await db.cancel_stale_plan(
+            thread_id=thread.id, plan_interaction_id=plan_interaction_id
+        ):
+            return
+        self._active_threads.discard(thread.id)
+        await self._post_failure(
+            thread=thread,
+            owner_mention=owner_mention,
+            reason="計畫送不出去,先收起來了,要的話重新發起一次",
         )
 
     async def on_plan_timeout(
@@ -641,8 +670,12 @@ class ResearchCogs(commands.Cog):
         if thread is None:
             return
         # Atomic claim: a double-click can fire two callbacks before the view-removal edit lands, so
-        # only the call that wins the planning->researching transition spawns the paid run.
-        if not await db.claim_research(thread_id=thread.id):
+        # only the call that wins the planning->researching transition spawns the paid run. Guarded
+        # on the view's plan interaction id so a stale approval view (left after a refine) cannot
+        # claim the row and launch research from its superseded plan.
+        if not await db.claim_research(
+            thread_id=thread.id, plan_interaction_id=view.plan_interaction_id
+        ):
             return
         self._active_threads.add(thread.id)
         self._spawn(
@@ -656,50 +689,70 @@ class ResearchCogs(commands.Cog):
 
     async def on_modify_plan(self, *, interaction: Interaction, view: PlanApprovalView) -> None:
         """Modify button: waits for the owner to type changes, then re-plans."""
-        await interaction.response.send_message(
-            content="好,直接在這個 thread 打你想調整的地方,我會重新規劃(10 分鐘內回覆有效)"
-        )
-        with contextlib.suppress(Exception):
-            await interaction.message.edit(view=None)
         thread = interaction.channel
         if thread is None:
             return
-
-        def _is_owner_reply(candidate: "Message") -> bool:
-            return (
-                candidate.channel.id == thread.id
-                and candidate.author.id == view.owner_id
-                and not candidate.author.bot
-            )
-
-        try:
-            reply = await self.bot.wait_for(
-                "message", check=_is_owner_reply, timeout=MODIFY_WAIT_TIMEOUT_SECONDS
-            )
-        except TimeoutError:
-            # The modify click removed the approval buttons; the plan is still valid (the row stays
-            # `planning`), so repost a fresh view rather than leaving the owner with no way forward.
-            await self._safe_send(
-                thread=thread,
-                content="等太久了,要的話用下面的按鈕再試一次",
-                view=PlanApprovalView(
-                    cog=self,
-                    owner_id=view.owner_id,
-                    plan_interaction_id=view.plan_interaction_id,
-                    agent=view.agent,
-                    thread_id=thread.id,
-                ),
-            )
+        # Idempotency: a double-click would install two `wait_for` listeners, so one feedback
+        # message would spawn competing `_run_refine` plans against the same interaction. Ignore a
+        # second click while one modify is already awaiting this thread's feedback. The membership
+        # check and the add share no `await`, so two clicks cannot both pass on the single loop.
+        if thread.id in self._pending_modify:
+            with contextlib.suppress(Exception):
+                await interaction.response.defer()
             return
-        self._spawn(
-            self._run_refine(
-                thread=thread,
-                owner_mention=f"<@{view.owner_id}>",
-                agent=view.agent,
-                previous_interaction_id=view.plan_interaction_id,
-                feedback=reply.content,
+        self._pending_modify.add(thread.id)
+        try:
+            await interaction.response.send_message(
+                content="好,直接在這個 thread 打你想調整的地方,我會重新規劃(10 分鐘內回覆有效)"
             )
-        )
+            with contextlib.suppress(Exception):
+                await interaction.message.edit(view=None)
+
+            def _is_owner_reply(candidate: "Message") -> bool:
+                return (
+                    candidate.channel.id == thread.id
+                    and candidate.author.id == view.owner_id
+                    and not candidate.author.bot
+                )
+
+            try:
+                reply = await self.bot.wait_for(
+                    "message", check=_is_owner_reply, timeout=MODIFY_WAIT_TIMEOUT_SECONDS
+                )
+            except TimeoutError:
+                # The modify click removed the approval buttons; the plan is still valid (the row
+                # stays `planning`), so repost a fresh view rather than leaving the owner stuck.
+                reposted = await self._safe_send(
+                    thread=thread,
+                    content="等太久了,要的話用下面的按鈕再試一次",
+                    view=PlanApprovalView(
+                        cog=self,
+                        owner_id=view.owner_id,
+                        plan_interaction_id=view.plan_interaction_id,
+                        agent=view.agent,
+                        thread_id=thread.id,
+                    ),
+                )
+                if reposted is None:
+                    # The fresh view could not be posted either, so no buttons or timeout exist to
+                    # free the slot; cancel the plan and release the owner.
+                    await self._cancel_unposted_plan(
+                        thread=thread,
+                        owner_mention=f"<@{view.owner_id}>",
+                        plan_interaction_id=view.plan_interaction_id,
+                    )
+                return
+            self._spawn(
+                self._run_refine(
+                    thread=thread,
+                    owner_mention=f"<@{view.owner_id}>",
+                    agent=view.agent,
+                    previous_interaction_id=view.plan_interaction_id,
+                    feedback=reply.content,
+                )
+            )
+        finally:
+            self._pending_modify.discard(thread.id)
 
     async def _run_refine(
         self,
@@ -790,12 +843,16 @@ class ResearchCogs(commands.Cog):
 
     async def _resume_one(self, *, session: db.PersistentResearchSession) -> None:
         """Resumes one research session, delivering when it settles."""
+        thread = await self._fetch_thread(thread_id=session.thread_id)
+        owner_mention = f"<@{session.owner_id}>"
+        # No interaction id means the row was claimed for research but the bot restarted before the
+        # real run id was stored; there is nothing to resume. Tell the thread so the owner is not
+        # left staring at the old `Researching...` message forever.
         if session.interaction_id is None:
             await db.set_phase(thread_id=session.thread_id, phase="failed")
             self._active_threads.discard(session.thread_id)
+            await self._notify_resume_failed(thread=thread, owner_id=session.owner_id)
             return
-        thread = await self._fetch_thread(thread_id=session.thread_id)
-        owner_mention = f"<@{session.owner_id}>"
         try:
             result = await resume_research(
                 client=self.interactions_client,
@@ -806,6 +863,7 @@ class ResearchCogs(commands.Cog):
             logfire.warn("research resume failed", thread_id=session.thread_id, _exc_info=True)
             await db.set_phase(thread_id=session.thread_id, phase="failed")
             self._active_threads.discard(session.thread_id)
+            await self._notify_resume_failed(thread=thread, owner_id=session.owner_id)
             return
         if thread is None:
             await db.set_phase(
@@ -821,6 +879,16 @@ class ResearchCogs(commands.Cog):
             status=None,
             offer_escalation="deep-research" not in session.agent,
         )
+
+    async def _notify_resume_failed(self, *, thread: "Thread | None", owner_id: int) -> None:
+        """Tells a thread its interrupted research could not be resumed after a restart (best-effort)."""
+        if thread is None:
+            return
+        with contextlib.suppress(Exception):
+            await thread.send(
+                content=f"<@{owner_id}> 重啟後沒辦法接回剛剛的研究,麻煩重新發起一次",
+                allowed_mentions=_owner_allowed_mentions(owner_id=owner_id),
+            )
 
     async def _fetch_thread(self, *, thread_id: int) -> "Thread | None":
         """Returns the thread by id from cache or a REST fetch, or None when gone."""

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -83,6 +83,50 @@ def test_deep_research_agent_config_shape() -> None:
     assert run_config["collaborative_planning"] is False
 
 
+class _RecordingInteractions:
+    """Records the kwargs of the last `create` and settles `get` immediately as completed."""
+
+    def __init__(self) -> None:
+        self.create_kwargs: dict[str, object] = {}
+
+    async def create(self, **kwargs: object) -> SimpleNamespace:
+        self.create_kwargs = kwargs
+        return SimpleNamespace(id="plan_x")
+
+    async def get(self, **kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            id=kwargs.get("id"), status="completed", output_text="a plan", steps=[]
+        )
+
+
+def _recording_client() -> SimpleNamespace:
+    return SimpleNamespace(aio=SimpleNamespace(interactions=_RecordingInteractions()))
+
+
+async def test_start_plan_passes_research_tools() -> None:
+    client = _recording_client()
+    plan = await agent.start_plan(
+        client=client, agent="deep-research-preview-04-2026", brief="b", system_instruction="sys"
+    )
+    # Planning must pass the restricted search/url tool set so the agent default (which can include
+    # code execution) cannot leak raw tool-call text into the plan.
+    assert client.aio.interactions.create_kwargs["tools"] is agent.RESEARCH_TOOLS
+    assert plan.status == "completed"
+
+
+async def test_refine_plan_passes_research_tools() -> None:
+    client = _recording_client()
+    plan = await agent.refine_plan(
+        client=client,
+        agent="deep-research-preview-04-2026",
+        previous_interaction_id="plan_v1",
+        feedback="tighten the scope",
+        system_instruction="sys",
+    )
+    assert client.aio.interactions.create_kwargs["tools"] is agent.RESEARCH_TOOLS
+    assert plan.status == "completed"
+
+
 def test_to_result_extracts_text_image_and_usage() -> None:
     image_b64 = base64.b64encode(b"PNGBYTES").decode()
     interaction = SimpleNamespace(
@@ -299,13 +343,36 @@ async def test_claim_research_is_idempotent_and_clears_stale_id(
         brief="b",
         phase="planning",
     )
-    assert await rdb.claim_research(thread_id=30) is True
+    assert await rdb.claim_research(thread_id=30, plan_interaction_id="plan_1") is True
     session = await rdb.get_session(thread_id=30)
     assert session is not None
     assert session.phase == "researching"
     assert session.interaction_id is None
     # A second (double-click) claim loses: the row is no longer in `planning`.
-    assert await rdb.claim_research(thread_id=30) is False
+    assert await rdb.claim_research(thread_id=30, plan_interaction_id="plan_1") is False
+
+
+async def test_claim_research_rejects_stale_plan_interaction(research_isolated_db: None) -> None:
+    await rdb.upsert_session(
+        thread_id=31,
+        owner_id=1,
+        channel_id=1,
+        guild_id=1,
+        source_message_id=1,
+        agent="deep-research-preview-04-2026",
+        interaction_id="plan_v2",
+        brief="b",
+        phase="planning",
+    )
+    # A stale approval view (its plan interaction was superseded by a refine) loses the claim, so
+    # research never launches from the old plan; the row stays `planning` for the fresh view.
+    assert await rdb.claim_research(thread_id=31, plan_interaction_id="plan_v1") is False
+    session = await rdb.get_session(thread_id=31)
+    assert session is not None
+    assert session.phase == "planning"
+    assert session.interaction_id == "plan_v2"
+    # The current plan's view wins the claim.
+    assert await rdb.claim_research(thread_id=31, plan_interaction_id="plan_v2") is True
 
 
 async def test_claim_planning_is_idempotent(research_isolated_db: None) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #310 (now merged). Codex flagged five P2 robustness issues in the deep-research plan/refine and restart-resume paths that were never resolved before merge; these are real bugs on `main` now. This PR addresses all five.

## Fixes

1. **Pass restricted tools during planning** (`_research/agent.py`). `start_plan` / `refine_plan` omitted `tools=`, so collaborative-planning interactions fell back to the agent default tool set (which can include code execution). The module already documents that code-execution tool calls leak raw `call:default_api:bash{...}` text into `output_text` and corrupt the report; the same leakage could land verbatim in a posted plan. Both calls now pass `tools=RESEARCH_TOOLS`, matching the actual research runs (`start_antigravity` / `start_deep_research`).

2. **Notify the thread when restart resume fails** (`research.py::_resume_one`). When a stored `researching` interaction could not be resumed (no run id stored yet, or repeated API errors), the row was marked failed and the active flag dropped, but nothing was posted — the owner was left staring at the old `Researching...` message. Both failure paths now post a best-effort owner-pinged notice via a new `_notify_resume_failed` helper.

3. **Free the owner when a plan view cannot be posted** (`research.py::_post_plan`). The row is set to `planning` before the approval view is sent; `_safe_send` swallows a failed send and returns `None`, leaving no buttons and no registered view timeout, so the owner stayed blocked until a restart sweep. The `None` return is now detected and the plan is cancelled (interaction-id-guarded) + the slot freed via a new `_cancel_unposted_plan` helper. The same guard is applied to the modify-timeout repost site.

4. **Guard plan acceptance by interaction id** (`_research/database.py::claim_research` + `research.py::on_accept_plan`). The atomic claim matched on `phase == "planning"` only, so a stale approval view (left after a refine) could claim the current row and launch research from its superseded `plan_interaction_id`. The claim now also matches `interaction_id == plan_interaction_id` (mirroring `cancel_stale_plan`), so a stale view loses the claim.

5. **Make modify clicks idempotent** (`research.py::on_modify_plan`). A double-click installed two `wait_for` listeners, so one feedback message spawned competing `_run_refine` plans. A second click is now ignored while one modify is already awaiting feedback, via an in-memory `_pending_modify` guard set before the first `await` (so two clicks cannot both pass on the single event loop).

## Note on the CI failure

The GitLeaks job on #310's final commit failed with `unknown revision`. Investigated: it is a merge/branch-delete race — the run for the last commit executed after the PR was squash-merged and its branch deleted, so gitleaks' API-derived diff range could not resolve against the stale PR merge ref. Eleven prior PR runs on the same branch and the `main` push scan all passed; the workflow itself is not broken, so no workflow change is included.

## Tests

`tests/test_research.py`: updated `claim_research` idempotency test for the new signature, added a stale-`plan_interaction_id` rejection test, and added assertions that `start_plan` / `refine_plan` pass `tools=RESEARCH_TOOLS`. Full suite green; ruff / mypy / pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)