### PR TITLE
chore: drop the mypy exclude so tests/ and scripts/ are type-checked

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -120,7 +120,6 @@ repos:
     rev: v2.3.0
     hooks:
       - id: mypy
-        exclude: '^(tests|scripts)/'
         additional_dependencies:
           - "Pydantic"
           - "Types-requests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -516,7 +516,6 @@ plugins = ["pydantic.mypy"]
 # strict = true
 explicit_package_bases = true
 cache_dir = "~/.cache/.mypy_cache"
-exclude = ["^tests/", "^scripts/"]
 ignore_missing_imports = true
 warn_unused_configs = true
 warn_return_any = false

--- a/scripts/batch_dev.py
+++ b/scripts/batch_dev.py
@@ -2,7 +2,7 @@
 
 import json
 import time
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Literal, cast
 from pathlib import Path
 from collections.abc import Sequence
 
@@ -24,8 +24,9 @@ config = LLMConfig()
 # dev we pin to the off-peak default. Swap manually when testing peak behaviour.
 SLOW_MODEL = ModelSettings(name="gemini-flash-latest", effort="low")
 
-BATCH_ENDPOINT = "/v1/responses"
-BATCH_COMPLETION_WINDOW = "24h"
+# Both are Literal in the Batch API signature, so they carry the same literal type here.
+BATCH_ENDPOINT: Literal["/v1/responses"] = "/v1/responses"
+BATCH_COMPLETION_WINDOW: Literal["24h"] = "24h"
 BATCH_POLL_INTERVAL_SECONDS = 10
 BATCH_TERMINAL_STATUSES = {"completed", "failed", "expired", "cancelled"}
 DEV_END_USER_ID = "batch_dev"

--- a/scripts/prompt_dev.py
+++ b/scripts/prompt_dev.py
@@ -2,6 +2,7 @@
 
 import time
 from typing import TYPE_CHECKING, cast
+from collections.abc import Iterator
 
 from google import genai
 from openai import OpenAI
@@ -131,6 +132,9 @@ def gen_reply_gemini(user_prompt: str, video_uri: str = "") -> None:
     Args:
         user_prompt: User message to send as the comparison prompt.
         video_uri: Optional URI of a video to include as input content, for testing Gemini's video understanding capabilities.
+
+    Raises:
+        RuntimeError: The SDK returned an interaction instead of the requested event stream.
     """
     client = genai.Client(
         api_key=config.api_key,
@@ -166,6 +170,11 @@ def gen_reply_gemini(user_prompt: str, video_uri: str = "") -> None:
         ],
         stream=True,
     )
+    # `stream=True` returns the event stream, but a plain `str` model name misses the SDK's
+    # `Model` literal overloads, so the call types as `Interaction | Stream[...]`. Narrow by
+    # excluding the interaction (it is iterable but not an iterator).
+    if not isinstance(responses, Iterator):
+        raise RuntimeError("Gemini interactions.create returned an interaction, not a stream")
     model_name = ""
     for response in responses:
         if response.event_type == "interaction.created":

--- a/scripts/video_dev.py
+++ b/scripts/video_dev.py
@@ -9,7 +9,9 @@ text), fixed 16:9, `delivery="uri"`, single `files.download` (the interaction on
 
 import time
 import base64
+from typing import Literal
 from pathlib import Path
+from collections.abc import Iterator
 
 from google import genai
 from rich.console import Console
@@ -39,10 +41,13 @@ def _upload_source_video(client: genai.Client, path: str) -> str:
     """Uploads a source clip to the Files API and returns its ACTIVE uri."""
     mime = f"video/{Path(path).suffix.lstrip('.') or 'mp4'}"
     uploaded = client.files.upload(file=path, config={"mime_type": mime})
+    file_name = uploaded.name
+    if file_name is None:
+        raise RuntimeError("Source video upload returned no file name")
     while uploaded.state == FileState.PROCESSING:
         console.print("Uploading source video... (PROCESSING)")
         time.sleep(2)
-        uploaded = client.files.get(name=uploaded.name)
+        uploaded = client.files.get(name=file_name)
     if uploaded.state != FileState.ACTIVE or uploaded.uri is None:
         raise RuntimeError(f"Source video upload failed: state={uploaded.state}")
     return uploaded.uri
@@ -63,11 +68,15 @@ def gen_video(
         source_video_path: Optional local video file to edit in place.
 
     Raises:
-        RuntimeError: The interaction did not complete with a video.
+        RuntimeError: The SDK returned an event stream instead of an interaction, or the
+            interaction did not complete with a video.
     """
     client = genai.Client(api_key=config.gemini_api_key)
 
-    content: list[object] = [TextContentParam(type="text", text=user_prompt)]
+    content: list[TextContentParam | ImageContentParam | VideoContentParam] = [
+        TextContentParam(type="text", text=user_prompt)
+    ]
+    task: Literal["text_to_video", "reference_to_video", "edit"]
     if source_video_path is not None:
         video_uri = _upload_source_video(client=client, path=source_video_path)
         content = [
@@ -107,6 +116,11 @@ def gen_video(
         response_format=response_format,
         generation_config=GenerationConfigParam(video_config=VideoConfigParam(task=task)),
     )
+    # No `stream=True`, so this is the interaction rather than an event stream. Narrowed by
+    # excluding the stream instead of naming `google.genai.interactions.Interaction`, which mypy
+    # binds to the request union (see `VideoGenerator.render`).
+    if isinstance(interaction, Iterator):
+        raise RuntimeError("Video generation returned an event stream, not an interaction")
     console.print(f"status={interaction.status}")
 
     video = interaction.output_video

--- a/tests/helpers/discord_mocks.py
+++ b/tests/helpers/discord_mocks.py
@@ -41,6 +41,7 @@ class OriginalEditPayload(TypedDict, total=False):
 
     content: str
     file: File
+    files: list[File]
     allowed_mentions: AllowedMentions
 
 

--- a/tests/test_douyin.py
+++ b/tests/test_douyin.py
@@ -149,9 +149,13 @@ class _FakeResponse:
 
 def _install_session(
     monkeypatch: pytest.MonkeyPatch, handler: Callable[[str, dict[str, object]], _FakeResponse]
-) -> list[dict[str, object]]:
-    """Replaces requests.Session with a stub driven by `handler`; returns the captured calls."""
-    calls: list[dict[str, object]] = []
+) -> list[dict[str, Any]]:
+    """Replaces requests.Session with a stub driven by `handler`; returns the captured calls.
+
+    A captured call is the request kwargs bag, so `Any` is what lets an assertion reach into a
+    nested value such as `calls[0]["headers"]["User-Agent"]`.
+    """
+    calls: list[dict[str, Any]] = []
 
     class _FakeSession:
         def __enter__(self) -> Self:
@@ -745,16 +749,19 @@ def test_local_write_failure_leaves_no_partial_file(
 
     real_open = Path.open
 
-    def failing_open(self: Path, *args: object, **kwargs: object) -> IO[bytes]:
-        """Writes a partial file and then fails, as a full disk would."""
-        handle = real_open(self, *args, **kwargs)  # type: ignore[arg-type]  # passthrough stub
+    def failing_open(self: Path, mode: str = "r") -> IO[bytes]:
+        """Writes a partial file and then fails, as a full disk would.
+
+        The downloader only ever opens with a positional mode, so the stub mirrors that shape.
+        """
+        handle: IO[bytes] = real_open(self, mode)
         original_write = handle.write
 
         def write(data: bytes) -> int:
             original_write(data)
             raise OSError(28, "No space left on device")
 
-        handle.write = write  # type: ignore[method-assign]  # simulating a mid-write disk failure
+        handle.write = write  # type: ignore[assignment]  # simulating a mid-write disk failure
         return handle
 
     monkeypatch.setattr(Path, "open", failing_open)

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -7,7 +7,7 @@ import re
 import json
 from types import SimpleNamespace
 import base64
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 import asyncio
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
@@ -695,6 +695,22 @@ class FakeClient:
         """Initializes fake OpenAI resource objects."""
         self.responses = FakeResponses()
         self.images = FakeImages()
+
+
+def _recorded_content_parts(
+    request: ResponseInputParam | str, index: int = 0
+) -> list[dict[str, Any]]:
+    """Returns the content parts of one item of a recorded `responses.create` input.
+
+    The recorder keeps the real `ResponseInputParam` annotation, a union of ~30 TypedDicts
+    that no structural assertion can index into, while the recorded payloads are plain
+    heterogeneous JSON. This is the single place that narrows them back to JSON.
+    """
+    assert not isinstance(request, str)
+    item = cast("dict[str, Any]", request[index])
+    parts = item["content"]
+    assert isinstance(parts, list)
+    return parts
 
 
 def _png_b64() -> str:
@@ -2269,8 +2285,9 @@ async def test_youtube_qa_uses_interactions_backend(
     last_step_parts = fake.recorder.calls[0].input[-1]["content"]
     assert {"type": "video", "uri": url} in last_step_parts
     # The shared streamer rendered the reply and a footer from the Interactions usage.
-    assert "watched it" in message.replies[0].content
-    assert "⬆ 12 ⬇ 34" in message.replies[0].content
+    reply_content = message.replies[0].content or ""
+    assert "watched it" in reply_content
+    assert "⬆ 12 ⬇ 34" in reply_content
     # A persistent watch reaction marks that the reply was grounded in the video.
     assert "<:youtube:1517546722535018596>" in message.added_reactions
 
@@ -3371,7 +3388,7 @@ async def test_prompt_generator_refines_with_grounding() -> None:
     assert client.responses.create_instructions == [IMAGE_PROMPT]
     assert client.responses.create_tools == [[{"googleSearch": {}}, {"urlContext": {}}]]
     # The raw request rides as the input_text part the director rewrites.
-    request_text = client.responses.create_inputs[0][0]["content"][0]["text"]
+    request_text = _recorded_content_parts(request=client.responses.create_inputs[0])[0]["text"]
     assert "draw a cat" in request_text
 
 
@@ -3404,12 +3421,12 @@ async def test_prompt_generator_error_falls_back_to_raw() -> None:
     """Any director error falls back to the raw prompt instead of raising into the route."""
     client = FakeClient()
 
-    async def _boom(**kwargs: object) -> object:
+    async def _boom(*args: object, **kwargs: object) -> object:
         """Fails the director call."""
-        del kwargs
+        del args, kwargs
         raise RuntimeError("director boom")
 
-    client.responses.create = _boom
+    client.responses.create = _boom  # type: ignore[method-assign]  # simulating a failing call
     generator = PromptGenerator(client=client, prompt_model=RuntimeModelCatalog().prompt_model)
 
     refined = await generator.refine(
@@ -3433,7 +3450,7 @@ async def test_prompt_generator_rides_source_images_as_input() -> None:
         image_bytes_list=[base64.b64decode(_png_b64())],
     )
 
-    director_content = client.responses.create_inputs[0][0]["content"]
+    director_content = _recorded_content_parts(request=client.responses.create_inputs[0])
     assert director_content[0]["type"] == "input_text"
     assert any(part.get("type") == "input_image" for part in director_content)
 
@@ -6858,11 +6875,11 @@ async def test_memory_selection_timeout_fallback_skips_locked_author_memory(
 
 def test_can_launch_research_requires_guild_text_channel() -> None:
     text = SimpleNamespace(guild=object(), channel=MagicMock(spec=nextcord.TextChannel))
-    assert _can_launch_research(message=text) is True  # type: ignore[arg-type]  # SimpleNamespace stub
+    assert _can_launch_research(message=text) is True
     thread = SimpleNamespace(guild=object(), channel=MagicMock(spec=nextcord.Thread))
-    assert _can_launch_research(message=thread) is False  # type: ignore[arg-type]  # SimpleNamespace stub
+    assert _can_launch_research(message=thread) is False
     dm = SimpleNamespace(guild=None, channel=MagicMock(spec=nextcord.TextChannel))
-    assert _can_launch_research(message=dm) is False  # type: ignore[arg-type]  # SimpleNamespace stub
+    assert _can_launch_research(message=dm) is False
 
 
 async def test_resume_memory_reenqueues_jobs_and_sweeps_other_scopes(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -6,6 +6,7 @@ are pinned here against the real production renderers and database helpers.
 
 import pytest
 import nextcord
+from openai.types.responses import ResponseInputParam, EasyInputMessageParam
 
 from discordbot.cogs._economy.database import adjust_balance
 from discordbot.cogs._gen_reply.memory_tool import (
@@ -39,9 +40,9 @@ def _answer_request(
     memory_ids: dict[int, str] | None = None,
     server_memory: str | None = None,
     callable_ids: dict[int, str] | None = None,
-) -> list[object]:
+) -> ResponseInputParam:
     """Builds a recorded answer input mirroring what the pipeline assembles."""
-    request: list[object] = []
+    request: ResponseInputParam = []
     if callable_ids is not None:
         request.append(render_callable_users_block(allowed=callable_ids))
     if server_memory is not None:
@@ -52,7 +53,7 @@ def _answer_request(
             for uid, body in memory_ids.items()
         ]
         request.append(render_memory_context_block(memories=memories))
-    request.append({"role": "user", "content": "hi"})
+    request.append(EasyInputMessageParam(role="user", content="hi"))
     return request
 
 
@@ -119,7 +120,10 @@ class _Recorder:
             [{"name": "get_user_memory"}],
             [{"type": "web_search"}],
         ]
-        self.create_inputs: list[object] = [["selection"], ["answer"]]
+        self.create_inputs: list[ResponseInputParam | str] = [
+            [EasyInputMessageParam(role="user", content="selection")],
+            [EasyInputMessageParam(role="user", content="answer")],
+        ]
 
 
 def test_request_index_maps_phase_to_position() -> None:
@@ -127,7 +131,9 @@ def test_request_index_maps_phase_to_position() -> None:
     recorder = _Recorder()
     assert request_index(responses=recorder, phase="selection") == 0
     assert request_index(responses=recorder, phase="answer") == 1
-    assert request_input(responses=recorder, phase="answer") == ["answer"]
+    assert request_input(responses=recorder, phase="answer") == [
+        EasyInputMessageParam(role="user", content="answer")
+    ]
 
 
 def test_tool_names_for_call_reads_offered_tools() -> None:

--- a/tests/test_parse_bilibili.py
+++ b/tests/test_parse_bilibili.py
@@ -2,6 +2,7 @@
 
 import time
 from types import SimpleNamespace
+from typing import Any
 import asyncio
 from pathlib import Path
 import threading
@@ -115,8 +116,12 @@ def _stub_bilibili(  # noqa: PLR0913 -- one canned outcome per stage the builder
     return resolved_uploads, recorded
 
 
-async def _build(gemini: bool = True, ingest: bool = True) -> list[dict[str, object]]:
-    """Runs the builder with the flags most tests share."""
+async def _build(gemini: bool = True, ingest: bool = True) -> list[dict[str, Any]]:
+    """Runs the builder with the flags most tests share.
+
+    The blocks are `EasyInputMessageParam`s, whose `content` is a union the assertions below
+    index into part by part; `Any` is what lets them read as plain JSON.
+    """
     return await build_bilibili_context_messages(
         url=_URL,
         answer_model_is_gemini=gemini,

--- a/tests/test_parse_douyin.py
+++ b/tests/test_parse_douyin.py
@@ -1,6 +1,7 @@
 """Tests for the Douyin-context builder that feeds linked posts to the answer model."""
 
 from types import SimpleNamespace
+from typing import Any
 import asyncio
 from pathlib import Path
 
@@ -123,8 +124,12 @@ def _stub_douyin(  # noqa: PLR0913 -- one canned outcome per stage the builder c
     return resolved_uploads, recorded
 
 
-async def _build(gemini: bool = True, ingest: bool = True) -> list[dict[str, object]]:
-    """Runs the builder with the flags most tests share."""
+async def _build(gemini: bool = True, ingest: bool = True) -> list[dict[str, Any]]:
+    """Runs the builder with the flags most tests share.
+
+    The blocks are `EasyInputMessageParam`s, whose `content` is a union the assertions below
+    index into part by part; `Any` is what lets them read as plain JSON.
+    """
     return await build_douyin_context_messages(
         url=_URL,
         answer_model_is_gemini=gemini,

--- a/tests/test_parse_douyin_cog.py
+++ b/tests/test_parse_douyin_cog.py
@@ -2,6 +2,7 @@
 
 import time
 from types import SimpleNamespace
+from typing import Unpack, TypedDict
 import asyncio
 from pathlib import Path
 
@@ -87,8 +88,18 @@ class _StubDownloader:
         )
 
 
+class _StubOptions(TypedDict, total=False):
+    """Canned per-stage outcomes a test forwards through `_cog` to the stub downloader."""
+
+    post: DouyinPost | None
+    files: list[tuple[str, bytes]] | None
+    parse_error: Exception | None
+    download_error: Exception | None
+    total_images: int
+
+
 def _cog(
-    bot_id: int = 999, **downloader_kwargs: object
+    bot_id: int = 999, **downloader_kwargs: Unpack[_StubOptions]
 ) -> tuple[DouyinCogs, dict[str, _StubDownloader]]:
     """Builds a cog wired to a stub downloader and a hosting-off delivery planner."""
     cog = DouyinCogs(bot=SimpleNamespace(user=SimpleNamespace(id=bot_id)))
@@ -120,6 +131,13 @@ def _message(content: str = _URL, filesize_limit: int = 25 * 1024 * 1024) -> Fak
     message.content = content
     message.guild = SimpleNamespace(filesize_limit=filesize_limit)
     return message
+
+
+def _reply_body(*, message: FakeDiscordMessage) -> str:
+    """Returns the first reply's text, failing loudly when the cog posted none."""
+    content = message.replies[0]["content"]
+    assert content is not None
+    return content
 
 
 async def test_a_pasted_link_is_expanded_with_its_caption() -> None:
@@ -199,7 +217,7 @@ async def test_a_blocked_request_is_never_reported_as_a_missing_post() -> None:
     await cog.on_message(message=message)
 
     assert message.reactions[-1] == DouyinCogs.blocked_emoji
-    body = message.replies[0]["content"]
+    body = _reply_body(message=message)
     assert "稍後再試" in body
     assert "刪除" not in body  # never conflated with a deleted or private post
 
@@ -212,7 +230,7 @@ async def test_a_deleted_post_says_so() -> None:
     await cog.on_message(message=message)
 
     assert message.reactions[-1] == "⚠️"
-    assert "刪除" in message.replies[0]["content"]
+    assert "刪除" in _reply_body(message=message)
 
 
 async def test_an_oversize_post_points_at_the_command() -> None:
@@ -223,7 +241,7 @@ async def test_an_oversize_post_points_at_the_command() -> None:
     await cog.on_message(message=message)
 
     assert message.reactions[-1] == "⚠️"
-    assert "/download_video" in message.replies[0]["content"]
+    assert "/download_video" in _reply_body(message=message)
 
 
 async def test_a_parse_failure_still_answers() -> None:
@@ -270,7 +288,7 @@ async def test_an_oversize_clip_is_hosted_as_a_url(tmp_path: Path) -> None:
 
     await cog.on_message(message=message)
 
-    content = message.replies[0]["content"]
+    content = _reply_body(message=message)
     assert any(line.startswith("https://media.test/") for line in content.splitlines())
     assert message.reactions[-1] == _GREEN
 
@@ -283,7 +301,7 @@ async def test_an_unhostable_oversize_clip_says_so() -> None:
     await cog.on_message(message=message)
 
     assert message.reactions[-1] == "⚠️"
-    assert "檔案大小超過" in message.replies[0]["content"]
+    assert "檔案大小超過" in _reply_body(message=message)
     assert not message.suppressed  # nothing was posted, so the source keeps its own preview
 
 
@@ -298,7 +316,7 @@ async def test_a_capped_gallery_reports_what_it_left_out() -> None:
 
     await cog.on_message(message=message)
 
-    assert "已省略 9 張圖片" in message.replies[0]["content"]
+    assert "已省略 9 張圖片" in _reply_body(message=message)
     assert message.reactions[-1] == _GREEN
 
 
@@ -365,6 +383,6 @@ async def test_a_stalled_expansion_gives_up_and_frees_the_slot(
     await cog.on_message(message=message)
 
     assert message.reactions[-1] == "⚠️"
-    body = message.replies[0]["content"]
+    body = _reply_body(message=message)
     assert "稍後再試" in body
     assert "刪除" not in body

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -2,6 +2,7 @@
 
 from types import SimpleNamespace
 import base64
+from typing import TYPE_CHECKING, cast
 from pathlib import Path
 
 from nextcord import AllowedMentions
@@ -22,6 +23,11 @@ from discordbot.cogs._research.delivery import (
     split_report_by_sections,
 )
 from discordbot.cogs._research.streaming import ResearchProgressStreamer
+
+if TYPE_CHECKING:
+    from nextcord import Thread, Message
+
+    from discordbot.cogs._research.database import ResearchPhase
 
 
 def _disabled_delivery() -> MediaDeliveryPlanner:
@@ -676,7 +682,13 @@ async def test_active_thread_for_owner_excludes_terminal(research_isolated_db: N
 
 
 async def test_list_resumable_only_returns_researching(research_isolated_db: None) -> None:
-    for thread_id, phase in ((20, "researching"), (21, "planning"), (22, "done")):
+    # One session per phase, so only the researching one may come back as resumable.
+    seeded: tuple[tuple[int, ResearchPhase], ...] = (
+        (20, "researching"),
+        (21, "planning"),
+        (22, "done"),
+    )
+    for thread_id, phase in seeded:
         await rdb.upsert_session(
             thread_id=thread_id,
             owner_id=thread_id,
@@ -686,7 +698,7 @@ async def test_list_resumable_only_returns_researching(research_isolated_db: Non
             agent="deep-research-preview-04-2026",
             interaction_id="int_x",
             brief="b",
-            phase=phase,  # type: ignore[arg-type]  # the test deliberately exercises each phase
+            phase=phase,
         )
     resumable = await rdb.list_resumable()
     assert {session.thread_id for session in resumable} == {20}
@@ -788,7 +800,13 @@ async def test_cancel_stale_plan_matches_current_interaction(research_isolated_d
 
 
 async def test_clear_stale_planning_cancels_only_planning(research_isolated_db: None) -> None:
-    for thread_id, phase in ((40, "planning"), (41, "researching"), (42, "planning")):
+    # Two planning sessions plus a researching one, so only the planning pair may be cancelled.
+    seeded: tuple[tuple[int, ResearchPhase], ...] = (
+        (40, "planning"),
+        (41, "researching"),
+        (42, "planning"),
+    )
+    for thread_id, phase in seeded:
         await rdb.upsert_session(
             thread_id=thread_id,
             owner_id=thread_id,
@@ -798,7 +816,7 @@ async def test_clear_stale_planning_cancels_only_planning(research_isolated_db: 
             agent="deep-research-preview-04-2026",
             interaction_id="int_x",
             brief="b",
-            phase=phase,  # type: ignore[arg-type]  # the test deliberately exercises each phase
+            phase=phase,
         )
     cleared = await rdb.clear_stale_planning()
     assert {session.thread_id for session in cleared} == {40, 42}
@@ -857,8 +875,8 @@ async def test_delivery_keeps_footer_message_under_the_limit() -> None:
     # A report chunk that sits just under the 2000-char message cap; appending the footer inline
     # would overflow, so it must ride its own trailing message.
     await deliver_report(
-        thread=thread,  # type: ignore[arg-type]  # minimal Thread double for the delivery path
-        status=status,  # type: ignore[arg-type]  # minimal status-message double
+        thread=cast("Thread", thread),  # minimal Thread double for the delivery path
+        status=cast("Message", status),  # minimal status-message double
         owner_mention="<@1>",
         result=_completed_result(report_text="X" * 1990),
         footer=footer,
@@ -883,8 +901,8 @@ async def test_delivery_inlines_footer_for_short_reports() -> None:
     status = _FakeStatusMessage()
     thread = _FakeThread()
     await deliver_report(
-        thread=thread,  # type: ignore[arg-type]  # minimal Thread double for the delivery path
-        status=status,  # type: ignore[arg-type]  # minimal status-message double
+        thread=cast("Thread", thread),  # minimal Thread double for the delivery path
+        status=cast("Message", status),  # minimal status-message double
         owner_mention="<@1>",
         result=_completed_result(report_text="# Report\nbody"),
         footer="-# footer",
@@ -914,8 +932,8 @@ async def test_delivery_hosts_oversized_report_file(tmp_path: Path) -> None:
         )
     )
     await deliver_report(
-        thread=thread,  # type: ignore[arg-type]  # minimal Thread double for the delivery path
-        status=status,  # type: ignore[arg-type]  # minimal status-message double
+        thread=cast("Thread", thread),  # minimal Thread double for the delivery path
+        status=cast("Message", status),  # minimal status-message double
         owner_mention="<@1>",
         result=_completed_result(report_text="# Report\nbody"),
         footer="-# footer",
@@ -941,8 +959,8 @@ async def test_delivery_attaches_both_files_when_each_fits_but_combined_over() -
     thread = _FakeThread()
     thread.guild = SimpleNamespace(filesize_limit=100)  # each file fits, md + png together do not
     await deliver_report(
-        thread=thread,  # type: ignore[arg-type]  # minimal Thread double for the delivery path
-        status=status,  # type: ignore[arg-type]  # minimal status-message double
+        thread=cast("Thread", thread),  # minimal Thread double for the delivery path
+        status=cast("Message", status),  # minimal status-message double
         owner_mention="<@1>",
         result=_completed_result(report_text="R" * 60, image_bytes=b"x" * 60),
         footer="-# footer",


### PR DESCRIPTION
Closes #363

## What

The mypy hook (and `[tool.mypy]`) skipped `tests/` and `scripts/`. Both excludes are gone, so mypy now checks the whole repository.

Dropping them surfaced 164 errors across 10 files. Each is fixed rather than silenced:

- `tests/test_parse_douyin.py`, `tests/test_parse_bilibili.py`, `tests/test_douyin.py` — recorded JSON payloads were annotated `dict[str, object]`, which no structural assertion can index into. Now `dict[str, Any]`, each with a docstring line stating why.
- `tests/test_parse_douyin_cog.py`, `tests/test_gen_reply.py` — helpers returning `str | None` were used directly in `in` checks. Now guarded by an explicit assert, so a missing reply fails loudly instead of raising an incidental `TypeError`. The stub downloader's `**kwargs` bag became an `Unpack[TypedDict]`, so a typo'd canned outcome is a type error instead of being silently swallowed.
- `tests/test_gen_reply.py` — the `ResponseInputParam` union of ~30 TypedDicts is narrowed back to JSON in one documented helper rather than at each assertion site.
- `tests/test_helpers.py` — `_answer_request` and the recorder fake now carry the real `ResponseInputParam` types, which also made the fake's sample data faithful to what the pipeline records.
- `tests/test_research.py` — the seeded phase literals are annotated instead of suppressed, and the delivery doubles use the repository's existing `cast` idiom.
- `tests/helpers/discord_mocks.py` — `OriginalEditPayload` was missing `files`, a key `video.py` really passes.
- `scripts/batch_dev.py`, `scripts/video_dev.py`, `scripts/prompt_dev.py` — the Batch API constants carry their `Literal` types, the Files API upload no longer passes a possibly-`None` name, and the two Interactions calls narrow structurally the way `generation.py` does.

No mypy or ruff configuration was relaxed: the only config change is the removal of the two excludes.

## Verification

- `uv run pre-commit run -a` passes.
- `uv run pytest` passes, 1325 tests.

## Note, out of scope

While verifying this, mypy turned out not to resolve the `discordbot` package at all: `[tool.mypy]` sets `explicit_package_bases = true` with no `mypy_path`, so files under `src/` are checked as `src.discordbot.*` while every `import discordbot.x` falls through to the untyped installed copy and becomes `Any`. Adding `mypy_path = "src"` surfaces 648 further errors (640 in `tests/`, 5 in `src/`, 3 in `scripts/`). That is a pre-existing, much larger piece of work and is deliberately not addressed here.