### PR TITLE
refactor: import nextcord classes explicitly instead of namespacing

### DIFF
--- a/src/discordbot/cogs/_economy/interactions.py
+++ b/src/discordbot/cogs/_economy/interactions.py
@@ -1,7 +1,6 @@
 """Shared send/edit helpers for economy interaction responses."""
 
-import nextcord
-from nextcord import Embed, Interaction
+from nextcord import File, Embed, Interaction
 from nextcord.ui import View
 
 from discordbot.utils.discord_embeds import embed_spacer_payload
@@ -9,10 +8,7 @@ from discordbot.utils.message_cleanup import schedule_public_message_delete
 
 
 async def send_expiring_followup(
-    interaction: Interaction,
-    embed: Embed,
-    view: View | None = None,
-    file: nextcord.File | None = None,
+    interaction: Interaction, embed: Embed, view: View | None = None, file: File | None = None
 ) -> None:
     """Sends a game-related economy embed and schedules its cleanup."""
     extra_files = [file] if file is not None else None

--- a/src/discordbot/cogs/_economy/views.py
+++ b/src/discordbot/cogs/_economy/views.py
@@ -3,7 +3,7 @@
 import contextlib
 
 import nextcord
-from nextcord import ButtonStyle, Interaction
+from nextcord import Message, ButtonStyle, Interaction
 from nextcord.ui import View, Button
 from nextcord.ext import commands
 
@@ -32,7 +32,7 @@ from discordbot.cogs._economy.interactions import edit_response_embed, send_ephe
 class LoanDecisionViewBase(View):
     """Shared cleanup behavior for public loan-decision views."""
 
-    message: nextcord.Message | None
+    message: Message | None
 
     def _schedule_cleanup(self, interaction: Interaction | None = None) -> None:
         """Schedules the public request message for cleanup after a terminal state."""
@@ -61,7 +61,7 @@ class CentralBankLoanDecisionView(LoanDecisionViewBase):
         self.proposal_id = proposal_id
         self.creator_id = creator_id
         self.allow_self_approval = allow_self_approval
-        self.message: nextcord.Message | None = None
+        self.message: Message | None = None
 
     async def on_timeout(self) -> None:
         """Rejects a stale central-bank request and cleans up its message."""
@@ -218,7 +218,7 @@ class CreditLoanDecisionView(LoanDecisionViewBase):
         self.proposal_id = proposal_id
         self.lender_id = lender_id
         self.creator_id = creator_id
-        self.message: nextcord.Message | None = None
+        self.message: Message | None = None
 
     async def on_timeout(self) -> None:
         """Rejects a stale personal credit request and cleans up its message."""

--- a/src/discordbot/cogs/_games/dragon_gate_views.py
+++ b/src/discordbot/cogs/_games/dragon_gate_views.py
@@ -8,7 +8,7 @@ import contextlib
 
 import logfire
 import nextcord
-from nextcord import Embed, Message, ButtonStyle, Interaction
+from nextcord import Embed, Message, ButtonStyle, Interaction, SelectOption
 from nextcord.ui import Item, View, Modal, Button, TextInput, StringSelect
 
 from discordbot.typings.games import GameParticipant, DragonGatePlayerResult
@@ -492,9 +492,9 @@ class DragonGateView(View):
         min_values=1,
         max_values=1,
         options=[
-            nextcord.SelectOption(label="底注", value="min", emoji="🪙"),
-            nextcord.SelectOption(label="全池", value="max", emoji="💰"),
-            nextcord.SelectOption(label="自訂", value="custom", emoji="✏️"),
+            SelectOption(label="底注", value="min", emoji="🪙"),
+            SelectOption(label="全池", value="max", emoji="💰"),
+            SelectOption(label="自訂", value="custom", emoji="✏️"),
         ],
         row=2,
     )
@@ -573,19 +573,19 @@ class DragonGateView(View):
         else:
             bet_select.placeholder = "🪙 選擇下注金額"
         bet_select.options = [
-            nextcord.SelectOption(
+            SelectOption(
                 label=f"底注 {compact_amount(amount=minimum)}",
                 value="min",
                 emoji="🪙",
                 description="最低下注金額",
             ),
-            nextcord.SelectOption(
+            SelectOption(
                 label=f"全池 {compact_amount(amount=maximum)}",
                 value="max",
                 emoji="💰",
                 description="一把定生死, 清空彩金池",
             ),
-            nextcord.SelectOption(
+            SelectOption(
                 label="自訂", value="custom", emoji="✏️", description="彈出視窗輸入精確金額"
             ),
         ]

--- a/src/discordbot/cogs/_gen_reply/streaming.py
+++ b/src/discordbot/cogs/_gen_reply/streaming.py
@@ -9,8 +9,7 @@ import contextlib
 from collections.abc import AsyncIterator
 
 import logfire
-import nextcord
-from nextcord import File, Message
+from nextcord import File, Message, NotFound, HTTPException
 from pydantic import Field, BaseModel, ConfigDict, PrivateAttr, SkipValidation
 from nextcord.utils import escape_mentions
 from openai.types.responses import (
@@ -181,8 +180,8 @@ class ResponseStreamer(BaseModel):
         """
         try:
             return await self.message.reply(content=content)
-        except nextcord.HTTPException as exc:
-            if exc.code != 50035 and not isinstance(exc, nextcord.NotFound):
+        except HTTPException as exc:
+            if exc.code != 50035 and not isinstance(exc, NotFound):
                 raise
             logfire.info(
                 "Source message deleted before reply; sending unparented",

--- a/src/discordbot/cogs/_memory/views.py
+++ b/src/discordbot/cogs/_memory/views.py
@@ -4,7 +4,7 @@ from typing import cast
 import contextlib
 
 import nextcord
-from nextcord import Embed, Interaction
+from nextcord import Embed, ButtonStyle, Interaction
 from nextcord.ui import View, Button
 
 MEMORY_VIEW_TIMEOUT_SECONDS = 180
@@ -108,14 +108,14 @@ class MemoryPagesView(View):
         cast("Button", self.previous_page).disabled = self.page_index <= 0
         cast("Button", self.next_page).disabled = self.page_index >= len(self.pages) - 1
 
-    @nextcord.ui.button(label="◀ 上一頁", style=nextcord.ButtonStyle.secondary)
+    @nextcord.ui.button(label="◀ 上一頁", style=ButtonStyle.secondary)
     async def previous_page(self, _button: Button, interaction: Interaction) -> None:
         """Shows the previous page in place."""
         self.page_index = max(self.page_index - 1, 0)
         self._sync_buttons()
         await interaction.response.edit_message(embed=self.current_embed(), view=self)
 
-    @nextcord.ui.button(label="下一頁 ▶", style=nextcord.ButtonStyle.secondary)
+    @nextcord.ui.button(label="下一頁 ▶", style=ButtonStyle.secondary)
     async def next_page(self, _button: Button, interaction: Interaction) -> None:
         """Shows the next page in place."""
         self.page_index = min(self.page_index + 1, len(self.pages) - 1)

--- a/src/discordbot/cogs/_research/delivery.py
+++ b/src/discordbot/cogs/_research/delivery.py
@@ -12,7 +12,8 @@ import io
 from typing import TYPE_CHECKING
 
 import logfire
-import nextcord
+from nextcord import File, Message, AllowedMentions
+from nextcord.ui import View
 
 if TYPE_CHECKING:
     from nextcord import Thread
@@ -56,12 +57,12 @@ def split_report(*, text: str, limit: int = DISCORD_MESSAGE_LIMIT) -> list[str]:
 async def deliver_report(  # noqa: PLR0913 -- the report body plus its completion-message inputs
     *,
     thread: "Thread",
-    status: nextcord.Message | None,
+    status: Message | None,
     owner_mention: str,
     result: "ResearchResult",
     footer: str,
-    view: nextcord.ui.View | None,
-    allowed_mentions: nextcord.AllowedMentions,
+    view: View | None,
+    allowed_mentions: AllowedMentions,
 ) -> None:
     """Delivers the report into the thread.
 
@@ -98,25 +99,25 @@ async def deliver_report(  # noqa: PLR0913 -- the report body plus its completio
         )
 
 
-def _final_files(*, report: str, image_bytes: bytes | None, limit: int) -> list[nextcord.File]:
+def _final_files(*, report: str, image_bytes: bytes | None, limit: int) -> list[File]:
     """The `research.md` (+ optional image) attachments for the last message, honoring the limit."""
-    files: list[nextcord.File] = []
+    files: list[File] = []
     encoded = report.encode("utf-8")
     if len(encoded) <= limit:
-        files.append(nextcord.File(fp=io.BytesIO(encoded), filename="research.md"))
+        files.append(File(fp=io.BytesIO(encoded), filename="research.md"))
     if image_bytes is not None and len(image_bytes) <= limit:
-        files.append(nextcord.File(fp=io.BytesIO(image_bytes), filename="research.png"))
+        files.append(File(fp=io.BytesIO(image_bytes), filename="research.png"))
     return files
 
 
 async def _place(  # noqa: PLR0913 -- target message plus its optional files / view / mention policy
     *,
-    status: nextcord.Message | None,
+    status: Message | None,
     thread: "Thread",
     content: str,
-    files: list[nextcord.File],
-    view: nextcord.ui.View | None,
-    allowed_mentions: nextcord.AllowedMentions,
+    files: list[File],
+    view: View | None,
+    allowed_mentions: AllowedMentions,
 ) -> None:
     """Edits the opening status message (when given) or sends a new message, with optional files/view."""
     if status is not None:

--- a/src/discordbot/cogs/_stock/views.py
+++ b/src/discordbot/cogs/_stock/views.py
@@ -4,7 +4,7 @@ from io import BytesIO
 from typing import cast
 
 import nextcord
-from nextcord import File, User, Member, Message, ButtonStyle, Interaction, SelectOption
+from nextcord import File, User, Embed, Member, Message, ButtonStyle, Interaction, SelectOption
 from pydantic import Field, BaseModel, ConfigDict, SkipValidation
 from nextcord.ui import Modal, Button, TextInput, StringSelect
 
@@ -55,7 +55,7 @@ def _select_option_label(symbol: str, name: str) -> str:
 
 def build_market_message_payload(
     quotes: tuple[StockMarketQuote, ...], page_index: int = 0
-) -> tuple[nextcord.Embed, File]:
+) -> tuple[Embed, File]:
     """Builds the market embed and board attachment for one page."""
     filename = market_board_filename(page_index=page_index)
     embed = build_market_embed(

--- a/src/discordbot/cogs/auto_unmute.py
+++ b/src/discordbot/cogs/auto_unmute.py
@@ -5,8 +5,8 @@ from functools import cached_property
 
 from openai import AsyncOpenAI
 import logfire
-import nextcord
-from nextcord import User, Guild, Member, Message, AuditLogAction
+from nextcord import User, Guild, Member, Message, Forbidden, AuditLogAction
+from nextcord.abc import Messageable
 from nextcord.ext import commands
 
 from discordbot.utils.llm import create_text_or_none
@@ -137,18 +137,18 @@ class AutoUnmuteCogs(commands.Cog):
                 if not hasattr(entry.changes.after, "communication_disabled_until"):
                     continue
                 return entry.user, entry.reason
-        except nextcord.Forbidden:
+        except Forbidden:
             logfire.warn(f"missing view_audit_log permission in {guild.name}")
         return None, None
 
-    def _resolve_channel(self, guild: Guild) -> nextcord.abc.Messageable | None:
+    def _resolve_channel(self, guild: Guild) -> Messageable | None:
         """Picks a target channel: last active channel, then system channel."""
         channel_id = self._last_active_channel.get(guild.id)
         if channel_id is not None:
             channel = guild.get_channel(channel_id)
-            if isinstance(channel, nextcord.abc.Messageable):
+            if isinstance(channel, Messageable):
                 return channel
-        if isinstance(guild.system_channel, nextcord.abc.Messageable):
+        if isinstance(guild.system_channel, Messageable):
             return guild.system_channel
         return None
 

--- a/src/discordbot/cogs/economy.py
+++ b/src/discordbot/cogs/economy.py
@@ -4,7 +4,7 @@ from io import BytesIO
 from datetime import UTC, datetime
 
 import nextcord
-from nextcord import Locale, Member, Interaction, SlashOption
+from nextcord import File, Locale, Member, Interaction, SlashOption
 from nextcord.ext import commands
 
 from discordbot.cogs._economy import embeds
@@ -331,7 +331,7 @@ class EconomyCogs(commands.Cog):
         await send_expiring_followup(
             interaction=interaction,
             embed=embed,
-            file=nextcord.File(fp=BytesIO(board), filename=BALANCE_LEADERBOARD_BOARD_FILENAME),
+            file=File(fp=BytesIO(board), filename=BALANCE_LEADERBOARD_BOARD_FILENAME),
         )
 
     @nextcord.slash_command(
@@ -367,7 +367,7 @@ class EconomyCogs(commands.Cog):
         await send_expiring_followup(
             interaction=interaction,
             embed=embed,
-            file=nextcord.File(fp=BytesIO(board), filename=LOSS_LEADERBOARD_BOARD_FILENAME),
+            file=File(fp=BytesIO(board), filename=LOSS_LEADERBOARD_BOARD_FILENAME),
         )
 
     @nextcord.slash_command(

--- a/src/discordbot/cogs/games.py
+++ b/src/discordbot/cogs/games.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 
 import logfire
 import nextcord
-from nextcord import Embed, Locale, Interaction, SlashOption
+from nextcord import User, Embed, Guild, Locale, Member, Interaction, SlashOption
 from nextcord.ext import commands
 
 from discordbot.typings.games import (
@@ -68,7 +68,7 @@ class GamesCogs(commands.Cog):
         self._startup_cleanup_done = False
         self._blackjack_shoes = BlackjackShoeStore()
 
-    async def _system_identity(self, guild: nextcord.Guild | None = None) -> SystemIdentity:
+    async def _system_identity(self, guild: Guild | None = None) -> SystemIdentity:
         """Returns the casino system identity used for narrator embeds.
 
         Slash commands only fire after the gateway has connected, so
@@ -89,7 +89,7 @@ class GamesCogs(commands.Cog):
         )
 
     async def _bot_blackjack_participant(
-        self, *, guild: nextcord.Guild | None, table_bet: int, channel_id: int
+        self, *, guild: Guild | None, table_bet: int, channel_id: int
     ) -> GameParticipant | None:
         """Returns a Blackjack participant for the bot player, or None if it cannot join."""
         bot_user = self.bot.user
@@ -129,7 +129,7 @@ class GamesCogs(commands.Cog):
 
     @staticmethod
     async def _identity_from_user(
-        user: nextcord.User | nextcord.Member, guild: nextcord.Guild | None = None
+        user: User | Member, guild: Guild | None = None
     ) -> GameParticipantIdentity:
         """Builds the shared game identity for a Discord user."""
         avatar_url = await guild_avatar_url(user=user, guild=guild)
@@ -141,11 +141,7 @@ class GamesCogs(commands.Cog):
         )
 
     async def _participant_from_user(
-        self,
-        user: nextcord.User | nextcord.Member,
-        wager: int,
-        mode: WagerMode,
-        guild: nextcord.Guild | None = None,
+        self, user: User | Member, wager: int, mode: WagerMode, guild: Guild | None = None
     ) -> ParticipantPreparationResult:
         """Builds a lobby participant under the requested wager and mode."""
         balance = await get_balance(user_id=user.id)
@@ -160,7 +156,7 @@ class GamesCogs(commands.Cog):
         )
 
     async def _all_in_participant_from_user(
-        self, user: nextcord.User | nextcord.Member, guild: nextcord.Guild | None = None
+        self, user: User | Member, guild: Guild | None = None
     ) -> ParticipantPreparationResult:
         """Builds a clamp-mode participant using the user's current full balance."""
         balance = await get_balance(user_id=user.id)
@@ -456,7 +452,7 @@ class GamesCogs(commands.Cog):
     async def blackjack_history(
         self,
         interaction: Interaction,
-        member: nextcord.Member | None = SlashOption(  # noqa: B008 -- nextcord SlashOption is the canonical default
+        member: Member | None = SlashOption(  # noqa: B008 -- nextcord SlashOption is the canonical default
             name="member",
             description="Player to inspect; defaults to yourself.",
             name_localizations={Locale.zh_TW: "玩家", Locale.ja: "プレイヤー"},

--- a/src/discordbot/cogs/gen_reply.py
+++ b/src/discordbot/cogs/gen_reply.py
@@ -12,8 +12,7 @@ import contextlib
 from google import genai
 from openai import AsyncOpenAI
 import logfire
-import nextcord
-from nextcord import File, Embed, Message
+from nextcord import File, Embed, Message, NotFound, TextChannel, HTTPException
 from pydantic import ValidationError
 from nextcord.ext import commands
 from google.genai.types import (
@@ -1628,10 +1627,10 @@ class ReplyGeneratorCogs(commands.Cog):
                 spacer = embed_spacer_payload(embeds=[error_embed], is_edit=False, target=message)
                 try:
                     await message.reply(content=None, embed=error_embed, **spacer)
-                except nextcord.HTTPException as send_error:
+                except HTTPException as send_error:
                     # Source deleted before the error landed (50035): send it unparented. Rebuild
                     # the spacer; the failed reply already consumed the single-use spacer file.
-                    if send_error.code != 50035 and not isinstance(send_error, nextcord.NotFound):
+                    if send_error.code != 50035 and not isinstance(send_error, NotFound):
                         raise
                     fresh_spacer = embed_spacer_payload(
                         embeds=[error_embed], is_edit=False, target=message
@@ -1835,7 +1834,7 @@ def _can_launch_research(*, message: Message) -> bool:
     `<deep-research>` marker is suppressed so the answer model never promises a run that cannot
     actually start (the launch would otherwise return the no-thread path and contradict itself).
     """
-    return message.guild is not None and isinstance(message.channel, nextcord.TextChannel)
+    return message.guild is not None and isinstance(message.channel, TextChannel)
 
 
 def _in_active_research_thread(*, bot: commands.Bot, channel_id: int) -> bool:

--- a/src/discordbot/cogs/maplestory.py
+++ b/src/discordbot/cogs/maplestory.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import nextcord
 from nextcord import Embed, Locale, Interaction, SlashOption, SelectOption
+from nextcord.ui import View
 from nextcord.ext import commands
 
 from discordbot.utils.discord_embeds import embed_spacer_payload
@@ -27,7 +28,7 @@ _ERROR_COLOR = 0xFF0000
 
 
 async def _send_maple_followup(
-    interaction: Interaction, embed: Embed, view: nextcord.ui.View | None = None
+    interaction: Interaction, embed: Embed, view: View | None = None
 ) -> None:
     """Sends a MapleStory result embed at a uniform width."""
     payload = embed_spacer_payload(embeds=[embed], is_edit=False, target=interaction)

--- a/src/discordbot/cogs/research.py
+++ b/src/discordbot/cogs/research.py
@@ -22,7 +22,17 @@ from google import genai
 from openai import AsyncOpenAI
 import logfire
 import nextcord
-from nextcord import Embed, Locale, Interaction, SlashOption, AllowedMentions
+from nextcord import (
+    Embed,
+    Locale,
+    Object,
+    Message,
+    Interaction,
+    SlashOption,
+    TextChannel,
+    AllowedMentions,
+)
+from nextcord.ui import View
 from nextcord.ext import commands
 
 from discordbot.utils.llm import create_text_or_none
@@ -51,7 +61,7 @@ if TYPE_CHECKING:
     from typing import Any
     from collections.abc import Callable, Awaitable, Coroutine
 
-    from nextcord import Thread, Message
+    from nextcord import Thread
 
 # How long the modify flow waits for the owner to type their changes in the thread.
 MODIFY_WAIT_TIMEOUT_SECONDS = 600.0
@@ -224,7 +234,7 @@ class ResearchCogs(commands.Cog):
         if not self.config.deep_research_available:
             await interaction.response.send_message(content="深度研究目前停用中", ephemeral=True)
             return
-        if interaction.user is None or not isinstance(interaction.channel, nextcord.TextChannel):
+        if interaction.user is None or not isinstance(interaction.channel, TextChannel):
             await interaction.response.send_message(
                 content="深度研究只能在伺服器的一般文字頻道開喔(私訊或討論串裡開不了 thread)",
                 ephemeral=True,
@@ -267,7 +277,7 @@ class ResearchCogs(commands.Cog):
         """
         # A research thread can only hang off a message in a guild text channel; a DM, an existing
         # thread, or a forum post cannot host a nested thread, so refuse before promising research.
-        if anchor.guild is None or not isinstance(anchor.channel, nextcord.TextChannel):
+        if anchor.guild is None or not isinstance(anchor.channel, TextChannel):
             return "unsupported", None
         async with self._owner_locks.hold(key=owner_id):
             existing = await db.active_thread_for_owner(owner_id=owner_id)
@@ -396,7 +406,7 @@ class ResearchCogs(commands.Cog):
         owner_mention: str,
         result: ResearchResult,
         agent: str,
-        status: "nextcord.Message | None",
+        status: Message | None,
         offer_escalation: bool,
     ) -> None:
         """Delivers a terminal result, finalizes the opening status message, and records the phase."""
@@ -440,12 +450,7 @@ class ResearchCogs(commands.Cog):
         self._active_threads.discard(thread.id)
 
     async def _finalize_status(
-        self,
-        *,
-        status: "nextcord.Message | None",
-        thread: "Thread",
-        content: str,
-        view: "nextcord.ui.View | None" = None,
+        self, *, status: Message | None, thread: "Thread", content: str, view: View | None = None
     ) -> None:
         """Edits the opening status message to its terminal content (with optional buttons).
 
@@ -563,7 +568,7 @@ class ResearchCogs(commands.Cog):
         *,
         thread: "Thread",
         owner_mention: str,
-        status: "nextcord.Message | None",
+        status: Message | None,
         plan: ResearchPlan,
         failed_status: str,
     ) -> bool:
@@ -591,7 +596,7 @@ class ResearchCogs(commands.Cog):
         owner_mention: str,
         plan: ResearchPlan,
         agent: str,
-        status: "nextcord.Message | None",
+        status: Message | None,
     ) -> None:
         """Posts the proposed plan text plus the approve / modify view."""
         if status is not None:
@@ -904,7 +909,7 @@ class ResearchCogs(commands.Cog):
     # ----- helpers ------------------------------------------------------------------------
 
     def _progress_editor(
-        self, *, status: "nextcord.Message | None", label: str
+        self, *, status: Message | None, label: str
     ) -> "Callable[[str | None, float], Awaitable[None]]":
         """Builds an on-progress callback that edits the status message with elapsed time."""
 
@@ -928,9 +933,9 @@ class ResearchCogs(commands.Cog):
         *,
         thread: "Thread",
         content: str,
-        view: "nextcord.ui.View | None" = None,
+        view: View | None = None,
         allowed_mentions: "AllowedMentions | None" = None,
-    ) -> "nextcord.Message | None":
+    ) -> Message | None:
         """Best-effort `thread.send`, returning the message or None on failure.
 
         Mentions default to fully suppressed (`AllowedMentions.none()`); a caller that wants the
@@ -978,7 +983,7 @@ def _owner_allowed_mentions(*, owner_id: int) -> AllowedMentions:
     Report and plan text is agent-generated, so any `@everyone` / role / other-user mention it
     contains must not resolve; only the deliberate owner ping is allowed through.
     """
-    return AllowedMentions(everyone=False, roles=False, users=[nextcord.Object(id=owner_id)])
+    return AllowedMentions(everyone=False, roles=False, users=[Object(id=owner_id)])
 
 
 def setup(bot: commands.Bot) -> None:

--- a/src/discordbot/utils/avatars.py
+++ b/src/discordbot/utils/avatars.py
@@ -3,24 +3,24 @@
 from typing import Protocol
 import contextlib
 
-import nextcord
+from nextcord import Asset, Guild, Member, HTTPException
 
 
 class AvatarUser(Protocol):
     """Discord user-like object with enough identity for avatar lookup."""
 
     id: int
-    display_avatar: nextcord.Asset
+    display_avatar: Asset
 
 
-def _member_avatar_url(member: nextcord.Member, fallback_url: str) -> str:
+def _member_avatar_url(member: Member, fallback_url: str) -> str:
     """Returns the member's guild avatar URL, falling back to a global avatar."""
     if member.guild_avatar is not None:
         return member.guild_avatar.url
     return fallback_url or member.display_avatar.url
 
 
-async def guild_avatar_url(user: AvatarUser, guild: nextcord.Guild | None = None) -> str:
+async def guild_avatar_url(user: AvatarUser, guild: Guild | None = None) -> str:
     """Returns a guild-scoped avatar URL when Discord exposes one.
 
     Args:
@@ -31,13 +31,13 @@ async def guild_avatar_url(user: AvatarUser, guild: nextcord.Guild | None = None
         The member's guild avatar URL when available, otherwise the user's global display avatar.
     """
     fallback_url = user.display_avatar.url
-    member: nextcord.Member | None = None
-    if isinstance(user, nextcord.Member):
+    member: Member | None = None
+    if isinstance(user, Member):
         member = user
     elif guild is not None and hasattr(guild, "get_member"):
         member = guild.get_member(user.id)
         if member is None and hasattr(guild, "fetch_member"):
-            with contextlib.suppress(nextcord.HTTPException):
+            with contextlib.suppress(HTTPException):
                 member = await guild.fetch_member(user.id)
 
     if member is None:

--- a/src/discordbot/utils/message_cleanup.py
+++ b/src/discordbot/utils/message_cleanup.py
@@ -5,8 +5,7 @@ import asyncio
 from pathlib import Path
 
 import logfire
-import nextcord
-from nextcord import Message
+from nextcord import Message, NotFound, Forbidden, HTTPException
 from pydantic import Field, BaseModel
 from sqlalchemy import Engine, text, event, create_engine
 from nextcord.ext import commands
@@ -202,9 +201,9 @@ async def delete_public_message(message: Message, message_id: int | None = None)
     resolved_message_id = message_id if message_id is not None else getattr(message, "id", None)
     try:
         await message.delete()
-    except nextcord.NotFound:
+    except NotFound:
         pass
-    except (nextcord.Forbidden, nextcord.HTTPException):
+    except (Forbidden, HTTPException):
         logfire.warn("Failed to delete public response", _exc_info=True)
         return False
     if isinstance(resolved_message_id, int):
@@ -219,7 +218,7 @@ async def delete_tracked_public_messages(bot: commands.Bot) -> None:
     for record in records:
         try:
             message = await _fetch_tracked_message(bot=bot, record=record)
-        except nextcord.NotFound:
+        except NotFound:
             await forget_public_message(message_id=record.message_id)
             deleted_count += 1
             continue
@@ -231,7 +230,7 @@ async def delete_tracked_public_messages(bot: commands.Bot) -> None:
                 _exc_info=True,
             )
             continue
-        except (nextcord.Forbidden, nextcord.HTTPException):
+        except (Forbidden, HTTPException):
             logfire.warn(
                 "Failed to fetch stale public response",
                 channel_id=record.channel_id,

--- a/src/discordbot/utils/owned_message_views.py
+++ b/src/discordbot/utils/owned_message_views.py
@@ -10,8 +10,7 @@ from io import BytesIO
 from collections.abc import Callable
 
 import logfire
-import nextcord
-from nextcord import File, Embed, Message, Interaction
+from nextcord import File, Embed, Message, NotFound, Interaction
 from nextcord.ui import View
 
 from discordbot.utils.discord_embeds import embed_spacer_payload
@@ -128,7 +127,7 @@ async def edit_owned_public_message(
         try:
             await target_message.edit(**kwargs)
             return
-        except nextcord.NotFound:
+        except NotFound:
             message_id = getattr(target_message, "id", None)
             if isinstance(message_id, int):
                 await forget_public_message(message_id=message_id)

--- a/tests/test_cogs_smoke.py
+++ b/tests/test_cogs_smoke.py
@@ -366,7 +366,7 @@ async def test_auto_unmute_tracks_audit_and_generates_reply(
     )
     assert cog._last_active_channel == {123: 456}
 
-    monkeypatch.setattr(auto_unmute.nextcord.abc, "Messageable", FakeSendChannel)
+    monkeypatch.setattr(auto_unmute, "Messageable", FakeSendChannel)
     assert cog._resolve_channel(guild=guild) is channel
     moderator, reason = await cog._lookup_audit(guild=guild)
     assert moderator.name == "moderator"


### PR DESCRIPTION
## Summary

Reference `nextcord` classes through explicit imports rather than the `nextcord.*` module namespace, matching the project convention that only functions/decorators may be invoked through a namespace.

## Details

- Converted class references to explicit imports across 16 modules: `HTTPException`, `NotFound`, `Forbidden`, `Message`, `Member`, `User`, `Guild`, `TextChannel`, `File`, `Embed`, `SelectOption`, `AllowedMentions`, `Object`, `Asset`, `ButtonStyle`, `ui.View` (`from nextcord.ui import View`), `abc.Messageable` (`from nextcord.abc import Messageable`).
- Left namespaced on purpose: decorators/functions (`nextcord.slash_command`, `nextcord.ui.button`/`string_select`/`select`, `nextcord.utils.utcnow`, `tasks.loop`) and the `nextcord.__version__` module attribute.
- Out of scope by decision: `commands.*` via `from nextcord.ext import commands` stays as-is (canonical nextcord idiom, already an explicit module import).
- Removed `import nextcord` where the conversion left it unused.
- Updated one test that patched `Messageable` through the module namespace to patch the bound name where it is actually used.

No behavior change.

## Verification

- `uv run pre-commit run -a` passes (ruff format + lint, mypy).
- `uv run pytest` — 939 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)