### PR TITLE
ci: avoid pages artifact name conflict on re-run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,10 +37,16 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v6
 
+      # Suffix the artifact name with the attempt number so a re-run does not
+      # collide with the previous attempt's artifact (deploy-pages fails on
+      # duplicate names within one run).
       - name: Upload to GitHub Pages
         uses: actions/upload-pages-artifact@v4
         with:
           path: ./site
+          name: github-pages-${{ github.run_attempt }}
 
       - name: Publish to GitHub Pages
         uses: actions/deploy-pages@v5
+        with:
+          artifact_name: github-pages-${{ github.run_attempt }}


### PR DESCRIPTION
## Summary

Re-running the `Publish GitHub Pages` workflow always fails with:

```
Error: Multiple artifacts named "github-pages" were unexpectedly found for this workflow run. Artifact count is 2.
```

Root cause (seen in [run 28785510776](https://github.com/Mai0313/discordbot/actions/runs/28785510776)):

- Attempt 1 uploaded the `github-pages` artifact successfully, but the Pages deployment failed on GitHub's side (`Deployment failed, try again later.`, a transient service error).
- Attempt 2 (re-run) uploaded another artifact with the same name. `actions/deploy-pages@v5` looks up the artifact by name across the whole run (all attempts), found two, and aborted. This is a known limitation of `deploy-pages` (see actions/deploy-pages#372).

## Fix

Suffix the pages artifact name with `github.run_attempt` on both `upload-pages-artifact` and `deploy-pages`, so each attempt uses a unique artifact name and re-runs no longer collide.

## Testing

- `uv run pre-commit run -a` passes (exit 0).
- Workflow-only change; the deploy path is exercised by the workflow itself once merged to `main`.
