### PR TITLE
fix: resolve the diagnostics surfaced by adopting ty ahead of mypy

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -158,7 +158,7 @@ The pre-commit gate is the canonical local quality check:
 uv run pre-commit run -a
 ```
 
-It runs Ruff formatting and linting, mypy with the Pydantic plugin, Markdown formatting, ShellCheck, codespell, gitleaks, uv lock checks, and standard file hygiene hooks.
+It runs Ruff formatting and linting, ty type checking, mypy with the Pydantic plugin, Markdown formatting, ShellCheck, codespell, gitleaks, uv lock checks, and standard file hygiene hooks.
 
 ## Documentation
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,6 +116,14 @@ repos:
   #       language: system
   #       entry: bash -c 'if command -v code2flow >/dev/null 2>&1; then code2flow **/**/*.py -o ./.github/code2flow/flow.png; else echo "code2flow not installed, skipping"; fi'
 
+  - repo: https://github.com/astral-sh/ty-pre-commit
+    rev: v0.0.63
+    hooks:
+      - id: ty
+        # ty checks the whole repo (src, tests, scripts), so its environment
+        # needs every dependency group, not just the default ones.
+        args: ["--all-groups"]
+
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v2.3.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![nextcord](https://img.shields.io/badge/-Nextcord-5865F2?logo=discord&logoColor=white)](https://github.com/nextcord/nextcord)
 [![openai](https://img.shields.io/badge/-OpenAI-412991?logo=openai&logoColor=white)](https://openai.com)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json)](https://github.com/astral-sh/ty)
 [![Pydantic v2](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/pydantic/pydantic/main/docs/badge/v2.json)](https://docs.pydantic.dev/latest/contributing/#badges)
 [![tests](https://github.com/Mai0313/discordbot/actions/workflows/test.yml/badge.svg)](https://github.com/Mai0313/discordbot/actions/workflows/test.yml)
 [![code-quality](https://github.com/Mai0313/discordbot/actions/workflows/code-quality-check.yml/badge.svg)](https://github.com/Mai0313/discordbot/actions/workflows/code-quality-check.yml)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,6 +8,7 @@
 [![nextcord](https://img.shields.io/badge/-Nextcord-5865F2?logo=discord&logoColor=white)](https://github.com/nextcord/nextcord)
 [![openai](https://img.shields.io/badge/-OpenAI-412991?logo=openai&logoColor=white)](https://openai.com)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json)](https://github.com/astral-sh/ty)
 [![Pydantic v2](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/pydantic/pydantic/main/docs/badge/v2.json)](https://docs.pydantic.dev/latest/contributing/#badges)
 [![tests](https://github.com/Mai0313/discordbot/actions/workflows/test.yml/badge.svg)](https://github.com/Mai0313/discordbot/actions/workflows/test.yml)
 [![code-quality](https://github.com/Mai0313/discordbot/actions/workflows/code-quality-check.yml/badge.svg)](https://github.com/Mai0313/discordbot/actions/workflows/code-quality-check.yml)

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -8,6 +8,7 @@
 [![nextcord](https://img.shields.io/badge/-Nextcord-5865F2?logo=discord&logoColor=white)](https://github.com/nextcord/nextcord)
 [![openai](https://img.shields.io/badge/-OpenAI-412991?logo=openai&logoColor=white)](https://openai.com)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json)](https://github.com/astral-sh/ty)
 [![Pydantic v2](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/pydantic/pydantic/main/docs/badge/v2.json)](https://docs.pydantic.dev/latest/contributing/#badges)
 [![tests](https://github.com/Mai0313/discordbot/actions/workflows/test.yml/badge.svg)](https://github.com/Mai0313/discordbot/actions/workflows/test.yml)
 [![code-quality](https://github.com/Mai0313/discordbot/actions/workflows/code-quality-check.yml/badge.svg)](https://github.com/Mai0313/discordbot/actions/workflows/code-quality-check.yml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -347,6 +347,7 @@ select = [
     # "ERA",  # eradicate
     "PD",  # pandas-vet
     # "PGH",  # pygrep-hooks
+    "PGH003",  # pygrep-hooks: blanket-type-ignore
     "PL",  # Pylint
     # "TRY",  # tryceratops
     "FLY",  # flynt
@@ -505,6 +506,30 @@ count = false
 quiet-level = 3
 # the correct one is Amoeba, but we use pronunciation in Chinese to name it.
 ignore-words-list = ["useable", "checkin"]
+
+
+# ================== #
+#         ty         #
+# ================== #
+
+# Gradually migrating from mypy to ty; ty runs before mypy in pre-commit.
+# https://docs.astral.sh/ty/reference/configuration
+# https://docs.astral.sh/ty/reference/rules
+# Based on: https://docs.astral.sh/ty/coming-from-mypy-or-pyright/#stricter-checking-with-ty
+[tool.ty.rules]
+blanket-ignore-comment = "error"
+missing-type-argument = "error"
+possibly-unresolved-reference = "warn"
+unsupported-dynamic-base = "warn"
+
+# NOTE: the following rules are known to have a significant number of false positives,
+# which is mostly unavoidable. Enable them at your own risk!
+division-by-zero = "warn"
+possibly-missing-attribute = "warn"
+possibly-missing-import = "warn"
+
+[tool.ty.analysis]
+strict-literal-narrowing = true
 
 
 # ================== #

--- a/scripts/agents_dev.py
+++ b/scripts/agents_dev.py
@@ -38,7 +38,7 @@ def gen_reply_oai(user_prompt: str) -> RunResult:
             model=AGENT_MODEL.name,
             base_url=config.base_url,
             api_key=config.api_key,
-            should_replay_reasoning_content=True,
+            should_replay_reasoning_content=lambda _context: True,
         ),
     )
 
@@ -47,7 +47,7 @@ def gen_reply_oai(user_prompt: str) -> RunResult:
     return result
 
 
-def gen_reply_gemini(user_prompt: str) -> RunResult:
+def gen_reply_gemini(user_prompt: str) -> None:
     client = genai.Client()
     responses = client.interactions.create(
         agent="antigravity-preview-05-2026",
@@ -72,7 +72,7 @@ def gen_reply_gemini(user_prompt: str) -> RunResult:
         f.write(orjson.dumps(responses_list, option=orjson.OPT_INDENT_2))
 
 
-async def gen_reply_agy(user_prompt: str) -> RunResult:
+async def gen_reply_agy(user_prompt: str) -> None:
     agent_config = antigravity.LocalAgentConfig(
         system_instructions=REPLY_PROMPT, api_key=config.gemini_api_key
     )

--- a/scripts/artale_data.py
+++ b/scripts/artale_data.py
@@ -112,13 +112,12 @@ def extract_json_list(text: str, key: str) -> list[JsonRecord] | None:
 
 def _get_nested_dict(d: Mapping[str, JsonValue], *keys: str) -> dict[str, str]:
     """Traverse nested dicts safely, returning {} if any key is missing."""
-    current: JsonValue | Mapping[str, JsonValue] = d
+    current: Mapping[str, JsonValue] = d
     for k in keys:
-        if not isinstance(current, Mapping):
+        nested = current.get(k)
+        if not isinstance(nested, dict):
             return {}
-        current = current.get(k, {})
-    if not isinstance(current, dict):
-        return {}
+        current = nested
     return {key: value for key, value in current.items() if isinstance(value, str)}
 
 

--- a/scripts/prompt_dev.py
+++ b/scripts/prompt_dev.py
@@ -9,15 +9,27 @@ from openai import OpenAI
 from anthropic import Anthropic
 from rich.console import Console
 from google.genai.types import HttpOptions
+from openai.types.responses import (
+    ResponseCreatedEvent,
+    ResponseCompletedEvent,
+    ResponseTextDeltaEvent,
+    ResponseReasoningTextDeltaEvent,
+    ResponseReasoningSummaryTextDeltaEvent,
+)
 from google.genai.interactions import (
+    StepDelta,
+    TextDelta,
     URLContext,
+    TextContent,
     GoogleSearch,
     AllowlistParam,
     EnvironmentParam,
     TextContentParam,
     VideoContentParam,
     AllowlistEntryParam,
+    ThoughtSummaryDelta,
     GenerationConfigParam,
+    InteractionCreatedEvent,
 )
 
 from discordbot.typings.llm import LLMConfig
@@ -25,6 +37,8 @@ from discordbot.typings.models import ModelSettings
 from discordbot.cogs._gen_reply.prompts import REPLY_PROMPT
 
 if TYPE_CHECKING:
+    from anthropic.types.tool_param import ToolParam as AnthropicToolParam
+    from openai.types.responses.tool_param import ToolParam
     from openai.types.responses.response_input_param import ResponseInputParam
     from openai.types.chat.chat_completion_tool_union_param import ChatCompletionToolUnionParam
 
@@ -69,14 +83,13 @@ def gen_reply(user_prompt: str) -> None:
     )
     model_name = ""
     for response in responses:
-        if response.type in {"response.created", "response.completed"}:
+        if isinstance(response, (ResponseCreatedEvent, ResponseCompletedEvent)):
             model_name = response.response.model
-        elif response.type in {
-            "response.reasoning_summary_text.delta",
-            "response.reasoning_text.delta",
-        }:
+        elif isinstance(
+            response, (ResponseReasoningSummaryTextDeltaEvent, ResponseReasoningTextDeltaEvent)
+        ):
             console.print(f"[dim]{response.delta}[/dim]", end="")
-        elif response.type == "response.output_text.delta":
+        elif isinstance(response, ResponseTextDeltaEvent):
             console.print(response.delta, end="")
     end = time.time()
     console.print(f"\n{responses.response.headers}")
@@ -95,7 +108,7 @@ def gen_reply_chat(user_prompt: str) -> None:
         user_prompt: User message to send as the single prompt input.
     """
     client = OpenAI(base_url=config.base_url, api_key=config.api_key)
-    tools: list[ChatCompletionToolUnionParam] = SLOW_MODEL.tools
+    tools: list[ToolParam] = SLOW_MODEL.tools
     start = time.time()
     responses = client.chat.completions.create(
         model=SLOW_MODEL.name,
@@ -106,7 +119,9 @@ def gen_reply_chat(user_prompt: str) -> None:
         reasoning_effort=SLOW_MODEL.effort,
         stream=True,
         stream_options={"include_usage": True},
-        tools=tools,
+        # Responses-API tool shape (SLOW_MODEL.tools) sent through the Chat Completions
+        # endpoint; LiteLLM translates it, but the two SDKs' tool TypedDicts differ statically.
+        tools=cast("list[ChatCompletionToolUnionParam]", tools),
         service_tier="auto",
         extra_headers={"x-litellm-end-user-id": "prompt_dev"},
         extra_body={
@@ -150,6 +165,9 @@ def gen_reply_gemini(user_prompt: str, video_uri: str = "") -> None:
             },
         ),
     )
+    thinking_level = SLOW_MODEL.effort
+    if thinking_level not in {"minimal", "low", "medium", "high"}:
+        raise RuntimeError(f"Unsupported Gemini interactions thinking level: {thinking_level}")
     start = time.time()
     responses = client.interactions.create(
         model=SLOW_MODEL.name,
@@ -162,7 +180,7 @@ def gen_reply_gemini(user_prompt: str, video_uri: str = "") -> None:
             type="remote", network=AllowlistParam(allowlist=[AllowlistEntryParam(domain="*")])
         ),
         generation_config=GenerationConfigParam(
-            thinking_level=SLOW_MODEL.effort, thinking_summaries="auto"
+            thinking_level=thinking_level, thinking_summaries="auto"
         ),
         tools=[
             URLContext(type="url_context"),
@@ -172,17 +190,22 @@ def gen_reply_gemini(user_prompt: str, video_uri: str = "") -> None:
     )
     # `stream=True` returns the event stream, but a plain `str` model name misses the SDK's
     # `Model` literal overloads, so the call types as `Interaction | Stream[...]`. Narrow by
-    # excluding the interaction (it is iterable but not an iterator).
+    # excluding the interaction (it is iterable but not an iterator). Pydantic's `Interaction`
+    # also implements `__iter__` (field iteration), so ty keeps a residual `tuple[str, Any]`
+    # branch through the isinstance guard; cast the stream to the events we actually read.
     if not isinstance(responses, Iterator):
         raise RuntimeError("Gemini interactions.create returned an interaction, not a stream")
+    stream = cast("Iterator[InteractionCreatedEvent | StepDelta]", responses)
     model_name = ""
-    for response in responses:
-        if response.event_type == "interaction.created":
-            model_name = response.interaction.model
-        if response.event_type == "step.delta":
-            if response.delta.type == "thought_summary":
+    for response in stream:
+        if isinstance(response, InteractionCreatedEvent):
+            model_name = response.interaction.model or ""
+        elif isinstance(response, StepDelta):
+            if isinstance(response.delta, ThoughtSummaryDelta) and isinstance(
+                response.delta.content, TextContent
+            ):
                 console.print(f"[dim]{response.delta.content.text}[/dim]", end="")
-            elif response.delta.type == "text":
+            elif isinstance(response.delta, TextDelta):
                 console.print(response.delta.text, end="")
     end = time.time()
     console.print(f"\n{model_name} on Gemini SDK takes {end - start:.2f} seconds")
@@ -207,7 +230,8 @@ def gen_reply_anthropic(user_prompt: str) -> None:
         thinking={"type": "adaptive"},
         system=REPLY_PROMPT,
         messages=[{"role": "user", "content": user_prompt}],
-        tools=SLOW_MODEL.tools,
+        # Same cross-SDK tool shape note as `gen_reply_chat`.
+        tools=cast("list[AnthropicToolParam]", SLOW_MODEL.tools),
     ) as responses:
         model_name = ""
         for response in responses:

--- a/scripts/test_fallback.py
+++ b/scripts/test_fallback.py
@@ -33,6 +33,7 @@ def use_streaming() -> None:
         extra_body={"mock_testing_fallbacks": True},
         stream=True,
     )
+    model_name = ""
     for response in responses:
         model_name = response.model
         console.print(response.choices[0].delta.content, end="")

--- a/scripts/trading.py
+++ b/scripts/trading.py
@@ -10,8 +10,9 @@ The commented provider blocks are ready-to-swap examples — uncomment one and c
 
 import datetime
 
-from tradingagents.default_config import DEFAULT_CONFIG
-from tradingagents.graph.trading_graph import TradingAgentsGraph
+# Not a pyproject dependency; kept for a future feature and runs outside this env.
+from tradingagents.default_config import DEFAULT_CONFIG  # ty: ignore[unresolved-import]
+from tradingagents.graph.trading_graph import TradingAgentsGraph  # ty: ignore[unresolved-import]
 
 
 def run_trading_agents(stock: str) -> str:

--- a/scripts/video_dev.py
+++ b/scripts/video_dev.py
@@ -9,7 +9,7 @@ text), fixed 16:9, `delivery="uri"`, single `files.download` (the interaction on
 
 import time
 import base64
-from typing import Literal
+from typing import Literal, Protocol, cast
 from pathlib import Path
 from collections.abc import Iterator
 
@@ -17,9 +17,11 @@ from google import genai
 from rich.console import Console
 from google.genai.types import FileState
 from google.genai.interactions import (
+    VideoContent,
     TextContentParam,
     VideoConfigParam,
     ImageContentParam,
+    InteractionStatus,
     VideoContentParam,
     GenerationConfigParam,
     VideoResponseFormatParam,
@@ -35,6 +37,19 @@ config = LLMConfig()
 # otherwise this script tests a stale model.
 VIDEO_MODEL = ModelSettings(name="gemini-omni-flash-preview")
 MAX_REFERENCE_IMAGES = 3
+
+
+class _VideoInteractionResult(Protocol):
+    """Attributes read off the completed interaction (not `stream=True` here).
+
+    Named locally instead of `google.genai.interactions.Interaction`: that module star-imports
+    the name from both the request union and the response class, so naming it in an
+    annotation/cast risks binding the wrong one (see `VideoGenerator.render`).
+    """
+
+    status: InteractionStatus
+    output_text: str | None
+    output_video: VideoContent | None
 
 
 def _upload_source_video(client: genai.Client, path: str) -> str:
@@ -121,12 +136,13 @@ def gen_video(
     # binds to the request union (see `VideoGenerator.render`).
     if isinstance(interaction, Iterator):
         raise RuntimeError("Video generation returned an event stream, not an interaction")
-    console.print(f"status={interaction.status}")
+    result = cast("_VideoInteractionResult", interaction)
+    console.print(f"status={result.status}")
 
-    video = interaction.output_video
-    if interaction.status != "completed" or video is None or video.uri is None:
+    video = result.output_video
+    if result.status != "completed" or video is None or video.uri is None:
         raise RuntimeError(
-            f"Video generation failed: status={interaction.status} note={interaction.output_text!r}"
+            f"Video generation failed: status={result.status} note={result.output_text!r}"
         )
 
     console.print("[bold]Downloading video...[/bold]")

--- a/scripts/voice_dev.py
+++ b/scripts/voice_dev.py
@@ -2,6 +2,12 @@ from typing import TYPE_CHECKING, cast
 
 from openai import OpenAI
 from rich.console import Console
+from openai.types.responses import (
+    ResponseTextDoneEvent,
+    ResponseTextDeltaEvent,
+    ResponseReasoningTextDeltaEvent,
+    ResponseReasoningSummaryTextDeltaEvent,
+)
 
 from discordbot.typings.llm import LLMConfig
 from discordbot.typings.models import ModelSettings
@@ -50,14 +56,13 @@ def gen_reply(user_prompt: str) -> None:
     )
     full_content = ""
     for response in responses:
-        if response.type in {
-            "response.reasoning_summary_text.delta",
-            "response.reasoning_text.delta",
-        }:
+        if isinstance(
+            response, (ResponseReasoningSummaryTextDeltaEvent, ResponseReasoningTextDeltaEvent)
+        ):
             console.print(f"[dim]{response.delta}[/dim]", end="")
-        elif response.type == "response.output_text.delta":
+        elif isinstance(response, ResponseTextDeltaEvent):
             console.print(response.delta, end="")
-        elif response.type == "response.output_text.done":
+        elif isinstance(response, ResponseTextDoneEvent):
             full_content = response.text
     audio_responses = client.audio.speech.create(
         input=full_content,

--- a/src/discordbot/cli.py
+++ b/src/discordbot/cli.py
@@ -83,7 +83,10 @@ class DiscordBot(commands.Bot):
 
     async def on_connect(self) -> None:
         """Called when the bot has successfully connected to Discord."""
-        logfire.info("Bot Connected", bot_name=self.user.name, bot_id=self.user.id)
+        bot_user = self.user
+        if bot_user is None:
+            return
+        logfire.info("Bot Connected", bot_name=bot_user.name, bot_id=bot_user.id)
 
     async def on_ready(self) -> None:
         """Called when the bot is ready; performs first-time-only setup.
@@ -96,9 +99,12 @@ class DiscordBot(commands.Bot):
             return
         self._initial_setup_done = True
 
+        bot_user = self.user
+        if bot_user is None:
+            return
         logfire.info(
             "Logged in",
-            bot_name=self.user.name,
+            bot_name=bot_user.name,
             discord_version=nextcord.__version__,
             python_version=platform.python_version(),
             system=f"{platform.system()} {platform.release()} ({os.name})",
@@ -114,7 +120,7 @@ class DiscordBot(commands.Bot):
         invite_url = (
             f"https://discord.com/oauth2/authorize?client_id={app_info.id}&permissions=8&scope=bot"
         )
-        logfire.info("Bot Started", bot_name=self.user.name, bot_id=self.user.id)
+        logfire.info("Bot Started", bot_name=bot_user.name, bot_id=bot_user.id)
         logfire.info("Invite Link", invite_url=invite_url)
 
     @tasks.loop(minutes=1.0)
@@ -123,7 +129,9 @@ class DiscordBot(commands.Bot):
         statuses = ["your mama"]
         random_status = secrets.choice(statuses)
         await self.change_presence(activity=Game(random_status))
-        logfire.debug("Status Changed", new_status=self.activity.name)
+        activity = self.activity
+        if activity is not None and activity.name is not None:
+            logfire.debug("Status Changed", new_status=activity.name)
 
     @status_task.before_loop
     async def before_status_task(self) -> None:
@@ -172,13 +180,16 @@ class DiscordBot(commands.Bot):
                 )
         await self.process_commands(message)
 
-    async def on_command_completion(self, context: commands.Context) -> None:
+    async def on_command_completion(self, context: commands.Context[commands.Bot]) -> None:
         """Handles successful command execution.
 
         Args:
             context: The context of the command that was executed.
         """
-        full_command_name = context.command.qualified_name
+        command = context.command
+        if command is None:
+            return
+        full_command_name = command.qualified_name
         split = full_command_name.split(" ")
         executed_command = str(split[0])
         logfire.info("Command Received", command=executed_command)
@@ -193,8 +204,8 @@ class DiscordBot(commands.Bot):
 
     async def on_command_error(
         self,
-        context: commands.Context,
-        error: commands.CommandOnCooldown
+        context: commands.Context[commands.Bot],
+        exception: commands.CommandOnCooldown
         | commands.NotOwner
         | commands.MissingPermissions
         | commands.BotMissingPermissions
@@ -206,10 +217,10 @@ class DiscordBot(commands.Bot):
 
         Args:
             context: The context of the command that failed.
-            error: The exception that was raised.
+            exception: The exception that was raised.
         """
-        if isinstance(error, commands.CommandOnCooldown):
-            minutes, seconds = divmod(error.retry_after, 60)
+        if isinstance(exception, commands.CommandOnCooldown):
+            minutes, seconds = divmod(exception.retry_after, 60)
             hours, minutes = divmod(minutes, 60)
             hours = hours % 24
             embed = Embed(
@@ -219,7 +230,7 @@ class DiscordBot(commands.Bot):
             await context.send(
                 embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False, target=context)
             )
-        elif isinstance(error, commands.NotOwner):
+        elif isinstance(exception, commands.NotOwner):
             embed = Embed(description="You are not the owner of the bot!", color=0xE02B2B)
             await context.send(
                 embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False, target=context)
@@ -231,40 +242,40 @@ class DiscordBot(commands.Bot):
                 author_id=context.author.id,
                 guild_id=context.guild.id if context.guild else None,
             )
-        elif isinstance(error, commands.MissingPermissions):
+        elif isinstance(exception, commands.MissingPermissions):
             embed = Embed(
                 description="You are missing the permission(s) `"
-                + ", ".join(error.missing_permissions)
+                + ", ".join(exception.missing_permissions)
                 + "` to execute this command!",
                 color=0xE02B2B,
             )
             await context.send(
                 embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False, target=context)
             )
-        elif isinstance(error, commands.BotMissingPermissions):
+        elif isinstance(exception, commands.BotMissingPermissions):
             embed = Embed(
                 description="I am missing the permission(s) `"
-                + ", ".join(error.missing_permissions)
+                + ", ".join(exception.missing_permissions)
                 + "` to fully perform this command!",
                 color=0xE02B2B,
             )
             await context.send(
                 embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False, target=context)
             )
-        elif isinstance(error, commands.MissingRequiredArgument):
+        elif isinstance(exception, commands.MissingRequiredArgument):
             embed = Embed(
                 title="Error!",
                 # We need to capitalize because the command arguments have no capital letter in the code and they are the first word in the error message.
-                description=str(error).capitalize(),
+                description=str(exception).capitalize(),
                 color=0xE02B2B,
             )
             await context.send(
                 embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False, target=context)
             )
-        elif isinstance(error, commands.CommandNotFound):
+        elif isinstance(exception, commands.CommandNotFound):
             embed = Embed(
                 title="Error!",
-                description=f"Command {error.command_name} not found",
+                description=f"Command {exception.command_name} not found",
                 color=0xE02B2B,
             )
             await context.send(
@@ -273,14 +284,14 @@ class DiscordBot(commands.Bot):
         else:
             # nextcord wraps a command-body failure in CommandInvokeError, so report
             # the unwrapped type to name the real defect.
-            original = getattr(error, "original", error)
+            original = getattr(exception, "original", exception)
             logfire.error(
                 "Unhandled command error",
                 command=context.command.qualified_name if context.command else None,
                 guild_id=context.guild.id if context.guild else None,
                 author_id=context.author.id,
                 error_type=type(original).__name__,
-                _exc_info=error,
+                _exc_info=exception,
             )
 
 

--- a/src/discordbot/cogs/_economy/database.py
+++ b/src/discordbot/cogs/_economy/database.py
@@ -117,6 +117,7 @@ from discordbot.utils.stored_integer import stored_int_to_int as _stored_int_to_
 from discordbot.utils.stored_integer import stored_int_to_text as _stored_int_to_text
 
 if TYPE_CHECKING:
+    from sqlalchemy.engine import CursorResult
     from sqlalchemy.sql.elements import ColumnElement
 
 # SELECT-then-conditional-UPDATE loops keep a small retry budget. With WAL +
@@ -1803,7 +1804,7 @@ async def _insert_first_checkin_in_session(
         )
         .on_conflict_do_nothing(index_elements=["user_id"])
     )
-    insert_result = await session.execute(statement=insert_stmt)
+    insert_result = cast("CursorResult[Any]", await session.execute(statement=insert_stmt))
     if (insert_result.rowcount or 0) == 0:
         return None
     credit_result = await session.execute(

--- a/src/discordbot/cogs/_economy/interactions.py
+++ b/src/discordbot/cogs/_economy/interactions.py
@@ -1,18 +1,30 @@
 """Shared send/edit helpers for economy interaction responses."""
 
-from nextcord import File, Embed, Interaction
+from typing import Any, Protocol, cast
+
+from nextcord import File, Embed, Message, Interaction
 from nextcord.ui import View
+from nextcord.ext import commands
 
 from discordbot.utils.discord_embeds import embed_spacer_payload
 from discordbot.utils.message_cleanup import schedule_public_message_delete
 
 
+class _MessageOwningView(Protocol):
+    """The subset of a loan-decision view needed to record its sent message."""
+
+    message: Message | None
+
+
 async def send_expiring_followup(
-    interaction: Interaction, embed: Embed, view: View | None = None, file: File | None = None
+    interaction: Interaction[commands.Bot],
+    embed: Embed,
+    view: View | None = None,
+    file: File | None = None,
 ) -> None:
     """Sends a game-related economy embed and schedules its cleanup."""
     extra_files = [file] if file is not None else None
-    kwargs: dict[str, object] = {
+    kwargs: dict[str, Any] = {
         "embed": embed,
         "wait": True,
         **embed_spacer_payload(
@@ -26,7 +38,9 @@ async def send_expiring_followup(
     schedule_public_message_delete(message=message, user_name=user_name)
 
 
-async def send_loan_request_followup(interaction: Interaction, embed: Embed, view: View) -> None:
+async def send_loan_request_followup(
+    interaction: Interaction[commands.Bot], embed: Embed, view: View
+) -> None:
     """Sends a loan request message that owns its cleanup after a terminal state."""
     message = await interaction.followup.send(
         embed=embed,
@@ -34,10 +48,10 @@ async def send_loan_request_followup(interaction: Interaction, embed: Embed, vie
         wait=True,
         **embed_spacer_payload(embeds=[embed], is_edit=False, target=interaction),
     )
-    view.message = message
+    cast("_MessageOwningView", view).message = message
 
 
-async def send_private_followup(interaction: Interaction, embed: Embed) -> None:
+async def send_private_followup(interaction: Interaction[commands.Bot], embed: Embed) -> None:
     """Sends a personal economy embed visible only to the caller."""
     await interaction.followup.send(
         embed=embed,
@@ -46,7 +60,7 @@ async def send_private_followup(interaction: Interaction, embed: Embed) -> None:
     )
 
 
-async def send_ephemeral_response(interaction: Interaction, embed: Embed) -> None:
+async def send_ephemeral_response(interaction: Interaction[commands.Bot], embed: Embed) -> None:
     """Sends an ephemeral economy embed as the initial interaction response."""
     await interaction.response.send_message(
         embed=embed,
@@ -55,7 +69,7 @@ async def send_ephemeral_response(interaction: Interaction, embed: Embed) -> Non
     )
 
 
-async def edit_response_embed(interaction: Interaction, embed: Embed) -> None:
+async def edit_response_embed(interaction: Interaction[commands.Bot], embed: Embed) -> None:
     """Edits the interaction's public message embed and clears its controls."""
     await interaction.response.edit_message(
         embed=embed,

--- a/src/discordbot/cogs/_economy/views.py
+++ b/src/discordbot/cogs/_economy/views.py
@@ -34,7 +34,7 @@ class LoanDecisionViewBase(View):
 
     message: Message | None
 
-    def _schedule_cleanup(self, interaction: Interaction | None = None) -> None:
+    def _schedule_cleanup(self, interaction: Interaction[commands.Bot] | None = None) -> None:
         """Schedules the public request message for cleanup after a terminal state."""
         message = self.message or getattr(interaction, "message", None)
         if message is None:
@@ -82,14 +82,14 @@ class CentralBankLoanDecisionView(LoanDecisionViewBase):
             )
         self._schedule_cleanup()
 
-    async def _send_permission_denied(self, interaction: Interaction) -> None:
+    async def _send_permission_denied(self, interaction: Interaction[commands.Bot]) -> None:
         """Replies privately when a non-banker clicks a decision button."""
         embed = build_error_embed(
             title="權限不足", description="### 只有央行成員可以處理央行借款申請"
         )
         await send_ephemeral_response(interaction=interaction, embed=embed)
 
-    async def _is_central_banker(self, interaction: Interaction) -> bool:
+    async def _is_central_banker(self, interaction: Interaction[commands.Bot]) -> bool:
         """Returns whether the clicking user can decide central-bank proposals."""
         if interaction.user is None:
             return False
@@ -106,7 +106,11 @@ class CentralBankLoanDecisionView(LoanDecisionViewBase):
         custom_id="central_bank:approve",
         row=0,
     )
-    async def approve(self, _button: Button, interaction: Interaction) -> None:
+    async def approve(
+        self,
+        _button: Button["CentralBankLoanDecisionView"],
+        interaction: Interaction[commands.Bot],
+    ) -> None:
         """Approves the central-bank request when clicked by a central banker."""
         if interaction.user is None:
             return
@@ -144,7 +148,11 @@ class CentralBankLoanDecisionView(LoanDecisionViewBase):
     @nextcord.ui.button(
         label="拒絕", emoji="✖️", style=ButtonStyle.danger, custom_id="central_bank:reject", row=0
     )
-    async def reject(self, _button: Button, interaction: Interaction) -> None:
+    async def reject(
+        self,
+        _button: Button["CentralBankLoanDecisionView"],
+        interaction: Interaction[commands.Bot],
+    ) -> None:
         """Rejects the central-bank request when clicked by a central banker."""
         if interaction.user is None:
             return
@@ -178,7 +186,11 @@ class CentralBankLoanDecisionView(LoanDecisionViewBase):
         custom_id="central_bank:cancel",
         row=0,
     )
-    async def cancel(self, _button: Button, interaction: Interaction) -> None:
+    async def cancel(
+        self,
+        _button: Button["CentralBankLoanDecisionView"],
+        interaction: Interaction[commands.Bot],
+    ) -> None:
         """Cancels the central-bank request when clicked by its creator."""
         if interaction.user is None:
             return
@@ -237,12 +249,14 @@ class CreditLoanDecisionView(LoanDecisionViewBase):
             )
         self._schedule_cleanup()
 
-    async def _send_permission_denied(self, interaction: Interaction, description: str) -> None:
+    async def _send_permission_denied(
+        self, interaction: Interaction[commands.Bot], description: str
+    ) -> None:
         """Replies privately when a user clicks a button they cannot use."""
         embed = build_error_embed(title="權限不足", description=description)
         await send_ephemeral_response(interaction=interaction, embed=embed)
 
-    async def _require_lender(self, interaction: Interaction) -> bool:
+    async def _require_lender(self, interaction: Interaction[commands.Bot]) -> bool:
         """Returns whether the clicking user is the requested lender."""
         if interaction.user is None:
             return False
@@ -256,7 +270,9 @@ class CreditLoanDecisionView(LoanDecisionViewBase):
     @nextcord.ui.button(
         label="批准", emoji="✅", style=ButtonStyle.success, custom_id="credit:approve", row=0
     )
-    async def approve(self, _button: Button, interaction: Interaction) -> None:
+    async def approve(
+        self, _button: Button["CreditLoanDecisionView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Approves the personal credit request when clicked by the lender."""
         if interaction.user is None or not await self._require_lender(interaction=interaction):
             return
@@ -290,7 +306,9 @@ class CreditLoanDecisionView(LoanDecisionViewBase):
     @nextcord.ui.button(
         label="拒絕", emoji="✖️", style=ButtonStyle.danger, custom_id="credit:reject", row=0
     )
-    async def reject(self, _button: Button, interaction: Interaction) -> None:
+    async def reject(
+        self, _button: Button["CreditLoanDecisionView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Rejects the personal credit request when clicked by the lender."""
         if interaction.user is None or not await self._require_lender(interaction=interaction):
             return
@@ -317,7 +335,9 @@ class CreditLoanDecisionView(LoanDecisionViewBase):
     @nextcord.ui.button(
         label="取消", emoji="🚫", style=ButtonStyle.secondary, custom_id="credit:cancel", row=0
     )
-    async def cancel(self, _button: Button, interaction: Interaction) -> None:
+    async def cancel(
+        self, _button: Button["CreditLoanDecisionView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Cancels the personal credit request when clicked by its creator."""
         if interaction.user is None:
             return

--- a/src/discordbot/cogs/_fishing/views.py
+++ b/src/discordbot/cogs/_fishing/views.py
@@ -10,7 +10,8 @@ import asyncio
 
 import nextcord
 from nextcord import User, Member, Message, ButtonStyle, Interaction, SelectOption
-from nextcord.ui import Modal, Button, TextInput, StringSelect
+from nextcord.ui import View, Modal, Button, TextInput, StringSelect
+from nextcord.ext import commands
 
 from discordbot.utils.avatars import guild_avatar_url
 from discordbot.typings.fishing import (
@@ -53,7 +54,7 @@ from discordbot.cogs._fishing.presentation import (
 CAST_ANIMATION_SECONDS = 1.0
 
 
-def require_fishing_user(interaction: Interaction) -> User | Member:
+def require_fishing_user(interaction: Interaction[commands.Bot]) -> User | Member:
     """Returns the interaction user or fails before any fishing state can be written."""
     if interaction.user is None:
         raise RuntimeError("Fishing interaction is missing Discord user identity")
@@ -79,7 +80,9 @@ class FishingPanelView(FishingPublicView):
     @nextcord.ui.button(
         label="拋竿", emoji="🎣", style=ButtonStyle.primary, custom_id="fishing:cast", row=0
     )
-    async def cast(self, _button: Button, interaction: Interaction) -> None:
+    async def cast(
+        self, _button: Button["FishingPanelView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Starts a cast from the panel."""
         self.stop()
         await begin_cast(interaction=interaction, owner_id=self.owner_id)
@@ -87,7 +90,9 @@ class FishingPanelView(FishingPublicView):
     @nextcord.ui.button(
         label="商店", emoji="🛒", style=ButtonStyle.secondary, custom_id="fishing:shop", row=0
     )
-    async def shop(self, _button: Button, interaction: Interaction) -> None:
+    async def shop(
+        self, _button: Button["FishingPanelView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Opens the gear shop."""
         self.stop()
         await show_shop(interaction=interaction, owner_id=self.owner_id)
@@ -95,7 +100,9 @@ class FishingPanelView(FishingPublicView):
     @nextcord.ui.button(
         label="排行榜", emoji="🏆", style=ButtonStyle.secondary, custom_id="fishing:board", row=1
     )
-    async def leaderboard(self, _button: Button, interaction: Interaction) -> None:
+    async def leaderboard(
+        self, _button: Button["FishingPanelView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Shows the top-catches leaderboard."""
         self.stop()
         await show_leaderboard(interaction=interaction, owner_id=self.owner_id)
@@ -103,7 +110,9 @@ class FishingPanelView(FishingPublicView):
     @nextcord.ui.button(
         label="我的紀錄", emoji="📊", style=ButtonStyle.secondary, custom_id="fishing:stats", row=1
     )
-    async def stats(self, _button: Button, interaction: Interaction) -> None:
+    async def stats(
+        self, _button: Button["FishingPanelView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Shows personal fishing stats and recent catches."""
         self.stop()
         await show_stats(interaction=interaction, owner_id=self.owner_id)
@@ -119,7 +128,7 @@ class FishingShopView(FishingPublicView):
         super().__init__(owner_id=owner_id)
         self.rods = rods
         self.baits = baits
-        rod_select = cast("StringSelect", self.rod_select)
+        rod_select = cast('StringSelect["FishingShopView"]', self.rod_select)
         rod_select.options = [
             SelectOption(
                 label=gear_option_label(gear=rod),
@@ -128,7 +137,7 @@ class FishingShopView(FishingPublicView):
             )
             for rod in rods
         ] or [SelectOption(label="目前沒有釣竿", value="none")]
-        bait_select = cast("StringSelect", self.bait_select)
+        bait_select = cast('StringSelect["FishingShopView"]', self.bait_select)
         bait_select.options = [
             SelectOption(
                 label=gear_option_label(gear=bait),
@@ -146,7 +155,9 @@ class FishingShopView(FishingPublicView):
         custom_id="fishing:shop:rod",
         row=0,
     )
-    async def rod_select(self, select: StringSelect, interaction: Interaction) -> None:
+    async def rod_select(
+        self, select: StringSelect["FishingShopView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Buys the selected rod and refreshes the shop."""
         value = select.values[0]
         if value in {"none", "loading"}:
@@ -172,7 +183,9 @@ class FishingShopView(FishingPublicView):
         custom_id="fishing:shop:bait",
         row=1,
     )
-    async def bait_select(self, select: StringSelect, interaction: Interaction) -> None:
+    async def bait_select(
+        self, select: StringSelect["FishingShopView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Opens the quantity modal for the selected bait."""
         value = select.values[0]
         if value in {"none", "loading"}:
@@ -191,7 +204,9 @@ class FishingShopView(FishingPublicView):
     @nextcord.ui.button(
         label="返回", emoji="↩️", style=ButtonStyle.secondary, custom_id="fishing:shop:back", row=2
     )
-    async def back(self, _button: Button, interaction: Interaction) -> None:
+    async def back(
+        self, _button: Button["FishingShopView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Returns to the main panel."""
         self.stop()
         await show_panel(interaction=interaction, owner_id=self.owner_id)
@@ -213,7 +228,7 @@ class FishingBaitQtyModal(Modal):
         self.owner_id = owner_id
         self.parent = parent
         self.message = message
-        self.quantity: TextInput = TextInput(
+        self.quantity: TextInput[View] = TextInput(
             label="數量",
             placeholder="輸入要購買的數量，例如 10",
             min_length=1,
@@ -223,7 +238,7 @@ class FishingBaitQtyModal(Modal):
         )
         self.add_item(item=self.quantity)
 
-    async def callback(self, interaction: Interaction) -> None:
+    async def callback(self, interaction: Interaction[commands.Bot]) -> None:
         """Parses the quantity and buys the bait."""
         user = require_fishing_user(interaction=interaction)
         if self.owner_id != user.id:
@@ -260,7 +275,7 @@ class FishingBaitSelectView(FishingPublicView):
     def __init__(self, owner_id: int, bait_options: list[SelectOption]) -> None:
         """Initializes the bait picker from owned bait stacks."""
         super().__init__(owner_id=owner_id)
-        bait_select = cast("StringSelect", self.bait_select)
+        bait_select = cast('StringSelect["FishingBaitSelectView"]', self.bait_select)
         bait_select.options = bait_options
 
     @nextcord.ui.string_select(
@@ -271,7 +286,9 @@ class FishingBaitSelectView(FishingPublicView):
         custom_id="fishing:cast:bait",
         row=0,
     )
-    async def bait_select(self, select: StringSelect, interaction: Interaction) -> None:
+    async def bait_select(
+        self, select: StringSelect["FishingBaitSelectView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Casts with the selected bait."""
         self.stop()
         await run_cast(interaction=interaction, owner_id=self.owner_id, bait_id=select.values[0])
@@ -279,7 +296,9 @@ class FishingBaitSelectView(FishingPublicView):
     @nextcord.ui.button(
         label="返回", emoji="↩️", style=ButtonStyle.secondary, custom_id="fishing:cast:back", row=1
     )
-    async def back(self, _button: Button, interaction: Interaction) -> None:
+    async def back(
+        self, _button: Button["FishingBaitSelectView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Returns to the main panel."""
         self.stop()
         await show_panel(interaction=interaction, owner_id=self.owner_id)
@@ -291,7 +310,9 @@ class FishingPostCastView(FishingPublicView):
     @nextcord.ui.button(
         label="再拋一次", emoji="🎣", style=ButtonStyle.primary, custom_id="fishing:recast", row=0
     )
-    async def recast(self, _button: Button, interaction: Interaction) -> None:
+    async def recast(
+        self, _button: Button["FishingPostCastView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Starts another cast."""
         self.stop()
         await begin_cast(interaction=interaction, owner_id=self.owner_id)
@@ -303,7 +324,9 @@ class FishingPostCastView(FishingPublicView):
         custom_id="fishing:postcast:shop",
         row=0,
     )
-    async def shop(self, _button: Button, interaction: Interaction) -> None:
+    async def shop(
+        self, _button: Button["FishingPostCastView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Opens the gear shop."""
         self.stop()
         await show_shop(interaction=interaction, owner_id=self.owner_id)
@@ -315,7 +338,9 @@ class FishingPostCastView(FishingPublicView):
         custom_id="fishing:postcast:back",
         row=0,
     )
-    async def back(self, _button: Button, interaction: Interaction) -> None:
+    async def back(
+        self, _button: Button["FishingPostCastView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Returns to the main panel."""
         self.stop()
         await show_panel(interaction=interaction, owner_id=self.owner_id)
@@ -327,7 +352,9 @@ class FishingNavView(FishingPublicView):
     @nextcord.ui.button(
         label="返回", emoji="↩️", style=ButtonStyle.secondary, custom_id="fishing:nav:back", row=0
     )
-    async def back(self, _button: Button, interaction: Interaction) -> None:
+    async def back(
+        self, _button: Button["FishingNavView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Returns to the main panel."""
         self.stop()
         await show_panel(interaction=interaction, owner_id=self.owner_id)
@@ -343,7 +370,9 @@ class FishingErrorView(FishingPublicView):
         custom_id="fishing:error:shop",
         row=0,
     )
-    async def shop(self, _button: Button, interaction: Interaction) -> None:
+    async def shop(
+        self, _button: Button["FishingErrorView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Opens the gear shop."""
         self.stop()
         await show_shop(interaction=interaction, owner_id=self.owner_id)
@@ -351,7 +380,9 @@ class FishingErrorView(FishingPublicView):
     @nextcord.ui.button(
         label="返回", emoji="↩️", style=ButtonStyle.secondary, custom_id="fishing:error:back", row=0
     )
-    async def back(self, _button: Button, interaction: Interaction) -> None:
+    async def back(
+        self, _button: Button["FishingErrorView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Returns to the main panel."""
         self.stop()
         await show_panel(interaction=interaction, owner_id=self.owner_id)
@@ -381,7 +412,7 @@ def _cast_failure_message(status: CastStatus) -> str:
 
 
 async def _purchase_and_refresh_shop(
-    interaction: Interaction,
+    interaction: Interaction[commands.Bot],
     owner_id: int,
     gear_id: str,
     quantity: int,
@@ -401,7 +432,7 @@ async def _purchase_and_refresh_shop(
     )
 
 
-async def show_panel(interaction: Interaction, owner_id: int) -> None:
+async def show_panel(interaction: Interaction[commands.Bot], owner_id: int) -> None:
     """Renders the main fishing panel into the public message."""
     user = require_fishing_user(interaction=interaction)
     panel = await get_fishing_panel(user_id=user.id)
@@ -414,7 +445,10 @@ async def show_panel(interaction: Interaction, owner_id: int) -> None:
 
 
 async def show_shop(
-    interaction: Interaction, owner_id: int, notice: str = "", message: Message | None = None
+    interaction: Interaction[commands.Bot],
+    owner_id: int,
+    notice: str = "",
+    message: Message | None = None,
 ) -> None:
     """Renders the gear shop into the public message."""
     user = require_fishing_user(interaction=interaction)
@@ -429,7 +463,7 @@ async def show_shop(
     )
 
 
-async def show_leaderboard(interaction: Interaction, owner_id: int) -> None:
+async def show_leaderboard(interaction: Interaction[commands.Bot], owner_id: int) -> None:
     """Renders the top-catches leaderboard into the public message."""
     catches = await fetch_top_catches(limit=10)
     grade_map = await get_grade_config_map()
@@ -440,7 +474,7 @@ async def show_leaderboard(interaction: Interaction, owner_id: int) -> None:
     )
 
 
-async def show_stats(interaction: Interaction, owner_id: int) -> None:
+async def show_stats(interaction: Interaction[commands.Bot], owner_id: int) -> None:
     """Renders personal fishing stats into the public message."""
     user = require_fishing_user(interaction=interaction)
     panel = await get_fishing_panel(user_id=user.id)
@@ -452,7 +486,7 @@ async def show_stats(interaction: Interaction, owner_id: int) -> None:
     )
 
 
-async def begin_cast(interaction: Interaction, owner_id: int) -> None:
+async def begin_cast(interaction: Interaction[commands.Bot], owner_id: int) -> None:
     """Validates gear then casts directly or asks which bait to use."""
     user = require_fishing_user(interaction=interaction)
     panel = await get_fishing_panel(user_id=user.id)
@@ -493,7 +527,7 @@ async def begin_cast(interaction: Interaction, owner_id: int) -> None:
     )
 
 
-async def run_cast(interaction: Interaction, owner_id: int, bait_id: str) -> None:
+async def run_cast(interaction: Interaction[commands.Bot], owner_id: int, bait_id: str) -> None:
     """Runs the two-beat cast animation and settles the catch."""
     await edit_owned_public_message(
         interaction=interaction, embed=build_casting_embed(), view=None

--- a/src/discordbot/cogs/_games/blackjack_views.py
+++ b/src/discordbot/cogs/_games/blackjack_views.py
@@ -77,6 +77,8 @@ if TYPE_CHECKING:
     from random import Random
     from collections.abc import Coroutine
 
+    from nextcord.ext import commands
+
     from discordbot.cogs._games.shoe import BlackjackShoeStore
 
 MAX_BLACKJACK_PLAYERS: Final[int] = 6
@@ -627,20 +629,20 @@ class BlackjackView(View):
         self._peek_animated = False
         self._state_revision = 0
         self._background_tasks: set[asyncio.Task[None]] = set()
-        self._action_buttons: dict[str, Button] = {
-            "bj:hit": cast("Button", self.hit),
-            "bj:stand": cast("Button", self.stand),
-            "bj:double": cast("Button", self.double),
-            "bj:split": cast("Button", self.split),
-            "bj:surrender": cast("Button", self.surrender),
+        self._action_buttons: dict[str, Button[BlackjackView]] = {
+            "bj:hit": cast('Button["BlackjackView"]', self.hit),
+            "bj:stand": cast('Button["BlackjackView"]', self.stand),
+            "bj:double": cast('Button["BlackjackView"]', self.double),
+            "bj:split": cast('Button["BlackjackView"]', self.split),
+            "bj:surrender": cast('Button["BlackjackView"]', self.surrender),
         }
-        self._insurance_buttons: tuple[Button, Button] = (
-            cast("Button", self.insure_yes),
-            cast("Button", self.insure_no),
+        self._insurance_buttons: tuple[Button[BlackjackView], Button[BlackjackView]] = (
+            cast('Button["BlackjackView"]', self.insure_yes),
+            cast('Button["BlackjackView"]', self.insure_no),
         )
         self.sync_buttons()
 
-    async def interaction_check(self, interaction: Interaction) -> bool:  # noqa: PLR0911 -- phase + identity gating naturally fans out into early returns
+    async def interaction_check(self, interaction: Interaction[commands.Bot]) -> bool:  # noqa: PLR0911 -- phase + identity gating naturally fans out into early returns
         """Restricts buttons to the active player (or any undecided insurance player)."""
         if self._settled:
             await send_ephemeral_notice(
@@ -696,7 +698,9 @@ class BlackjackView(View):
     @nextcord.ui.button(
         label="再要一張", emoji="🃏", style=ButtonStyle.primary, custom_id="bj:hit", row=0
     )
-    async def hit(self, _button: Button, interaction: Interaction) -> None:
+    async def hit(
+        self, _button: Button[BlackjackView], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Handles the active player's Hit button."""
         await interaction.response.defer()
         if interaction.message is None or interaction.user is None:
@@ -725,7 +729,9 @@ class BlackjackView(View):
     @nextcord.ui.button(
         label="停手", emoji="✋", style=ButtonStyle.secondary, custom_id="bj:stand", row=0
     )
-    async def stand(self, _button: Button, interaction: Interaction) -> None:
+    async def stand(
+        self, _button: Button[BlackjackView], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Handles the active player's Stand button."""
         await interaction.response.defer()
         if interaction.message is None or interaction.user is None:
@@ -754,7 +760,9 @@ class BlackjackView(View):
     @nextcord.ui.button(
         label="加倍", emoji="💰", style=ButtonStyle.success, custom_id="bj:double", row=1
     )
-    async def double(self, _button: Button, interaction: Interaction) -> None:
+    async def double(
+        self, _button: Button[BlackjackView], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Doubles the active hand's bet and finishes it after one draw."""
         await interaction.response.defer()
         if interaction.message is None or interaction.user is None:
@@ -783,7 +791,9 @@ class BlackjackView(View):
     @nextcord.ui.button(
         label="分牌", emoji="🪓", style=ButtonStyle.success, custom_id="bj:split", row=1
     )
-    async def split(self, _button: Button, interaction: Interaction) -> None:
+    async def split(
+        self, _button: Button[BlackjackView], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Splits the active pair into two sibling sub-hands."""
         await interaction.response.defer()
         if interaction.message is None or interaction.user is None:
@@ -812,7 +822,9 @@ class BlackjackView(View):
     @nextcord.ui.button(
         label="投降", emoji="🏳️", style=ButtonStyle.danger, custom_id="bj:surrender", row=1
     )
-    async def surrender(self, _button: Button, interaction: Interaction) -> None:
+    async def surrender(
+        self, _button: Button[BlackjackView], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Surrenders the active hand for a half-bet refund."""
         await interaction.response.defer()
         if interaction.message is None or interaction.user is None:
@@ -841,7 +853,9 @@ class BlackjackView(View):
     @nextcord.ui.button(
         label="保險 ½", emoji="🛡️", style=ButtonStyle.success, custom_id="bj:insure_yes", row=1
     )
-    async def insure_yes(self, _button: Button, interaction: Interaction) -> None:
+    async def insure_yes(
+        self, _button: Button[BlackjackView], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Takes insurance for the calling player."""
         await interaction.response.defer()
         if interaction.message is None:
@@ -889,7 +903,9 @@ class BlackjackView(View):
     @nextcord.ui.button(
         label="不保險", emoji="❌", style=ButtonStyle.secondary, custom_id="bj:insure_no", row=1
     )
-    async def insure_no(self, _button: Button, interaction: Interaction) -> None:
+    async def insure_no(
+        self, _button: Button[BlackjackView], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Declines insurance for the calling player."""
         await interaction.response.defer()
         if interaction.message is None:
@@ -1199,7 +1215,7 @@ class BlackjackView(View):
         )
 
     async def _reject_stale_action_locked(
-        self, interaction: Interaction, message: Message
+        self, interaction: Interaction[commands.Bot], message: Message
     ) -> None:
         """Sends a private stale-action notice and refreshes the table."""
         await send_ephemeral_notice(

--- a/src/discordbot/cogs/_games/dragon_gate_views.py
+++ b/src/discordbot/cogs/_games/dragon_gate_views.py
@@ -61,6 +61,8 @@ from discordbot.cogs._economy.presentation import amount_code, currency_text
 if TYPE_CHECKING:
     from random import Random
 
+    from nextcord.ext import commands
+
     from discordbot.typings.economy import JackpotSnapshot
 
 DRAGON_GATE_ACTION_TIMEOUT_SECONDS = 180
@@ -427,15 +429,17 @@ class DragonGateView(View):
         self._jackpot_generation = jackpot_generation
         self._final_balances: dict[int, int] = dict(final_balances)
         self._refunded_to_pool: dict[int, int] = {}
-        self._buttons: dict[str, Button] = {
-            "dg:higher": cast("Button", self.choose_higher),
-            "dg:lower": cast("Button", self.choose_lower),
-            "dg:leave": cast("Button", self.leave_table),
+        self._buttons: dict[str, Button[DragonGateView]] = {
+            "dg:higher": cast('Button["DragonGateView"]', self.choose_higher),
+            "dg:lower": cast('Button["DragonGateView"]', self.choose_lower),
+            "dg:leave": cast('Button["DragonGateView"]', self.leave_table),
         }
-        self._selects: dict[str, StringSelect] = {"dg:bet": cast("StringSelect", self.bet_select)}
+        self._selects: dict[str, StringSelect[DragonGateView]] = {
+            "dg:bet": cast('StringSelect["DragonGateView"]', self.bet_select)
+        }
         self.sync_controls()
 
-    async def interaction_check(self, interaction: Interaction) -> bool:
+    async def interaction_check(self, interaction: Interaction[commands.Bot]) -> bool:
         """Restricts bet/direction to the active player; leave is open to all seated."""
         if self._settled or interaction.user is None:
             return False
@@ -474,14 +478,18 @@ class DragonGateView(View):
     @nextcord.ui.button(
         label="同點猜大", emoji="⬆️", style=ButtonStyle.secondary, custom_id="dg:higher", row=1
     )
-    async def choose_higher(self, _button: Button, interaction: Interaction) -> None:
+    async def choose_higher(
+        self, _button: Button[DragonGateView], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Chooses higher for a same-point gate."""
         await self._choose_direction(interaction=interaction, direction="higher")
 
     @nextcord.ui.button(
         label="同點猜小", emoji="⬇️", style=ButtonStyle.secondary, custom_id="dg:lower", row=1
     )
-    async def choose_lower(self, _button: Button, interaction: Interaction) -> None:
+    async def choose_lower(
+        self, _button: Button[DragonGateView], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Chooses lower for a same-point gate."""
         await self._choose_direction(interaction=interaction, direction="lower")
 
@@ -497,18 +505,24 @@ class DragonGateView(View):
         ],
         row=2,
     )
-    async def bet_select(self, select: StringSelect, interaction: Interaction) -> None:
+    async def bet_select(
+        self, select: StringSelect[DragonGateView], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Routes the bet select choice to a fixed amount or a custom modal."""
         await self._handle_bet_choice(choice=select.values[0], interaction=interaction)
 
     @nextcord.ui.button(
         label="離桌", emoji="🚪", style=ButtonStyle.danger, custom_id="dg:leave", row=0
     )
-    async def leave_table(self, _button: Button, interaction: Interaction) -> None:
+    async def leave_table(
+        self, _button: Button[DragonGateView], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Lets any seated player withdraw mid-table without ending the round."""
         await self._handle_leave(interaction=interaction)
 
-    async def _handle_bet_choice(self, choice: str, interaction: Interaction) -> None:
+    async def _handle_bet_choice(
+        self, choice: str, interaction: Interaction[commands.Bot]
+    ) -> None:
         """Routes a select-menu choice to a fixed bet or custom modal."""
         if choice == "custom":
             if self.round_state.needs_pair_choice():
@@ -529,7 +543,9 @@ class DragonGateView(View):
             amount = self._active_max_bet()
         await self._place_select_bet(interaction=interaction, amount=amount)
 
-    async def submit_custom_bet(self, interaction: Interaction, raw_amount: str | None) -> None:
+    async def submit_custom_bet(
+        self, interaction: Interaction[commands.Bot], raw_amount: str | None
+    ) -> None:
         """Handles the custom bet modal submission."""
         amount = parse_wager_amount(raw_amount=raw_amount)
         if amount is None:
@@ -598,7 +614,7 @@ class DragonGateView(View):
         )
 
     async def _choose_direction(
-        self, interaction: Interaction, direction: DragonGateDirection
+        self, interaction: Interaction[commands.Bot], direction: DragonGateDirection
     ) -> None:
         """Stores a high or low choice for the active pair gate."""
         await interaction.response.defer()
@@ -652,13 +668,13 @@ class DragonGateView(View):
         user_id = active.participant.user_id if active is not None else None
         return self._max_bet_for(user_id=user_id)
 
-    async def _place_select_bet(self, interaction: Interaction, amount: int) -> None:
+    async def _place_select_bet(self, interaction: Interaction[commands.Bot], amount: int) -> None:
         """Defers a select interaction and places the chosen fixed bet."""
         await interaction.response.defer()
         await self._place_bet_locked_by_interaction(interaction=interaction, amount=amount)
 
     async def _place_bet_locked_by_interaction(
-        self, interaction: Interaction, amount: int
+        self, interaction: Interaction[commands.Bot], amount: int
     ) -> None:
         """Resolves a bet, settles it against the jackpot, and refreshes the table."""
         if interaction.user is None:
@@ -729,7 +745,7 @@ class DragonGateView(View):
                 )
             )
 
-    async def _handle_leave(self, interaction: Interaction) -> None:
+    async def _handle_leave(self, interaction: Interaction[commands.Bot]) -> None:
         """Withdraws a seated player and refunds positive table delta to the jackpot."""
         if interaction.user is None:
             return
@@ -870,11 +886,11 @@ class DragonGateView(View):
                 return participant
         return None
 
-    def _button(self, custom_id: str) -> Button:
+    def _button(self, custom_id: str) -> Button[DragonGateView]:
         """Returns a button component by custom ID."""
         return self._buttons[custom_id]
 
-    def _select(self, custom_id: str) -> StringSelect:
+    def _select(self, custom_id: str) -> StringSelect[DragonGateView]:
         """Returns a string select component by custom ID."""
         return self._selects[custom_id]
 
@@ -886,7 +902,7 @@ class DragonGateView(View):
         return f"現在輪到 {active_turn.participant.display_name}"
 
     async def _send_bet_error_notice(
-        self, interaction: Interaction, error: DragonGateError
+        self, interaction: Interaction[commands.Bot], error: DragonGateError
     ) -> None:
         """Maps Dragon Gate rule errors to user-facing ephemeral notices."""
         if isinstance(error, DragonGatePairChoiceRequiredError):
@@ -910,7 +926,7 @@ class DragonGateView(View):
             content = "這桌已經不能操作了"
         await self._send_notice(interaction=interaction, content=content)
 
-    async def _send_notice(self, interaction: Interaction, content: str) -> None:
+    async def _send_notice(self, interaction: Interaction[commands.Bot], content: str) -> None:
         """Sends a private action notice to the interacting user."""
         await send_ephemeral_notice(
             interaction=interaction,
@@ -918,7 +934,9 @@ class DragonGateView(View):
             log_message="Failed to send Dragon Gate action notice",
         )
 
-    async def on_error(self, error: Exception, item: Item, interaction: Interaction) -> None:
+    async def on_error(
+        self, error: Exception, item: Item[DragonGateView], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Logs active-table component failures instead of only printing to stderr."""
         logfire.error(
             "Dragon Gate action interaction failed",
@@ -935,7 +953,7 @@ class DragonGateBetModal(Modal):
         """Initializes the modal with a range-aware amount input."""
         super().__init__(title="自訂下注")
         self.view = view
-        self.amount: TextInput = TextInput(
+        self.amount: TextInput[View] = TextInput(
             label="下注金額",
             placeholder=f"{minimum:,} 到 {maximum:,}",
             min_length=1,
@@ -944,7 +962,7 @@ class DragonGateBetModal(Modal):
         )
         self.add_item(item=self.amount)
 
-    async def callback(self, interaction: Interaction) -> None:
+    async def callback(self, interaction: Interaction[commands.Bot]) -> None:
         """Submits the custom bet amount back to the active table view."""
         await self.view.submit_custom_bet(interaction=interaction, raw_amount=self.amount.value)
 

--- a/src/discordbot/cogs/_games/interactions.py
+++ b/src/discordbot/cogs/_games/interactions.py
@@ -6,20 +6,20 @@ from collections.abc import Callable, Iterable
 
 import logfire
 from nextcord import Message
-from nextcord.ui import Item, View
+from nextcord.ui import Item, View, Button
 from nextcord.errors import DiscordServerError
 
 
 def disable_view_components(
-    children: Iterable[Item], component_types: tuple[type[Item], ...]
+    children: Iterable[Item[View]], component_types: tuple[type[Button[View]], ...]
 ) -> None:
     """Disables view children matching any supplied component type."""
     for child in children:
-        if isinstance(child, component_types):
+        if isinstance(child, component_types) and isinstance(child, Button):
             child.disabled = True
 
 
-def set_view_item_visible(view: View, item: Item, visible: bool) -> None:
+def set_view_item_visible(view: View, item: Item[View], visible: bool) -> None:
     """Adds or removes one view item without recreating the component."""
     if visible and item not in view.children:
         view.add_item(item=item)

--- a/src/discordbot/cogs/_games/lobby.py
+++ b/src/discordbot/cogs/_games/lobby.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
     from random import Random
     from collections.abc import Iterable
 
+    from nextcord.ext import commands
+
     from discordbot.typings.games import GameParticipant, RefreshParticipantsResult
 
 
@@ -33,7 +35,7 @@ class PrepareParticipant(Protocol):
     stays uniform across lobbies.
     """
 
-    async def __call__(self, interaction: Interaction) -> GameParticipant | None:
+    async def __call__(self, interaction: Interaction[commands.Bot]) -> GameParticipant | None:
         """Returns a prepared participant or sends the interaction error."""
 
 
@@ -108,7 +110,9 @@ class BaseGameLobbyView(View):
         schedule_public_message_delete(message=self.message, user_name=self.owner.account_name)
 
     @nextcord.ui.button(label="加入", emoji="✅", style=ButtonStyle.success)
-    async def join(self, _button: Button, interaction: Interaction) -> None:
+    async def join(
+        self, _button: Button[BaseGameLobbyView], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Adds the interacting user to the lobby."""
         if interaction.user is None:
             return
@@ -132,7 +136,9 @@ class BaseGameLobbyView(View):
             )
 
     @nextcord.ui.button(label="離開", emoji="🚪", style=ButtonStyle.secondary)
-    async def leave(self, _button: Button, interaction: Interaction) -> None:
+    async def leave(
+        self, _button: Button[BaseGameLobbyView], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Removes the interacting user from the lobby."""
         if interaction.user is None:
             return
@@ -153,7 +159,9 @@ class BaseGameLobbyView(View):
             )
 
     @nextcord.ui.button(label="開始", emoji="▶️", style=ButtonStyle.primary)
-    async def start(self, _button: Button, interaction: Interaction) -> None:
+    async def start(
+        self, _button: Button[BaseGameLobbyView], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Starts the game if the lobby owner pressed the button."""
         if interaction.user is None:
             return
@@ -193,13 +201,18 @@ class BaseGameLobbyView(View):
             **embed_spacer_payload(embeds=[embed], is_edit=True, target=message),
         )
 
-    async def _send_notice(self, interaction: Interaction, content: str) -> None:
+    async def _send_notice(self, interaction: Interaction[commands.Bot], content: str) -> None:
         """Sends a private lobby notice to the interacting user."""
         await send_ephemeral_notice(
             interaction=interaction, content=content, log_message="Failed to send lobby notice"
         )
 
-    async def on_error(self, error: Exception, item: Item, interaction: Interaction) -> None:
+    async def on_error(
+        self,
+        error: Exception,
+        item: Item[BaseGameLobbyView],
+        interaction: Interaction[commands.Bot],
+    ) -> None:
         """Logs lobby component failures instead of only printing to stderr."""
         logfire.error(
             "Lobby interaction failed",

--- a/src/discordbot/cogs/_gen_reply/generation.py
+++ b/src/discordbot/cogs/_gen_reply/generation.py
@@ -502,6 +502,47 @@ class VoiceGenerator(BaseModel):
             return VoiceClip(outcome=VoiceOutcome.ERROR)
 
 
+class _RenderedVideo(Protocol):
+    """The attributes read off a completed omni interaction's `output_video`."""
+
+    @property
+    def uri(self) -> str | None: ...
+
+
+class _RenderedAudio(Protocol):
+    """The attributes read off a completed Lyria interaction's `output_audio`."""
+
+    @property
+    def data(self) -> str | None: ...
+
+    @property
+    def mime_type(self) -> str | None: ...
+
+
+class _InteractionResult(Protocol):
+    """Structural view of a non-streaming `interactions.create` result.
+
+    The genai response class cannot be named: `google.genai.interactions` star-imports
+    `Interaction` from both the request-union alias (which carries none of these attributes)
+    and the response module, and only the runtime import order makes the response class win,
+    so a nominal cast would type the wrong object. Excluding the stream with `isinstance`
+    is not enough either, since `AsyncStream` is only structurally an `AsyncIterator`, so the
+    checker keeps it in the union; the read attributes are declared here and cast to instead.
+    """
+
+    @property
+    def status(self) -> str: ...
+
+    @property
+    def output_text(self) -> str | None: ...
+
+    @property
+    def output_video(self) -> _RenderedVideo | None: ...
+
+    @property
+    def output_audio(self) -> _RenderedAudio | None: ...
+
+
 class VideoGenerator(BaseModel):
     """Native Gemini (omni) video render behind the VIDEO route and the QA-route `<generate-video>` marker.
 
@@ -599,24 +640,22 @@ class VideoGenerator(BaseModel):
                 generation_config=generation_config,
                 timeout=VIDEO_RENDER_TIMEOUT_SECONDS,
             )
-        # No `stream=True`, so this is the interaction rather than an event stream. Narrowed by
-        # excluding the stream instead of casting to `google.genai.interactions.Interaction`:
-        # that module star-imports the name from both `triggers` (an alias for the union of the
-        # two *request* models, which carry no `output_video` / `status` / `output_text`) and
-        # `types.interactions` (the response class), and only the runtime import order makes the
-        # response class win, so the cast named the request union and typed the wrong object.
+        # No `stream=True`, so this is the interaction rather than an event stream: exclude the
+        # stream at runtime, then read the result through the structural `_InteractionResult`
+        # view (its docstring has why the genai response class cannot be named or narrowed to).
         if isinstance(interaction, AsyncIterator):
             raise RuntimeError("Video generation returned an event stream, not an interaction")
-        video = interaction.output_video
-        if interaction.status != "completed" or video is None or video.uri is None:
+        result = cast("_InteractionResult", interaction)
+        video = result.output_video
+        if result.status != "completed" or video is None or video.uri is None:
             logfire.warn(
                 "gen_reply video generation failed",
-                status=str(interaction.status),
+                status=str(result.status),
                 task=task_label,
-                note=interaction.output_text,
+                note=result.output_text,
             )
             raise RuntimeError(
-                f"Video generation failed: status={interaction.status} note={interaction.output_text!r}"
+                f"Video generation failed: status={result.status} note={result.output_text!r}"
             )
         logfire.debug(
             "gen_reply video job done", task=task_label, render_seconds=time.monotonic() - started
@@ -745,7 +784,11 @@ class MusicGenerator(BaseModel):
                     input=user_prompt,
                     system_instruction=MUSIC_STYLE_DIRECTIVE,
                 )
-            audio = interaction.output_audio
+            # No `stream=True`, so this is the interaction rather than an event stream (read via
+            # `_InteractionResult`, see its docstring); the guard lands in the except -> None path.
+            if isinstance(interaction, AsyncIterator):
+                raise RuntimeError("Music generation returned an event stream, not an interaction")
+            audio = cast("_InteractionResult", interaction).output_audio
             if audio is None or not audio.data:
                 logfire.warn("Inline music generation returned no audio; replying without music")
                 return None

--- a/src/discordbot/cogs/_gen_reply/interactions.py
+++ b/src/discordbot/cogs/_gen_reply/interactions.py
@@ -157,7 +157,7 @@ async def adapt_interactions_stream(
     `_consume` switches on `response.type` and reads `response.delta` /
     `response.response.model` / `response.response.usage.{input,output}_tokens`. The
     Interactions stream uses different names (`event_type`, `delta.text`,
-    `interaction.model`, `metadata.usage.total_*_tokens`), so each event is remapped onto a
+    `interaction.model`, `interaction.usage.total_*_tokens`), so each event is remapped onto a
     minimal namespace with the OpenAI-Responses field names. Usage is emitted exactly once on
     `interaction.completed` because `_consume` accumulates it with `+=` over a token seed from
     the earlier selection call; a per-step emit would double-count.
@@ -189,11 +189,11 @@ async def adapt_interactions_stream(
                         SimpleNamespace(type="response.reasoning_summary_text.delta", delta=text),
                     )
         elif event.event_type == "interaction.completed":
-            # Usage rides the completed interaction; `metadata.usage` is optional and often
-            # absent, so read the interaction first and only fall back to metadata.
+            # Usage rides the completed interaction; `metadata.total_usage` is optional and
+            # often absent, so read the interaction first and only fall back to metadata.
             usage = event.interaction.usage
             if usage is None and event.metadata is not None:
-                usage = event.metadata.usage
+                usage = event.metadata.total_usage
             usage_ns = (
                 SimpleNamespace(
                     input_tokens=usage.total_input_tokens or 0,

--- a/src/discordbot/cogs/_gen_reply/streaming.py
+++ b/src/discordbot/cogs/_gen_reply/streaming.py
@@ -400,12 +400,18 @@ class ResponseStreamer(BaseModel):
         Only accumulates state; the snapshot editor task renders it to Discord, so this
         loop never blocks on a Discord edit between deltas.
         """
+        # Discriminate on the `type` literal, never isinstance against the SDK event classes:
+        # the YouTube path's `adapt_interactions_stream` yields duck-typed namespaces that carry
+        # only the field names read here, so an isinstance check would silently drop its events.
         async for response in responses:
-            if response.type in {"response.created", "response.completed"}:
+            if response.type == "response.created":
                 # Capture the model on `created` too so the usage footer never falls back
                 # to an empty model name (and $0.00000000) when a stream ends without a
-                # clean `completed` event. Usage only arrives on `completed`.
+                # clean `completed` event.
                 self.model_name = response.response.model
+            elif response.type == "response.completed":
+                self.model_name = response.response.model
+                # Usage only arrives on `completed`.
                 if response.response.usage:
                     self.input_tokens += response.response.usage.input_tokens
                     self.output_tokens += response.response.usage.output_tokens

--- a/src/discordbot/cogs/_gen_reply/streaming.py
+++ b/src/discordbot/cogs/_gen_reply/streaming.py
@@ -153,7 +153,10 @@ class ResponseStreamer(BaseModel):
     media_delivery: MediaDeliveryPlanner = Field(
         default_factory=lambda: MediaDeliveryPlanner(
             media_hosting=MediaHostingService(
-                config=MediaHostingConfig(MEDIA_HOSTING_ENABLED=False)
+                # model_validate: the alias kwarg form is invisible to type
+                # checkers without a pydantic plugin (ty), and env merging is
+                # irrelevant for an all-disabled config.
+                config=MediaHostingConfig.model_validate({"MEDIA_HOSTING_ENABLED": False})
             )
         ),
         description=(

--- a/src/discordbot/cogs/_help/views.py
+++ b/src/discordbot/cogs/_help/views.py
@@ -6,6 +6,7 @@ import contextlib
 import nextcord
 from nextcord import Embed, Locale, Interaction, SelectOption
 from nextcord.ui import View, StringSelect
+from nextcord.ext import commands
 
 from discordbot.cogs._help.content import CATEGORY_ORDER, OVERVIEW_VALUE, resolve_guide
 from discordbot.cogs._help.presentation import build_section_embed, build_overview_embed
@@ -29,8 +30,8 @@ class HelpView(View):
         self._requester_name = requester_name
         self._requester_avatar_url = requester_avatar_url
         self._active = OVERVIEW_VALUE
-        self._origin: Interaction | None = None
-        self._select = cast("StringSelect", self.category_select)
+        self._origin: Interaction[commands.Bot] | None = None
+        self._select = cast("StringSelect[HelpView]", self.category_select)
         self._select.placeholder = self.guide.select_placeholder
         self._sync_options()
 
@@ -42,7 +43,7 @@ class HelpView(View):
             requester_avatar_url=self._requester_avatar_url,
         )
 
-    def bind_origin(self, interaction: Interaction) -> None:
+    def bind_origin(self, interaction: Interaction[commands.Bot]) -> None:
         """Records the originating interaction so timeout can disable the menu."""
         self._origin = interaction
 
@@ -87,7 +88,9 @@ class HelpView(View):
         max_values=1,
         options=[SelectOption(label="loading", value="loading")],
     )
-    async def category_select(self, select: StringSelect, interaction: Interaction) -> None:
+    async def category_select(
+        self, select: StringSelect["HelpView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Swaps the embed in place to the chosen category."""
         self._active = select.values[0]
         self._sync_options()
@@ -99,4 +102,4 @@ class HelpView(View):
             return
         self._select.disabled = True
         with contextlib.suppress(Exception):
-            await self._origin.edit_original_response(view=self)
+            await self._origin.edit_original_message(view=self)

--- a/src/discordbot/cogs/_maplestory/views.py
+++ b/src/discordbot/cogs/_maplestory/views.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Protocol
 
 import nextcord
 from nextcord import Embed, Interaction, SelectOption
-from nextcord.ui import View, Select
+from nextcord.ui import View, StringSelect
 
 from discordbot.utils.discord_embeds import embed_spacer_payload
 
@@ -26,6 +26,8 @@ from .embeds import (
 )
 
 if TYPE_CHECKING:
+    from nextcord.ext import commands
+
     from .service import MapleStoryService
 
 
@@ -128,7 +130,9 @@ class MapleDropSearchView(View):
         max_values=1,
         options=[SelectOption(label="載入中...", value="loading")],
     )
-    async def select_result(self, select: Select, interaction: Interaction) -> None:
+    async def select_result(
+        self, select: StringSelect[MapleDropSearchView], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Handles the selection of a search result.
 
         Args:
@@ -149,9 +153,10 @@ class MapleDropSearchView(View):
             else None
         )
 
-        if embed:
+        message = interaction.message
+        if embed and message is not None:
             await interaction.followup.edit_message(
-                message_id=interaction.message.id,
+                message_id=message.id,
                 embed=embed,
                 view=None,
                 **embed_spacer_payload(embeds=[embed], is_edit=True, target=interaction),
@@ -163,4 +168,6 @@ class MapleDropSearchView(View):
         Args:
             options: A list of SelectOption objects.
         """
-        self.select_result.options = options[:25]
+        for child in self.children:
+            if isinstance(child, StringSelect):
+                child.options = options[:25]

--- a/src/discordbot/cogs/_memory/views.py
+++ b/src/discordbot/cogs/_memory/views.py
@@ -6,6 +6,7 @@ import contextlib
 import nextcord
 from nextcord import Embed, ButtonStyle, Interaction
 from nextcord.ui import View, Button
+from nextcord.ext import commands
 
 MEMORY_VIEW_TIMEOUT_SECONDS = 180
 
@@ -86,10 +87,10 @@ class MemoryPagesView(View):
         self.footer_text = footer_text
         self.title = title
         self.page_index = 0
-        self._origin: Interaction | None = None
+        self._origin: Interaction[commands.Bot] | None = None
         self._sync_buttons()
 
-    def bind_origin(self, interaction: Interaction) -> None:
+    def bind_origin(self, interaction: Interaction[commands.Bot]) -> None:
         """Records the originating interaction so timeout can disable the buttons."""
         self._origin = interaction
 
@@ -105,18 +106,24 @@ class MemoryPagesView(View):
 
     def _sync_buttons(self) -> None:
         """Disables the boundary buttons at the first and last page."""
-        cast("Button", self.previous_page).disabled = self.page_index <= 0
-        cast("Button", self.next_page).disabled = self.page_index >= len(self.pages) - 1
+        cast("Button[MemoryPagesView]", self.previous_page).disabled = self.page_index <= 0
+        cast("Button[MemoryPagesView]", self.next_page).disabled = (
+            self.page_index >= len(self.pages) - 1
+        )
 
     @nextcord.ui.button(label="◀ 上一頁", style=ButtonStyle.secondary)
-    async def previous_page(self, _button: Button, interaction: Interaction) -> None:
+    async def previous_page(
+        self, _button: Button["MemoryPagesView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Shows the previous page in place."""
         self.page_index = max(self.page_index - 1, 0)
         self._sync_buttons()
         await interaction.response.edit_message(embed=self.current_embed(), view=self)
 
     @nextcord.ui.button(label="下一頁 ▶", style=ButtonStyle.secondary)
-    async def next_page(self, _button: Button, interaction: Interaction) -> None:
+    async def next_page(
+        self, _button: Button["MemoryPagesView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Shows the next page in place."""
         self.page_index = min(self.page_index + 1, len(self.pages) - 1)
         self._sync_buttons()
@@ -134,4 +141,4 @@ class MemoryPagesView(View):
         # `on_timeout` in a bare `create_task`, so a narrower filter would let an
         # aiohttp transport error escape into a task that cannot handle it.
         with contextlib.suppress(Exception):
-            await self._origin.edit_original_response(view=self)
+            await self._origin.edit_original_message(view=self)

--- a/src/discordbot/cogs/_research/database.py
+++ b/src/discordbot/cogs/_research/database.py
@@ -22,7 +22,7 @@ from typing import Any, Literal, cast
 from datetime import datetime
 
 from pydantic import Field, BaseModel
-from sqlalchemy import String, Integer, DateTime, event, select, update
+from sqlalchemy import String, Integer, DateTime, CursorResult, event, select, update
 from sqlalchemy.orm import Mapped, DeclarativeBase, mapped_column
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 from sqlalchemy.dialects.sqlite import insert
@@ -261,14 +261,17 @@ async def claim_research(*, thread_id: int, plan_interaction_id: str) -> bool:
     await _ensure_schema()
     now = _database_now()
     async with open_session() as session:
-        result = await session.execute(
-            statement=update(ResearchSessionRow)
-            .where(
-                ResearchSessionRow.thread_id == thread_id,
-                ResearchSessionRow.phase == "planning",
-                ResearchSessionRow.interaction_id == plan_interaction_id,
-            )
-            .values(phase="researching", interaction_id=None, updated_at=now)
+        result = cast(
+            "CursorResult[Any]",
+            await session.execute(
+                statement=update(ResearchSessionRow)
+                .where(
+                    ResearchSessionRow.thread_id == thread_id,
+                    ResearchSessionRow.phase == "planning",
+                    ResearchSessionRow.interaction_id == plan_interaction_id,
+                )
+                .values(phase="researching", interaction_id=None, updated_at=now)
+            ),
         )
         await session.commit()
         return bool(result.rowcount and result.rowcount > 0)
@@ -283,10 +286,15 @@ async def claim_planning(*, thread_id: int) -> bool:
     await _ensure_schema()
     now = _database_now()
     async with open_session() as session:
-        result = await session.execute(
-            statement=update(ResearchSessionRow)
-            .where(ResearchSessionRow.thread_id == thread_id, ResearchSessionRow.phase == "done")
-            .values(phase="planning", updated_at=now)
+        result = cast(
+            "CursorResult[Any]",
+            await session.execute(
+                statement=update(ResearchSessionRow)
+                .where(
+                    ResearchSessionRow.thread_id == thread_id, ResearchSessionRow.phase == "done"
+                )
+                .values(phase="planning", updated_at=now)
+            ),
         )
         await session.commit()
         return bool(result.rowcount and result.rowcount > 0)
@@ -302,14 +310,17 @@ async def cancel_stale_plan(*, thread_id: int, plan_interaction_id: str) -> bool
     await _ensure_schema()
     now = _database_now()
     async with open_session() as session:
-        result = await session.execute(
-            statement=update(ResearchSessionRow)
-            .where(
-                ResearchSessionRow.thread_id == thread_id,
-                ResearchSessionRow.phase == "planning",
-                ResearchSessionRow.interaction_id == plan_interaction_id,
-            )
-            .values(phase="cancelled", updated_at=now)
+        result = cast(
+            "CursorResult[Any]",
+            await session.execute(
+                statement=update(ResearchSessionRow)
+                .where(
+                    ResearchSessionRow.thread_id == thread_id,
+                    ResearchSessionRow.phase == "planning",
+                    ResearchSessionRow.interaction_id == plan_interaction_id,
+                )
+                .values(phase="cancelled", updated_at=now)
+            ),
         )
         await session.commit()
         return bool(result.rowcount and result.rowcount > 0)

--- a/src/discordbot/cogs/_research/views.py
+++ b/src/discordbot/cogs/_research/views.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 import nextcord
 from nextcord import ButtonStyle, Interaction
 from nextcord.ui import View, Button
+from nextcord.ext import commands
 
 if TYPE_CHECKING:
     from discordbot.cogs.research import ResearchCogs
@@ -20,7 +21,7 @@ ESCALATION_VIEW_TIMEOUT_SECONDS = 1800.0
 PLAN_VIEW_TIMEOUT_SECONDS = 1800.0
 
 
-async def _is_owner(*, interaction: Interaction, owner_id: int) -> bool:
+async def _is_owner(*, interaction: Interaction[commands.Bot], owner_id: int) -> bool:
     """Returns True for the owner's click; otherwise denies ephemerally and returns False."""
     if interaction.user is not None and interaction.user.id == owner_id:
         return True
@@ -37,14 +38,20 @@ class ResultEscalationView(View):
         super().__init__(timeout=ESCALATION_VIEW_TIMEOUT_SECONDS)
         self.cog = cog
         self.owner_id = owner_id
-        # Presence-based: drop the Max button entirely when the tier is disabled.
+        # Presence-based: drop the Max button entirely when the tier is disabled. Looked up from
+        # `children` because `View.__init__` replaces the decorated callback with the real Button.
         if not max_enabled:
-            self.remove_item(self.escalate_max)
+            for child in self.children:
+                if isinstance(child, Button) and child.custom_id == "research:escalate_max":
+                    self.remove_item(item=child)
+                    break
 
     @nextcord.ui.button(
         label="升級 Deep Research", style=ButtonStyle.primary, custom_id="research:escalate_dr"
     )
-    async def escalate_dr(self, _button: Button, interaction: Interaction) -> None:
+    async def escalate_dr(
+        self, _button: Button["ResultEscalationView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         if not await _is_owner(interaction=interaction, owner_id=self.owner_id):
             return
         await self.cog.on_escalate(interaction=interaction, view=self, max_tier=False)
@@ -52,7 +59,9 @@ class ResultEscalationView(View):
     @nextcord.ui.button(
         label="Deep Research Max", style=ButtonStyle.danger, custom_id="research:escalate_max"
     )
-    async def escalate_max(self, _button: Button, interaction: Interaction) -> None:
+    async def escalate_max(
+        self, _button: Button["ResultEscalationView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         if not await _is_owner(interaction=interaction, owner_id=self.owner_id):
             return
         await self.cog.on_escalate(interaction=interaction, view=self, max_tier=True)
@@ -88,7 +97,9 @@ class PlanApprovalView(View):
     @nextcord.ui.button(
         label="接受並開始", style=ButtonStyle.success, custom_id="research:plan_accept"
     )
-    async def accept(self, _button: Button, interaction: Interaction) -> None:
+    async def accept(
+        self, _button: Button["PlanApprovalView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         if not await _is_owner(interaction=interaction, owner_id=self.owner_id):
             return
         await self.cog.on_accept_plan(interaction=interaction, view=self)
@@ -96,7 +107,9 @@ class PlanApprovalView(View):
     @nextcord.ui.button(
         label="修改計畫", style=ButtonStyle.secondary, custom_id="research:plan_modify"
     )
-    async def modify(self, _button: Button, interaction: Interaction) -> None:
+    async def modify(
+        self, _button: Button["PlanApprovalView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         if not await _is_owner(interaction=interaction, owner_id=self.owner_id):
             return
         await self.cog.on_modify_plan(interaction=interaction, view=self)

--- a/src/discordbot/cogs/_stock/database.py
+++ b/src/discordbot/cogs/_stock/database.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from time import monotonic
 import uuid
 from random import Random, SystemRandom
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, cast
 import asyncio
 from datetime import datetime, timedelta
 
@@ -73,6 +73,8 @@ from discordbot.cogs._economy.database import get_balance, apply_ordered_wallet_
 if TYPE_CHECKING:
     from contextlib import AbstractAsyncContextManager
     from collections.abc import Callable, Awaitable
+
+    from sqlalchemy.engine import CursorResult
 
 _engine: AsyncEngine = create_async_engine(url="sqlite+aiosqlite:///data/database/stock.db")
 _schema_ready_for: AsyncEngine | None = None
@@ -954,10 +956,13 @@ async def _insert_price_tick_or_existing(
     session: AsyncSession, symbol: str, price_cents: int, created_at: datetime
 ) -> int:
     """Inserts a tick once and returns the persisted price for that boundary."""
-    result = await session.execute(
-        statement=insert(StockPriceTick)
-        .values(symbol=symbol, price_cents=price_cents, created_at=created_at)
-        .on_conflict_do_nothing(index_elements=["symbol", "created_at"])
+    result = cast(
+        "CursorResult[Any]",
+        await session.execute(
+            statement=insert(StockPriceTick)
+            .values(symbol=symbol, price_cents=price_cents, created_at=created_at)
+            .on_conflict_do_nothing(index_elements=["symbol", "created_at"])
+        ),
     )
     if result.rowcount:
         return price_cents
@@ -2369,7 +2374,9 @@ async def settle_stock_operation(  # noqa: PLR0913 -- Service boundary returns t
                 effective_now=effective_now,
                 rng=rng,
             )
-            if not plan.success:
+            # success=True is only ever built as a _StockOperationPlan; the
+            # isinstance check makes that discrimination visible to type checkers.
+            if not plan.success or not isinstance(plan, _StockOperationPlan):
                 await session.rollback()
                 return plan
             plan = plan.model_copy(
@@ -2641,17 +2648,20 @@ async def reset_all_positions() -> int:
     await _ensure_schema()
     now = _database_now()
     async with open_stock_session() as session:
-        result = await session.execute(
-            statement=update(StockPosition).values(
-                long_shares=0,
-                long_cost_basis=0,
-                short_shares=0,
-                short_entry_value=0,
-                short_collateral=0,
-                realized_pnl=0,
-                version=StockPosition.version + 1,
-                updated_at=now,
-            )
+        result = cast(
+            "CursorResult[Any]",
+            await session.execute(
+                statement=update(StockPosition).values(
+                    long_shares=0,
+                    long_cost_basis=0,
+                    short_shares=0,
+                    short_entry_value=0,
+                    short_collateral=0,
+                    realized_pnl=0,
+                    version=StockPosition.version + 1,
+                    updated_at=now,
+                )
+            ),
         )
         await session.execute(
             statement=update(StockOperation)

--- a/src/discordbot/cogs/_stock/views.py
+++ b/src/discordbot/cogs/_stock/views.py
@@ -6,7 +6,8 @@ from typing import cast
 import nextcord
 from nextcord import File, User, Embed, Member, Message, ButtonStyle, Interaction, SelectOption
 from pydantic import Field, BaseModel, ConfigDict, SkipValidation
-from nextcord.ui import Modal, Button, TextInput, StringSelect
+from nextcord.ui import View, Modal, Button, TextInput, StringSelect
+from nextcord.ext import commands
 
 from discordbot.typings.stock import STOCK_ACTION_TIMEOUT_SECONDS, StockAction, StockMarketQuote
 from discordbot.utils.avatars import guild_avatar_url
@@ -38,7 +39,7 @@ MARKET_PAGE_SIZE = 25
 SELECT_OPTION_LABEL_LIMIT = 100
 
 
-def require_stock_user(interaction: Interaction) -> User | Member:
+def require_stock_user(interaction: Interaction[commands.Bot]) -> User | Member:
     """Returns the interaction user or fails before any stock state can be written."""
     if interaction.user is None:
         raise RuntimeError("Stock interaction is missing Discord user identity")
@@ -85,7 +86,7 @@ class _StockQuantitySubmission(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
 
-    interaction: SkipValidation[Interaction] = Field(
+    interaction: SkipValidation[Interaction[commands.Bot]] = Field(
         ..., description="Discord interaction that submitted the quantity."
     )
     symbol: str = Field(..., description="Stock symbol being operated on.")
@@ -114,7 +115,7 @@ class StockMarketView(StockPublicView):
         page_quotes = quotes[
             self.page_index * MARKET_PAGE_SIZE : (self.page_index + 1) * MARKET_PAGE_SIZE
         ]
-        self._select = cast("StringSelect", self.stock_select)
+        self._select = cast("StringSelect[StockMarketView]", self.stock_select)
         self._select.options = [
             SelectOption(
                 label=_select_option_label(symbol=quote.profile.symbol, name=quote.profile.name),
@@ -123,8 +124,8 @@ class StockMarketView(StockPublicView):
             )
             for quote in page_quotes
         ] or [SelectOption(label="目前沒有股票", value="none", description="請稍後再試")]
-        self._previous_page = cast("Button", self.previous_page)
-        self._next_page = cast("Button", self.next_page)
+        self._previous_page = cast("Button[StockMarketView]", self.previous_page)
+        self._next_page = cast("Button[StockMarketView]", self.next_page)
         self._previous_page.disabled = self.page_index <= 0
         self._next_page.disabled = self.page_index >= self.page_count - 1
 
@@ -136,7 +137,9 @@ class StockMarketView(StockPublicView):
         custom_id="stock:select",
         row=0,
     )
-    async def stock_select(self, select: StringSelect, interaction: Interaction) -> None:
+    async def stock_select(
+        self, select: StringSelect["StockMarketView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Shows a public detail view for the selected stock."""
         symbol = select.values[0]
         if symbol in {"loading", "none"}:
@@ -153,21 +156,27 @@ class StockMarketView(StockPublicView):
     @nextcord.ui.button(
         label="上一頁", emoji="◀️", style=ButtonStyle.secondary, custom_id="stock:page:prev", row=1
     )
-    async def previous_page(self, _button: Button, interaction: Interaction) -> None:
+    async def previous_page(
+        self, _button: Button["StockMarketView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Moves the market list to the previous page."""
         await self._show_page(interaction=interaction, page_index=self.page_index - 1)
 
     @nextcord.ui.button(
         label="下一頁", emoji="▶️", style=ButtonStyle.secondary, custom_id="stock:page:next", row=1
     )
-    async def next_page(self, _button: Button, interaction: Interaction) -> None:
+    async def next_page(
+        self, _button: Button["StockMarketView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Moves the market list to the next page."""
         await self._show_page(interaction=interaction, page_index=self.page_index + 1)
 
     @nextcord.ui.button(
         label="教學", emoji="📘", style=ButtonStyle.secondary, custom_id="stock:tutorial", row=2
     )
-    async def tutorial(self, _button: Button, interaction: Interaction) -> None:
+    async def tutorial(
+        self, _button: Button["StockMarketView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Shows the stock tutorial in the public stock message."""
         self.stop()
         await edit_owned_public_message(
@@ -176,7 +185,7 @@ class StockMarketView(StockPublicView):
             view=StockTutorialView(owner_id=self.owner_id),
         )
 
-    async def _show_page(self, interaction: Interaction, page_index: int) -> None:
+    async def _show_page(self, interaction: Interaction[commands.Bot], page_index: int) -> None:
         """Edits the market list to a bounded page index."""
         self.stop()
         normalized_page = min(max(page_index, 0), self.page_count - 1)
@@ -201,7 +210,9 @@ class StockTutorialView(StockPublicView):
     @nextcord.ui.button(
         label="返回列表", emoji="↩️", style=ButtonStyle.secondary, custom_id="stock:tutorial:back"
     )
-    async def back(self, _button: Button, interaction: Interaction) -> None:
+    async def back(
+        self, _button: Button["StockTutorialView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Returns to the market list."""
         quotes = await list_market_quotes()
         embed, file = build_market_message_payload(quotes=quotes)
@@ -225,7 +236,9 @@ class StockDetailView(StockPublicView):
     @nextcord.ui.button(
         label="操作股票", emoji="🧾", style=ButtonStyle.primary, custom_id="stock:operate", row=0
     )
-    async def operate(self, _button: Button, interaction: Interaction) -> None:
+    async def operate(
+        self, _button: Button["StockDetailView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Shows action selection before opening the quantity modal."""
         self.stop()
         await edit_stock_action_prompt(
@@ -235,7 +248,9 @@ class StockDetailView(StockPublicView):
     @nextcord.ui.button(
         label="近期新聞", emoji="📰", style=ButtonStyle.secondary, custom_id="stock:news", row=0
     )
-    async def news(self, _button: Button, interaction: Interaction) -> None:
+    async def news(
+        self, _button: Button["StockDetailView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Shows recent deterministic news in the public stock message."""
         news = await get_stock_news(symbol=self.symbol)
         self.stop()
@@ -248,7 +263,9 @@ class StockDetailView(StockPublicView):
     @nextcord.ui.button(
         label="返回列表", emoji="↩️", style=ButtonStyle.secondary, custom_id="stock:back", row=1
     )
-    async def back(self, _button: Button, interaction: Interaction) -> None:
+    async def back(
+        self, _button: Button["StockDetailView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Returns to the public market list."""
         quotes = await list_market_quotes()
         embed, file = build_market_message_payload(quotes=quotes)
@@ -272,7 +289,9 @@ class StockNewsControlsView(StockPublicView):
     @nextcord.ui.button(
         label="返回明細", emoji="↩️", style=ButtonStyle.secondary, custom_id="stock:news:back"
     )
-    async def back(self, _button: Button, interaction: Interaction) -> None:
+    async def back(
+        self, _button: Button["StockNewsControlsView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Returns to the public stock detail view."""
         self.stop()
         await edit_stock_detail(
@@ -307,7 +326,9 @@ class StockActionView(StockPublicView):
         custom_id="stock:action",
         row=0,
     )
-    async def action_select(self, select: StringSelect, interaction: Interaction) -> None:
+    async def action_select(
+        self, select: StringSelect["StockActionView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Opens the quantity modal for the selected operation."""
         await interaction.response.send_modal(
             modal=StockQuantityModal(
@@ -326,7 +347,9 @@ class StockActionView(StockPublicView):
         custom_id="stock:action:back",
         row=1,
     )
-    async def back(self, _button: Button, interaction: Interaction) -> None:
+    async def back(
+        self, _button: Button["StockActionView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Returns to the public stock detail view."""
         self.stop()
         await edit_stock_detail(
@@ -349,7 +372,9 @@ class StockPostTradeView(StockPublicView):
         custom_id="stock:refresh",
         row=0,
     )
-    async def refresh(self, _button: Button, interaction: Interaction) -> None:
+    async def refresh(
+        self, _button: Button["StockPostTradeView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Edits the public message into a fresh detail view."""
         self.stop()
         await edit_stock_detail(
@@ -363,7 +388,9 @@ class StockPostTradeView(StockPublicView):
         custom_id="stock:post:back",
         row=0,
     )
-    async def back(self, _button: Button, interaction: Interaction) -> None:
+    async def back(
+        self, _button: Button["StockPostTradeView"], interaction: Interaction[commands.Bot]
+    ) -> None:
         """Returns to the public market list."""
         quotes = await list_market_quotes()
         embed, file = build_market_message_payload(quotes=quotes)
@@ -394,7 +421,7 @@ class StockQuantityModal(Modal):
         self.message = message
         self.parent = parent
         self.owner_id = owner_id
-        self.quantity: TextInput = TextInput(
+        self.quantity: TextInput[View] = TextInput(
             label="數量",
             placeholder="請輸入股數，或輸入 ALL",
             min_length=1,
@@ -404,7 +431,7 @@ class StockQuantityModal(Modal):
         )
         self.add_item(item=self.quantity)
 
-    async def callback(self, interaction: Interaction) -> None:
+    async def callback(self, interaction: Interaction[commands.Bot]) -> None:
         """Submits the quantity to the stock settlement service."""
         await submit_stock_quantity(
             submission=_StockQuantitySubmission(
@@ -419,7 +446,10 @@ class StockQuantityModal(Modal):
         )
 
     async def submit_quantity(
-        self, interaction: Interaction, raw_quantity: str, action: StockAction | None = None
+        self,
+        interaction: Interaction[commands.Bot],
+        raw_quantity: str,
+        action: StockAction | None = None,
     ) -> None:
         """Submits a raw quantity string to the stock settlement service."""
         await submit_stock_quantity(
@@ -435,7 +465,9 @@ class StockQuantityModal(Modal):
         )
 
 
-async def edit_stock_detail(interaction: Interaction, symbol: str, owner_id: int) -> None:
+async def edit_stock_detail(
+    interaction: Interaction[commands.Bot], symbol: str, owner_id: int
+) -> None:
     """Shows or edits a public stock detail view for one interaction."""
     user = require_stock_user(interaction=interaction)
     if not interaction.response.is_done():
@@ -461,7 +493,9 @@ async def edit_stock_detail(interaction: Interaction, symbol: str, owner_id: int
     )
 
 
-async def edit_stock_action_prompt(interaction: Interaction, symbol: str, owner_id: int) -> None:
+async def edit_stock_action_prompt(
+    interaction: Interaction[commands.Bot], symbol: str, owner_id: int
+) -> None:
     """Shows the operation dropdown with fresh stock and position context."""
     user = require_stock_user(interaction=interaction)
     if not interaction.response.is_done():

--- a/src/discordbot/cogs/auto_unmute.py
+++ b/src/discordbot/cogs/auto_unmute.py
@@ -131,7 +131,7 @@ class AutoUnmuteCogs(commands.Cog):
             logfire.warn(
                 "failed to send auto-unmute reply",
                 guild_id=member.guild.id,
-                channel_id=channel.id,
+                channel_id=getattr(channel, "id", None),
                 error_type=type(exc).__name__,
                 _exc_info=exc,
             )

--- a/src/discordbot/cogs/economy.py
+++ b/src/discordbot/cogs/economy.py
@@ -106,7 +106,7 @@ class EconomyCogs(commands.Cog):
         },
         nsfw=False,
     )
-    async def admin(self, interaction: Interaction) -> None:
+    async def admin(self, interaction: Interaction[commands.Bot]) -> None:
         """Slash command group for economy admin operations."""
 
     @admin.subcommand(
@@ -120,7 +120,7 @@ class EconomyCogs(commands.Cog):
     )
     async def admin_refund_tax(
         self,
-        interaction: Interaction,
+        interaction: Interaction[commands.Bot],
         member: Member = SlashOption(
             name="member",
             description=f"The member or bot to receive the {CURRENCY_NAME}.",
@@ -169,7 +169,7 @@ class EconomyCogs(commands.Cog):
     )
     async def admin_collect_tax(
         self,
-        interaction: Interaction,
+        interaction: Interaction[commands.Bot],
         member: Member = SlashOption(
             name="member",
             description=f"The member or bot to debit the {CURRENCY_NAME} from.",
@@ -208,7 +208,12 @@ class EconomyCogs(commands.Cog):
         )
 
     async def _run_admin_adjustment(
-        self, interaction: Interaction, member: Member, action: str, title: str, delta: int
+        self,
+        interaction: Interaction[commands.Bot],
+        member: Member,
+        action: str,
+        title: str,
+        delta: int,
     ) -> None:
         """Runs a gated admin balance adjustment and publishes successful results."""
         if interaction.user is None:
@@ -261,7 +266,7 @@ class EconomyCogs(commands.Cog):
     )
     async def balance(
         self,
-        interaction: Interaction,
+        interaction: Interaction[commands.Bot],
         member: Member | None = SlashOption(
             name="member",
             description="Member to inspect; defaults to yourself.",
@@ -308,7 +313,7 @@ class EconomyCogs(commands.Cog):
         },
         nsfw=False,
     )
-    async def leaderboard(self, interaction: Interaction) -> None:
+    async def leaderboard(self, interaction: Interaction[commands.Bot]) -> None:
         """Replies with the top 10 point holders.
 
         Args:
@@ -344,7 +349,7 @@ class EconomyCogs(commands.Cog):
         },
         nsfw=False,
     )
-    async def loss_leaderboard(self, interaction: Interaction) -> None:
+    async def loss_leaderboard(self, interaction: Interaction[commands.Bot]) -> None:
         """Replies with the top 10 gross casino losses for the current day.
 
         Args:
@@ -382,7 +387,7 @@ class EconomyCogs(commands.Cog):
     )
     async def give(
         self,
-        interaction: Interaction,
+        interaction: Interaction[commands.Bot],
         member: Member = SlashOption(
             name="member",
             description=f"The member or bot to receive the {CURRENCY_NAME}.",
@@ -485,7 +490,7 @@ class EconomyCogs(commands.Cog):
         },
         nsfw=False,
     )
-    async def casino(self, interaction: Interaction) -> None:
+    async def casino(self, interaction: Interaction[commands.Bot]) -> None:
         """Shows the casino system's accumulated P&L (was `/house`)."""
         await interaction.response.defer()
         snapshot = await get_casino_ledger()
@@ -502,7 +507,7 @@ class EconomyCogs(commands.Cog):
         },
         nsfw=False,
     )
-    async def pocat(self, interaction: Interaction) -> None:
+    async def pocat(self, interaction: Interaction[commands.Bot]) -> None:
         """Shows the bot player's `user_wallet` balance and gross flows."""
         await interaction.response.defer()
         if self.bot.user is None:
@@ -544,7 +549,7 @@ class EconomyCogs(commands.Cog):
         },
         nsfw=False,
     )
-    async def credit(self, interaction: Interaction) -> None:
+    async def credit(self, interaction: Interaction[commands.Bot]) -> None:
         """Slash command group for personal credit operations."""
 
     @credit.subcommand(
@@ -558,7 +563,7 @@ class EconomyCogs(commands.Cog):
     )
     async def credit_borrow(
         self,
-        interaction: Interaction,
+        interaction: Interaction[commands.Bot],
         member: Member = SlashOption(
             name="member",
             description="The member you want to borrow from.",
@@ -688,7 +693,7 @@ class EconomyCogs(commands.Cog):
     )
     async def credit_repay(
         self,
-        interaction: Interaction,
+        interaction: Interaction[commands.Bot],
         member: Member = SlashOption(
             name="member",
             description="The lender to repay.",
@@ -769,7 +774,7 @@ class EconomyCogs(commands.Cog):
     )
     async def credit_call(
         self,
-        interaction: Interaction,
+        interaction: Interaction[commands.Bot],
         member: Member = SlashOption(
             name="member",
             description="The borrower to collect from.",
@@ -842,7 +847,7 @@ class EconomyCogs(commands.Cog):
             Locale.ja: "active personal loan contracts を表示します。",
         },
     )
-    async def credit_status(self, interaction: Interaction) -> None:
+    async def credit_status(self, interaction: Interaction[commands.Bot]) -> None:
         """Shows the caller's active personal credit contracts."""
         await interaction.response.defer(ephemeral=True)
         if interaction.user is None:
@@ -873,7 +878,7 @@ class EconomyCogs(commands.Cog):
         },
         nsfw=False,
     )
-    async def central_bank(self, interaction: Interaction) -> None:
+    async def central_bank(self, interaction: Interaction[commands.Bot]) -> None:
         """Slash command group for central bank operations."""
 
     @central_bank.subcommand(
@@ -887,7 +892,7 @@ class EconomyCogs(commands.Cog):
     )
     async def central_bank_borrow(
         self,
-        interaction: Interaction,
+        interaction: Interaction[commands.Bot],
         amount: str = SlashOption(
             name="amount",
             description=f"How much {CURRENCY_NAME} to request. Commas are allowed.",
@@ -973,7 +978,7 @@ class EconomyCogs(commands.Cog):
     )
     async def central_bank_repay(
         self,
-        interaction: Interaction,
+        interaction: Interaction[commands.Bot],
         amount: str = SlashOption(
             name="amount",
             description="Maximum amount to repay. Commas are allowed.",
@@ -1035,7 +1040,7 @@ class EconomyCogs(commands.Cog):
     )
     async def central_bank_call(
         self,
-        interaction: Interaction,
+        interaction: Interaction[commands.Bot],
         member: Member = SlashOption(
             name="member",
             description="The borrower to collect from.",
@@ -1114,7 +1119,7 @@ class EconomyCogs(commands.Cog):
             Locale.ja: "中央銀行の lending capacity を表示します。",
         },
     )
-    async def central_bank_status(self, interaction: Interaction) -> None:
+    async def central_bank_status(self, interaction: Interaction[commands.Bot]) -> None:
         """Shows central bank lending capacity."""
         await interaction.response.defer()
         exclude_user_ids = (self.bot.user.id,) if self.bot.user else ()
@@ -1138,7 +1143,7 @@ class EconomyCogs(commands.Cog):
         },
         nsfw=False,
     )
-    async def checkin_command(self, interaction: Interaction) -> None:
+    async def checkin_command(self, interaction: Interaction[commands.Bot]) -> None:
         """Claims today's check-in reward; ephemeral so only the caller sees it.
 
         Args:
@@ -1182,7 +1187,7 @@ class EconomyCogs(commands.Cog):
         },
         nsfw=False,
     )
-    async def vip_command(self, interaction: Interaction) -> None:
+    async def vip_command(self, interaction: Interaction[commands.Bot]) -> None:
         """Buys the permanent VIP perk for a one-time fixed cost.
 
         Args:

--- a/src/discordbot/cogs/games.py
+++ b/src/discordbot/cogs/games.py
@@ -172,7 +172,7 @@ class GamesCogs(commands.Cog):
 
     async def _prepare_participant(
         self,
-        interaction: Interaction,
+        interaction: Interaction[commands.Bot],
         wager: int,
         mode: WagerMode,
         insufficient_embed_builder: Callable[[int], Embed],
@@ -264,7 +264,7 @@ class GamesCogs(commands.Cog):
         description_localizations={Locale.zh_TW: "小遊戲指令", Locale.ja: "ゲームコマンド。"},
         nsfw=False,
     )
-    async def games(self, interaction: Interaction) -> None:
+    async def games(self, interaction: Interaction[commands.Bot]) -> None:
         """Slash command group for casino games."""
 
     @games.subcommand(
@@ -278,7 +278,7 @@ class GamesCogs(commands.Cog):
     )
     async def blackjack(
         self,
-        interaction: Interaction,
+        interaction: Interaction[commands.Bot],
         bet: str = SlashOption(
             name="bet",
             description=f"Table stake in {CURRENCY_NAME}; enter 0 to go all in. Commas are allowed.",
@@ -382,7 +382,7 @@ class GamesCogs(commands.Cog):
             Locale.ja: "共有ジャックポットのインビトウィーン table を開きます。",
         },
     )
-    async def dragon_gate(self, interaction: Interaction) -> None:
+    async def dragon_gate(self, interaction: Interaction[commands.Bot]) -> None:
         """Opens a 射龍門 lobby. The owner starts the table from the lobby.
 
         Args:
@@ -451,7 +451,7 @@ class GamesCogs(commands.Cog):
     )
     async def blackjack_history(
         self,
-        interaction: Interaction,
+        interaction: Interaction[commands.Bot],
         member: Member | None = SlashOption(
             name="member",
             description="Player to inspect; defaults to yourself.",
@@ -507,7 +507,7 @@ class GamesCogs(commands.Cog):
             Locale.ja: "釣りパネルを開いて、道具購入とキャストで遊びます。",
         },
     )
-    async def fishing(self, interaction: Interaction) -> None:
+    async def fishing(self, interaction: Interaction[commands.Bot]) -> None:
         """Opens the personal fishing panel as one public, in-place message.
 
         Args:

--- a/src/discordbot/cogs/gen_reply.py
+++ b/src/discordbot/cogs/gen_reply.py
@@ -1068,7 +1068,7 @@ class ReplyGeneratorCogs(commands.Cog):
                 memory_lookups=context.memory_labels,
                 input_tokens=context.selection_input_tokens,
                 output_tokens=context.selection_output_tokens,
-                model_effort=model.effort,
+                model_effort=model.effort or "",
             )
             with logfire.span(span_name, model=model.name):
                 responses = await self.openai_client.responses.create(

--- a/src/discordbot/cogs/help.py
+++ b/src/discordbot/cogs/help.py
@@ -37,16 +37,19 @@ class HelpCogs(commands.Cog):
         },
         nsfw=False,
     )
-    async def help(self, interaction: Interaction) -> None:
+    async def help(self, interaction: Interaction[commands.Bot]) -> None:
         """Shows a category-driven guide on how to use this bot.
 
         Args:
             interaction: The interaction that triggered the command.
         """
+        user = interaction.user
+        if user is None:
+            return
         view = HelpView(
-            locale=interaction.locale,
-            requester_name=interaction.user.display_name,
-            requester_avatar_url=interaction.user.display_avatar.url,
+            locale=interaction.locale or "",
+            requester_name=user.display_name,
+            requester_avatar_url=user.display_avatar.url,
         )
         await interaction.response.send_message(
             embed=view.initial_embed(), view=view, ephemeral=True

--- a/src/discordbot/cogs/log_msg.py
+++ b/src/discordbot/cogs/log_msg.py
@@ -183,7 +183,9 @@ class MessageLogger(BaseModel):
         if isinstance(self.message.channel, DMChannel):
             author_name = self.message.author.display_name
             return f"DM_{author_name}_{self.message.author.id}"
-        return f"channel_{self.message.channel.name}_{self.message.channel.id}"
+        channel = self.message.channel
+        channel_name = getattr(channel, "name", None) or channel.id
+        return f"channel_{channel_name}_{channel.id}"
 
     @computed_field
     @property
@@ -302,7 +304,7 @@ class LogMessageCog(commands.Cog):
         asyncio.create_task(MessageLogger(message=after).log())  # noqa: RUF006
 
     @commands.Cog.listener()
-    async def on_command_completion(self, context: commands.Context) -> None:
+    async def on_command_completion(self, context: commands.Context[commands.Bot]) -> None:
         """Listens for command completions and logs the message that triggered it.
 
         Args:

--- a/src/discordbot/cogs/maplestory.py
+++ b/src/discordbot/cogs/maplestory.py
@@ -28,7 +28,7 @@ _ERROR_COLOR = 0xFF0000
 
 
 async def _send_maple_followup(
-    interaction: Interaction, embed: Embed, view: View | None = None
+    interaction: Interaction[commands.Bot], embed: Embed, view: View | None = None
 ) -> None:
     """Sends a MapleStory result embed at a uniform width."""
     payload = embed_spacer_payload(embeds=[embed], is_edit=False, target=interaction)
@@ -70,14 +70,16 @@ class MapleStoryCogs(commands.Cog):
             return equipment_label
         return self._translate(category="misc", name=item)
 
-    async def _send_error(self, interaction: Interaction) -> None:
+    async def _send_error(self, interaction: Interaction[commands.Bot]) -> None:
         """Sends a generic error message to the user."""
         embed = Embed(
             title=":x: 錯誤", description="無法載入資料，請聯絡管理員", color=_ERROR_COLOR
         )
         await _send_maple_followup(interaction=interaction, embed=embed)
 
-    async def _send_not_found(self, interaction: Interaction, kind: str, query: str) -> None:
+    async def _send_not_found(
+        self, interaction: Interaction[commands.Bot], kind: str, query: str
+    ) -> None:
         """Sends a 'not found' message to the user."""
         embed = Embed(
             title=":mag: 搜尋結果",
@@ -95,7 +97,7 @@ class MapleStoryCogs(commands.Cog):
             Locale.ja: "メイプルストーリー Artale データを検索します。",
         },
     )
-    async def maplestory(self, interaction: Interaction) -> None:
+    async def maplestory(self, interaction: Interaction[commands.Bot]) -> None:
         """Slash command group for MapleStory Artale data queries."""
 
     # ── /maplestory monster ─────────────────────────────────────────
@@ -111,7 +113,7 @@ class MapleStoryCogs(commands.Cog):
     )
     async def maple_monster(
         self,
-        interaction: Interaction,
+        interaction: Interaction[commands.Bot],
         name: str = SlashOption(
             name="name",
             description="Monster name to search",
@@ -167,7 +169,7 @@ class MapleStoryCogs(commands.Cog):
     )
     async def maple_equip(
         self,
-        interaction: Interaction,
+        interaction: Interaction[commands.Bot],
         name: str = SlashOption(
             name="name",
             description="Equipment name to search",
@@ -227,7 +229,7 @@ class MapleStoryCogs(commands.Cog):
     )
     async def maple_scroll(
         self,
-        interaction: Interaction,
+        interaction: Interaction[commands.Bot],
         name: str = SlashOption(
             name="name",
             description="Scroll name to search",
@@ -287,7 +289,7 @@ class MapleStoryCogs(commands.Cog):
     )
     async def maple_npc(
         self,
-        interaction: Interaction,
+        interaction: Interaction[commands.Bot],
         name: str = SlashOption(
             name="name",
             description="NPC name to search",
@@ -342,7 +344,7 @@ class MapleStoryCogs(commands.Cog):
     )
     async def maple_quest(
         self,
-        interaction: Interaction,
+        interaction: Interaction[commands.Bot],
         name: str = SlashOption(
             name="name",
             description="Quest name to search",
@@ -400,7 +402,7 @@ class MapleStoryCogs(commands.Cog):
     )
     async def maple_map(
         self,
-        interaction: Interaction,
+        interaction: Interaction[commands.Bot],
         name: str = SlashOption(
             name="name",
             description="Map name to search",
@@ -460,7 +462,7 @@ class MapleStoryCogs(commands.Cog):
     )
     async def maple_item(
         self,
-        interaction: Interaction,
+        interaction: Interaction[commands.Bot],
         name: str = SlashOption(
             name="name",
             description="Item name to search",
@@ -522,7 +524,7 @@ class MapleStoryCogs(commands.Cog):
             Locale.ja: "メイプルストーリーデータベース統計を表示",
         },
     )
-    async def maple_stats(self, interaction: Interaction) -> None:
+    async def maple_stats(self, interaction: Interaction[commands.Bot]) -> None:
         """Gets MapleStory database statistics.
 
         Args:

--- a/src/discordbot/cogs/memory.py
+++ b/src/discordbot/cogs/memory.py
@@ -100,7 +100,7 @@ class MemoryCogs(commands.Cog):
         },
         nsfw=False,
     )
-    async def memory(self, interaction: Interaction) -> None:
+    async def memory(self, interaction: Interaction[commands.Bot]) -> None:
         """Slash command group for memory management."""
 
     @memory.subcommand(
@@ -112,7 +112,7 @@ class MemoryCogs(commands.Cog):
             Locale.ja: "ボットがあなたについて記憶している内容を表示します。",
         },
     )
-    async def memory_show(self, interaction: Interaction) -> None:
+    async def memory_show(self, interaction: Interaction[commands.Bot]) -> None:
         """Shows the caller's consolidated memory, paginated."""
         if interaction.user is None:
             return
@@ -138,7 +138,7 @@ class MemoryCogs(commands.Cog):
             Locale.ja: "このサーバーについてボットが記憶している内容を確認します。",
         },
     )
-    async def memory_server(self, interaction: Interaction) -> None:
+    async def memory_server(self, interaction: Interaction[commands.Bot]) -> None:
         """Subcommand group for per-server memory viewing."""
 
     @memory_server.subcommand(
@@ -150,7 +150,7 @@ class MemoryCogs(commands.Cog):
             Locale.ja: "このサーバーのコミュニティについてボットが記憶している内容を表示します。",
         },
     )
-    async def memory_server_show(self, interaction: Interaction) -> None:
+    async def memory_server_show(self, interaction: Interaction[commands.Bot]) -> None:
         """Shows the bot's consolidated memory of the current server, paginated."""
         if interaction.guild is None or self.bot.user is None:
             # Per-server memory only exists inside a guild; there is no scope in DMs.
@@ -175,7 +175,7 @@ class MemoryCogs(commands.Cog):
 
     async def _show_memory(  # noqa: PLR0913 -- display strings plus the optional tone section
         self,
-        interaction: Interaction,
+        interaction: Interaction[commands.Bot],
         scope: str,
         title: str,
         empty_description: str,
@@ -216,7 +216,7 @@ class MemoryCogs(commands.Cog):
         await interaction.response.send_message(embed=embed, ephemeral=True)
 
     async def _send_memory_pages(
-        self, interaction: Interaction, text: str, footer_text: str, title: str
+        self, interaction: Interaction[commands.Bot], text: str, footer_text: str, title: str
     ) -> None:
         """Sends paginated memory pages, attaching the pager only when needed."""
         pages = paginate_on_lines(text=text, limit=MEMORY_PAGE_MAX_CHARS)
@@ -243,7 +243,7 @@ class MemoryCogs(commands.Cog):
             Locale.ja: "観察ログだけを使って、あなたに関する記憶を一から作り直します。",
         },
     )
-    async def memory_regenerate(self, interaction: Interaction) -> None:
+    async def memory_regenerate(self, interaction: Interaction[commands.Bot]) -> None:
         """Schedules a background rebuild of the caller's memory from evidence alone."""
         if interaction.user is None:
             return

--- a/src/discordbot/cogs/research.py
+++ b/src/discordbot/cogs/research.py
@@ -26,6 +26,7 @@ from nextcord import (
     Embed,
     Locale,
     Object,
+    Thread,
     Message,
     NotFound,
     Forbidden,
@@ -65,8 +66,6 @@ from discordbot.cogs._gen_reply.exceptions import extract_friendly_error
 if TYPE_CHECKING:
     from typing import Any
     from collections.abc import Coroutine
-
-    from nextcord import Thread
 
 # How long the modify flow waits for the owner to type their changes in the thread.
 MODIFY_WAIT_TIMEOUT_SECONDS = 600.0
@@ -219,7 +218,7 @@ class ResearchCogs(commands.Cog):
     )
     async def deep_research(
         self,
-        interaction: Interaction,
+        interaction: Interaction[commands.Bot],
         topic: str = SlashOption(
             name="topic",
             description="What to research (a clear, self-contained topic).",
@@ -600,13 +599,13 @@ class ResearchCogs(commands.Cog):
     # ----- escalation (Deep Research) -----------------------------------------------------
 
     async def on_escalate(
-        self, *, interaction: Interaction, view: ResultEscalationView, max_tier: bool
+        self, *, interaction: Interaction[commands.Bot], view: ResultEscalationView, max_tier: bool
     ) -> None:
         """Escalation button: opens a Deep Research plan discussion."""
         with contextlib.suppress(Exception):
             await interaction.response.edit_message(view=None)
         thread = interaction.channel
-        if thread is None:
+        if not isinstance(thread, Thread):
             return
         existing = await db.active_thread_for_owner(owner_id=view.owner_id)
         if existing is not None and existing != thread.id:
@@ -778,12 +777,14 @@ class ResearchCogs(commands.Cog):
                 allowed_mentions=_owner_allowed_mentions(owner_id=owner_id),
             )
 
-    async def on_accept_plan(self, *, interaction: Interaction, view: PlanApprovalView) -> None:
+    async def on_accept_plan(
+        self, *, interaction: Interaction[commands.Bot], view: PlanApprovalView
+    ) -> None:
         """Approve button: runs the full Deep Research from the approved plan."""
         with contextlib.suppress(Exception):
             await interaction.response.edit_message(view=None)
         thread = interaction.channel
-        if thread is None:
+        if not isinstance(thread, Thread):
             return
         # Atomic claim: a double-click can fire two callbacks before the view-removal edit lands, so
         # only the call that wins the planning->researching transition spawns the paid run. Guarded
@@ -803,10 +804,12 @@ class ResearchCogs(commands.Cog):
             )
         )
 
-    async def on_modify_plan(self, *, interaction: Interaction, view: PlanApprovalView) -> None:
+    async def on_modify_plan(
+        self, *, interaction: Interaction[commands.Bot], view: PlanApprovalView
+    ) -> None:
         """Modify button: waits for the owner to type changes, then re-plans."""
         thread = interaction.channel
-        if thread is None:
+        if not isinstance(thread, Thread):
             return
         # Idempotency: a double-click would install two `wait_for` listeners, so one feedback
         # message would spawn competing `_run_refine` plans against the same interaction. Ignore a
@@ -821,8 +824,10 @@ class ResearchCogs(commands.Cog):
             await interaction.response.send_message(
                 content="好,直接在這個 thread 打你想調整的地方,我會重新規劃(10 分鐘內回覆有效)"
             )
-            with contextlib.suppress(Exception):
-                await interaction.message.edit(view=None)
+            plan_message = interaction.message
+            if plan_message is not None:
+                with contextlib.suppress(Exception):
+                    await plan_message.edit(view=None)
 
             def _is_owner_reply(candidate: "Message") -> bool:
                 return (
@@ -1029,7 +1034,7 @@ class ResearchCogs(commands.Cog):
     async def _fetch_thread(self, *, thread_id: int) -> "Thread | None":
         """Returns the thread by id from cache or a REST fetch, or None when gone."""
         cached = self.bot.get_channel(thread_id)
-        if cached is not None:
+        if isinstance(cached, Thread):
             return cached
         try:
             fetched = await self.bot.fetch_channel(thread_id)
@@ -1047,7 +1052,7 @@ class ResearchCogs(commands.Cog):
                 _exc_info=exc,
             )
             return None
-        return fetched
+        return fetched if isinstance(fetched, Thread) else None
 
     # ----- helpers ------------------------------------------------------------------------
 

--- a/src/discordbot/cogs/stock.py
+++ b/src/discordbot/cogs/stock.py
@@ -57,7 +57,7 @@ class StockCogs(commands.Cog):
         },
         nsfw=False,
     )
-    async def stock(self, interaction: Interaction) -> None:
+    async def stock(self, interaction: Interaction[commands.Bot]) -> None:
         """Shows the public stock market list."""
         await interaction.response.defer()
         user = require_stock_user(interaction=interaction)

--- a/src/discordbot/cogs/template.py
+++ b/src/discordbot/cogs/template.py
@@ -51,7 +51,7 @@ class TemplateCogs(commands.Cog):
         },
         nsfw=False,
     )
-    async def ping(self, interaction: Interaction) -> None:
+    async def ping(self, interaction: Interaction[commands.Bot]) -> None:
         """Checks the bot's response time.
 
         Args:
@@ -66,10 +66,11 @@ class TemplateCogs(commands.Cog):
             timestamp=nextcord.utils.utcnow(),
         )
         embed.add_field(name="Bot Latency", value=f"`{bot_latency}ms`")
-        embed.set_footer(
-            text=f"Requested by {interaction.user.display_name}",
-            icon_url=interaction.user.display_avatar.url,
-        )
+        user = interaction.user
+        if user is not None:
+            embed.set_footer(
+                text=f"Requested by {user.display_name}", icon_url=user.display_avatar.url
+            )
 
         await interaction.followup.send(
             embed=embed, **embed_spacer_payload(embeds=[embed], is_edit=False, target=interaction)

--- a/src/discordbot/cogs/video.py
+++ b/src/discordbot/cogs/video.py
@@ -61,7 +61,7 @@ class VideoCogs(commands.Cog):
     )
     async def download_video(
         self,
-        interaction: Interaction,
+        interaction: Interaction[commands.Bot],
         url: str = SlashOption(
             description="Video URL, or the share text containing it (YouTube, Instagram, X, Douyin, etc.)",
             required=True,
@@ -145,7 +145,11 @@ class VideoCogs(commands.Cog):
             await self._edit_quietly(interaction=interaction, content="-# 檔案無法下載")
 
     async def _handle_douyin(
-        self, interaction: Interaction, url: str, quality: VideoQuality, upload_limit: int
+        self,
+        interaction: Interaction[commands.Bot],
+        url: str,
+        quality: VideoQuality,
+        upload_limit: int,
     ) -> None:
         """Downloads a Douyin video or photo post and sends it back.
 
@@ -173,7 +177,7 @@ class VideoCogs(commands.Cog):
 
     async def _download_and_deliver_douyin(
         self,
-        interaction: Interaction,
+        interaction: Interaction[commands.Bot],
         url: str,
         quality: VideoQuality,
         upload_limit: int,
@@ -257,7 +261,11 @@ class VideoCogs(commands.Cog):
             await self._edit_quietly(interaction=interaction, content="-# 檔案無法下載")
 
     async def _deliver_douyin(
-        self, interaction: Interaction, plan: MediaPlan, result: DouyinDownload, url: str
+        self,
+        interaction: Interaction[commands.Bot],
+        plan: MediaPlan,
+        result: DouyinDownload,
+        url: str,
     ) -> None:
         """Edits the placeholder into the final Douyin response.
 
@@ -305,7 +313,7 @@ class VideoCogs(commands.Cog):
             content="\n".join(lines), allowed_mentions=AllowedMentions.none()
         )
 
-    async def _edit_quietly(self, interaction: Interaction, content: str) -> None:
+    async def _edit_quietly(self, interaction: Interaction[commands.Bot], content: str) -> None:
         """Edits the deferred message, swallowing a failure to edit it.
 
         Broad on purpose: this is the last-resort reporter every failure path in the cog uses, so
@@ -322,7 +330,11 @@ class VideoCogs(commands.Cog):
             )
 
     async def _deliver(
-        self, interaction: Interaction, file_size_mb: float, file_path: Path, url: str
+        self,
+        interaction: Interaction[commands.Bot],
+        file_size_mb: float,
+        file_path: Path,
+        url: str,
     ) -> None:
         """Edits the deferred placeholder into the final downloaded file response."""
         body = f"-# 檔案大小: {file_size_mb:.1f}MB\n-# 來源: <{url}>"
@@ -333,7 +345,7 @@ class VideoCogs(commands.Cog):
         )
 
     async def _deliver_url(
-        self, interaction: Interaction, file_size_mb: float, public_url: str
+        self, interaction: Interaction[commands.Bot], file_size_mb: float, public_url: str
     ) -> None:
         """Edits the placeholder into a hosted-URL response for a file too big to upload.
 

--- a/src/discordbot/utils/avatars.py
+++ b/src/discordbot/utils/avatars.py
@@ -9,8 +9,13 @@ from nextcord import Asset, Guild, Member, HTTPException
 class AvatarUser(Protocol):
     """Discord user-like object with enough identity for avatar lookup."""
 
-    id: int
-    display_avatar: Asset
+    # Read-only properties: nextcord's User/Member expose these as properties,
+    # which cannot satisfy a mutable protocol attribute.
+    @property
+    def id(self) -> int: ...
+
+    @property
+    def display_avatar(self) -> Asset: ...
 
 
 async def guild_avatar_url(user: AvatarUser, guild: Guild | None = None) -> str:

--- a/src/discordbot/utils/douyin.py
+++ b/src/discordbot/utils/douyin.py
@@ -14,7 +14,7 @@ import re
 import json
 import time
 import types
-from typing import ClassVar
+from typing import Any, ClassVar
 from pathlib import Path
 from functools import cached_property
 import threading
@@ -241,7 +241,7 @@ class DouyinDownload(BaseModel):
 # 403 on download, which is worse than re-fetching. Bounded like the other long-lived caches in
 # this project (see `_gen_reply/attachment/base.py`) so a long-running bot cannot accumulate one
 # full payload per link it has ever seen.
-_PAYLOAD_CACHE: OrderedDict[str, tuple[float, dict]] = OrderedDict()
+_PAYLOAD_CACHE: OrderedDict[str, tuple[float, dict[str, Any]]] = OrderedDict()
 _PAYLOAD_CACHE_TTL_SECONDS = 300.0
 _PAYLOAD_CACHE_MAX_ENTRIES = 128
 
@@ -418,7 +418,7 @@ class DouyinDownloader(BaseModel):
         # against the request URL rather than trusting the header verbatim.
         return urljoin(url, location)
 
-    def _fetch_share_payload(self, aweme_id: str) -> dict:
+    def _fetch_share_payload(self, aweme_id: str) -> dict[str, Any]:
         """Fetches and parses the share page for a post id.
 
         Args:
@@ -475,7 +475,7 @@ class DouyinDownloader(BaseModel):
         return info
 
     @staticmethod
-    def _find_video_info(router_data: dict) -> dict | None:
+    def _find_video_info(router_data: dict[str, Any]) -> dict[str, Any] | None:
         """Finds the `videoInfoRes` object inside `loaderData`.
 
         The `loaderData` key is named after the URL path that was fetched (`note_(id)/page` for a
@@ -499,7 +499,7 @@ class DouyinDownloader(BaseModel):
         return None
 
     @staticmethod
-    def _first_item(info: dict, aweme_id: str) -> dict:
+    def _first_item(info: dict[str, Any], aweme_id: str) -> dict[str, Any]:
         """Returns the post object, translating Douyin's soft failures into errors.
 
         Douyin answers a deleted, private or region-locked post with HTTP 200, an empty
@@ -563,12 +563,12 @@ class DouyinDownloader(BaseModel):
         )
 
     @staticmethod
-    def _video_id(item: dict) -> str:
+    def _video_id(item: dict[str, Any]) -> str:
         """Reads the internal video id used to build a play URL."""
         return ((item.get("video") or {}).get("play_addr") or {}).get("uri") or ""
 
     @staticmethod
-    def _image_urls(images: list) -> list[str]:
+    def _image_urls(images: list[Any]) -> list[str]:
         """Picks one watermark-free URL per image.
 
         Despite the names, `url_list` holds the clean images and `download_url_list` holds the

--- a/src/discordbot/utils/message_cleanup.py
+++ b/src/discordbot/utils/message_cleanup.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import logfire
 from nextcord import Message, NotFound, Forbidden, HTTPException
+from nextcord.abc import Messageable
 from pydantic import Field, BaseModel
 from sqlalchemy import Engine, text, event, create_engine
 from nextcord.ext import commands
@@ -209,9 +210,9 @@ async def list_pending_public_messages() -> list[PendingPublicMessage]:
 async def _fetch_tracked_message(bot: commands.Bot, record: PendingPublicMessage) -> Message:
     """Fetches a tracked message from a concrete Discord channel."""
     channel = bot.get_channel(record.channel_id)
-    if channel is None or not hasattr(channel, "fetch_message"):
+    if channel is None or not isinstance(channel, Messageable):
         channel = await bot.fetch_channel(record.channel_id)
-    if not hasattr(channel, "fetch_message"):
+    if not isinstance(channel, Messageable):
         msg = f"Channel {record.channel_id} cannot fetch messages"
         raise TypeError(msg)
     return await channel.fetch_message(record.message_id)

--- a/src/discordbot/utils/message_cleanup.py
+++ b/src/discordbot/utils/message_cleanup.py
@@ -6,9 +6,9 @@ from pathlib import Path
 
 import logfire
 from nextcord import Message, NotFound, Forbidden, HTTPException
-from nextcord.abc import Messageable
 from pydantic import Field, BaseModel
 from sqlalchemy import Engine, text, event, create_engine
+from nextcord.abc import Messageable
 from nextcord.ext import commands
 from sqlalchemy.engine import Connection
 

--- a/src/discordbot/utils/owned_message_views.py
+++ b/src/discordbot/utils/owned_message_views.py
@@ -7,11 +7,13 @@ own embeds, controls, and notice text.
 """
 
 from io import BytesIO
+from typing import cast
 from collections.abc import Callable
 
 import logfire
-from nextcord import File, Embed, Message, NotFound, Interaction
+from nextcord import File, Embed, Message, NotFound, Attachment, Interaction
 from nextcord.ui import View
+from nextcord.ext import commands
 
 from discordbot.utils.discord_embeds import embed_spacer_payload
 from discordbot.utils.message_cleanup import (
@@ -21,7 +23,9 @@ from discordbot.utils.message_cleanup import (
 )
 
 
-async def send_ephemeral_notice(interaction: Interaction, content: str, log_message: str) -> None:
+async def send_ephemeral_notice(
+    interaction: Interaction[commands.Bot], content: str, log_message: str
+) -> None:
     """Sends an ephemeral interaction notice with response/followup fallback."""
     try:
         if interaction.response.is_done():
@@ -53,7 +57,7 @@ class OwnedPublicView(View):
         """Records the message this view should update or delete."""
         self.message = message
 
-    async def interaction_check(self, interaction: Interaction) -> bool:
+    async def interaction_check(self, interaction: Interaction[commands.Bot]) -> bool:
         """Allows only the user who opened this panel to operate it."""
         if interaction.user is None:
             raise RuntimeError("Interaction is missing Discord user identity")
@@ -97,7 +101,7 @@ def _fresh_extra_files(file_factory: Callable[[], File] | None) -> list[File] | 
 
 
 async def edit_owned_public_message(
-    interaction: Interaction,
+    interaction: Interaction[commands.Bot],
     embed: Embed,
     view: OwnedPublicView | None,
     file: File | None = None,
@@ -108,41 +112,46 @@ async def edit_owned_public_message(
     if view is not None:
         view.bind_message(message=target_message)
     file_factory = _fresh_file_factory(file=file)
-    kwargs: dict[str, object] = {
-        "embed": embed,
-        "view": view,
-        **embed_spacer_payload(
-            embeds=[embed],
-            is_edit=True,
-            target=target_message or interaction,
-            extra_files=_fresh_extra_files(file_factory=file_factory),
-        ),
-    }
+    edit_spacer = embed_spacer_payload(
+        embeds=[embed],
+        is_edit=True,
+        target=target_message or interaction,
+        extra_files=_fresh_extra_files(file_factory=file_factory),
+    )
+    edit_files = cast("list[File]", edit_spacer.get("files", []))
+    edit_attachments = cast("list[Attachment]", edit_spacer.get("attachments", []))
     if not interaction.response.is_done():
-        edited = await interaction.response.edit_message(**kwargs)
+        edited = await interaction.response.edit_message(
+            embed=embed, view=view, files=edit_files, attachments=edit_attachments
+        )
         if isinstance(edited, Message) and view is not None:
             view.bind_message(message=edited)
         return
     if target_message is not None:
         try:
-            await target_message.edit(**kwargs)
+            await target_message.edit(
+                embed=embed, view=view, files=edit_files, attachments=edit_attachments
+            )
             return
         except NotFound:
             message_id = getattr(target_message, "id", None)
             if isinstance(message_id, int):
                 await forget_public_message(message_id=message_id)
-    followup_kwargs: dict[str, object] = {
-        "embed": embed,
-        "view": view,
-        "wait": True,
-        **embed_spacer_payload(
-            embeds=[embed],
-            is_edit=False,
-            target=interaction,
-            extra_files=_fresh_extra_files(file_factory=file_factory),
-        ),
-    }
-    sent_message = await interaction.followup.send(**followup_kwargs)
+    followup_spacer = embed_spacer_payload(
+        embeds=[embed],
+        is_edit=False,
+        target=interaction,
+        extra_files=_fresh_extra_files(file_factory=file_factory),
+    )
+    followup_files = cast("list[File]", followup_spacer.get("files", []))
+    if view is not None:
+        sent_message = await interaction.followup.send(
+            embed=embed, view=view, wait=True, files=followup_files
+        )
+    else:
+        sent_message = await interaction.followup.send(
+            embed=embed, wait=True, files=followup_files
+        )
     if view is not None:
         view.bind_message(message=sent_message)
     user_name = getattr(interaction.user, "name", None)

--- a/src/discordbot/utils/threads.py
+++ b/src/discordbot/utils/threads.py
@@ -2,6 +2,7 @@
 
 import re
 import json
+from typing import Any
 from pathlib import Path
 from datetime import UTC, datetime
 from functools import cached_property
@@ -539,9 +540,9 @@ class ThreadsDownloader(BaseModel):
             raise RuntimeError(f"Failed to fetch HTML from {url}: {e}") from e
 
     @staticmethod
-    def _find_keys(obj: dict | list | str | float | None, key: str) -> list:
+    def _find_keys(obj: dict[str, Any] | list[Any] | str | float | None, key: str) -> list[Any]:
         """Recursively searches for all occurrences of a key in a JSON-like object."""
-        results: list = []
+        results: list[Any] = []
         if isinstance(obj, dict):
             for k, v in obj.items():
                 if k == key and isinstance(v, list | dict):

--- a/tests/helpers/casting.py
+++ b/tests/helpers/casting.py
@@ -1,0 +1,81 @@
+"""Typed boundaries for handing test doubles to production signatures.
+
+The suite's fakes (``FakeMessage``, ``FakeInteraction``, recorder clients, ...)
+stay plain classes so tests can read their recorded attributes back, while
+production signatures take the real nextcord/OpenAI types. These adapters
+centralize the one ``cast`` each boundary needs, so call sites stay clean and
+the cast target stays consistent. The ``object`` parameters are deliberate:
+every fake family across the test modules funnels through the same adapter.
+"""
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, cast
+
+from nextcord import Message, NotFound, Interaction
+from nextcord.ext import commands
+
+from discordbot.utils.media_delivery import MediaHostingConfig
+
+if TYPE_CHECKING:
+    from aiohttp import ClientResponse
+
+
+def as_message(fake: object) -> Message:
+    """Views a message double as the nextcord Message a production signature expects."""
+    return cast("Message", fake)
+
+
+def as_interaction(fake: object) -> Interaction[Any]:
+    """Views an interaction double as the nextcord Interaction a production signature expects."""
+    return cast("Interaction[Any]", fake)
+
+
+def as_bot(fake: object) -> commands.Bot:
+    """Views a bot double as the commands.Bot a cog constructor or ``setup`` expects."""
+    return cast("commands.Bot", fake)
+
+
+def step_dicts(steps: object) -> list[dict[str, Any]]:
+    """Views a typed input/step list as plain dicts for key-level assertions.
+
+    The Responses/Interactions input lists are unions of TypedDicts; indexing a
+    key only some members carry is an invalid-key error even when the test just
+    built the concrete member. Assertions only read keys, so the plain-dict view
+    is safe.
+    """
+    return cast("list[dict[str, Any]]", steps)
+
+
+def make_not_found(message: str = "missing") -> NotFound:
+    """Builds the ``NotFound`` nextcord raises for a deleted Discord entity.
+
+    The constructor only reads ``status``/``reason`` off the response, so a
+    minimal stub stands in for the aiohttp response.
+    """
+    response = cast("ClientResponse", SimpleNamespace(status=404, reason="Not Found"))
+    return NotFound(response=response, message=message)
+
+
+def make_media_hosting_config(
+    enabled: bool,
+    base_url: str = "",
+    serve_dir: str = "",
+    max_bytes: int | None = None,
+    retention_hours: float | None = None,
+) -> MediaHostingConfig:
+    """Builds a MediaHostingConfig through its env-alias names.
+
+    ``model_validate`` keeps the alias spelling type-clean (the alias kwargs on
+    ``__init__`` are invisible to a checker without a pydantic plugin) and stays
+    hermetic: unlike ``__init__``, it never merges environment values in.
+    """
+    payload: dict[str, object] = {
+        "MEDIA_HOSTING_ENABLED": enabled,
+        "MEDIA_HOSTING_BASE_URL": base_url,
+        "MEDIA_HOSTING_SERVE_DIR": serve_dir,
+    }
+    if max_bytes is not None:
+        payload["MEDIA_HOSTING_MAX_BYTES"] = max_bytes
+    if retention_hours is not None:
+        payload["MEDIA_HOSTING_RETENTION_HOURS"] = retention_hours
+    return MediaHostingConfig.model_validate(payload)

--- a/tests/helpers/embeds.py
+++ b/tests/helpers/embeds.py
@@ -7,11 +7,24 @@ title carries its category marker — and hand the field back so the caller chec
 only the value that actually encodes behavior (an amount, a status).
 """
 
+from typing import Protocol
+
 from nextcord import Embed
-from nextcord.embeds import EmbedProxy
 
 
-def assert_embed_has_field(embed: Embed, name: str) -> EmbedProxy:
+class EmbedField(Protocol):
+    """The field shape ``Embed.fields`` yields at runtime.
+
+    Mirrors nextcord's TYPE_CHECKING-only ``_EmbedFieldProxy`` so this module
+    never imports a private name.
+    """
+
+    name: str | None
+    value: str | None
+    inline: bool
+
+
+def assert_embed_has_field(embed: Embed, name: str) -> EmbedField:
     """Asserts a field with the given name exists and returns it for value checks."""
     for field in embed.fields:
         if field.name == name:

--- a/tests/test_avatar_utils.py
+++ b/tests/test_avatar_utils.py
@@ -1,15 +1,26 @@
 """Tests for guild-aware Discord avatar selection."""
 
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
-
-import nextcord
+from typing import TYPE_CHECKING, cast
 
 from discordbot import cli
-from discordbot.utils.avatars import guild_avatar_url
+from discordbot.utils.avatars import AvatarUser, guild_avatar_url
+
+from tests.helpers.casting import as_message, make_not_found
 
 if TYPE_CHECKING:
     import pytest
+    from nextcord import Guild
+
+
+def _as_avatar_user(fake: object) -> AvatarUser:
+    """Views a fake user as the AvatarUser protocol `guild_avatar_url` expects."""
+    return cast("AvatarUser", fake)
+
+
+def _as_guild(fake: object) -> "Guild | None":
+    """Views a fake guild as the nextcord Guild `guild_avatar_url` expects."""
+    return cast("Guild | None", fake)
 
 
 class FakeUser:
@@ -20,6 +31,7 @@ class FakeUser:
         self.id = user_id
         self.name = "tester"
         self.display_avatar = SimpleNamespace(url=avatar_url)
+        self.bot = False
 
 
 class FakeMember(FakeUser):
@@ -60,8 +72,7 @@ class FakeGuild:
         self.fetch_count += 1
         if self.fetched_member is not None and self.fetched_member.id == user_id:
             return self.fetched_member
-        response = SimpleNamespace(status=404, reason="Not Found")
-        raise nextcord.NotFound(response=response, message="member not found")
+        raise make_not_found(message="member not found")
 
 
 async def test_guild_avatar_url_prefers_cached_guild_avatar() -> None:
@@ -71,7 +82,9 @@ async def test_guild_avatar_url_prefers_cached_guild_avatar() -> None:
         fetched_member=None,
     )
 
-    avatar_url = await guild_avatar_url(user=FakeUser(), guild=guild)
+    avatar_url = await guild_avatar_url(
+        user=_as_avatar_user(fake=FakeUser()), guild=_as_guild(fake=guild)
+    )
 
     assert avatar_url == "https://cdn.test/cached.png"
     assert guild.fetch_count == 0
@@ -84,7 +97,9 @@ async def test_guild_avatar_url_fetches_member_when_cache_misses() -> None:
         fetched_member=FakeMember(guild_avatar_url="https://cdn.test/fetched.png"),
     )
 
-    avatar_url = await guild_avatar_url(user=FakeUser(), guild=guild)
+    avatar_url = await guild_avatar_url(
+        user=_as_avatar_user(fake=FakeUser()), guild=_as_guild(fake=guild)
+    )
 
     assert avatar_url == "https://cdn.test/fetched.png"
     assert guild.fetch_count == 1
@@ -95,7 +110,8 @@ async def test_guild_avatar_url_falls_back_to_global_avatar() -> None:
     guild = FakeGuild(cached_member=None, fetched_member=None)
 
     avatar_url = await guild_avatar_url(
-        user=FakeUser(avatar_url="https://cdn.test/global.png"), guild=guild
+        user=_as_avatar_user(fake=FakeUser(avatar_url="https://cdn.test/global.png")),
+        guild=_as_guild(fake=guild),
     )
 
     assert avatar_url == "https://cdn.test/global.png"
@@ -137,6 +153,6 @@ async def test_message_reward_stores_guild_avatar(monkeypatch: "pytest.MonkeyPat
         user=object(), process_commands=noop_process_commands, _message_reward_at={}
     )
 
-    await cli.DiscordBot.on_message(bot, message=message)
+    await cli.DiscordBot.on_message(cast("cli.DiscordBot", bot), message=as_message(fake=message))
 
     assert captured_avatar_url == "https://cdn.test/server.png"

--- a/tests/test_blackjack_ev.py
+++ b/tests/test_blackjack_ev.py
@@ -1,6 +1,6 @@
 """Deterministic tests for the hole-card-aware Blackjack EV engine."""
 
-from discordbot.typings.games import Card
+from discordbot.typings.games import Card, DealerOutcome, ActionEvAnalysis
 from discordbot.cogs._games.blackjack_ev import (
     _add_value,
     compute_action_evs,
@@ -22,7 +22,7 @@ def _full_shoe() -> list[Card]:
     return [_card(rank=rank) for rank in ranks] * 16
 
 
-def _distribution_total(outcome: object) -> float:
+def _distribution_total(outcome: DealerOutcome) -> float:
     """Sums the six dealer-outcome probabilities."""
     return (
         outcome.bust_probability
@@ -34,7 +34,7 @@ def _distribution_total(outcome: object) -> float:
     )
 
 
-def _ev_for(analysis: object, action: str) -> float:
+def _ev_for(analysis: ActionEvAnalysis, action: str) -> float:
     """Returns the computed EV for a single action."""
     return next(item.expected_value for item in analysis.action_evs if item.action == action)
 

--- a/tests/test_blackjack_history.py
+++ b/tests/test_blackjack_history.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 
 from discordbot.typings.games import (
     Card,
+    SettleOutcome,
     GameParticipant,
     BlackjackHistoryHand,
     BlackjackPlayerResult,
@@ -62,7 +63,7 @@ def _participant(*, user_id: int, name: str, bet: int) -> GameParticipant:
 def _result(  # noqa: PLR0913 -- settlement result needs every per-round field
     *,
     participant: GameParticipant,
-    outcome: str,
+    outcome: SettleOutcome,
     delta: int,
     hands: list[BlackjackHandSettlement],
     insurance: BlackjackInsuranceSettlement | None = None,
@@ -85,7 +86,7 @@ def _result(  # noqa: PLR0913 -- settlement result needs every per-round field
     return BlackjackPlayerResult(participant=participant, settlement=settlement)
 
 
-def _record_view(*, delta: int, outcome: str) -> BlackjackHistoryRecord:
+def _record_view(*, delta: int, outcome: SettleOutcome) -> BlackjackHistoryRecord:
     """Builds a read-model record without touching the database."""
     return BlackjackHistoryRecord(
         round_id="r",

--- a/tests/test_blackjack_view_buttons.py
+++ b/tests/test_blackjack_view_buttons.py
@@ -10,10 +10,12 @@ path; bot-turn tests cover the deterministic bot player decisions.
 
 from types import SimpleNamespace
 from random import Random
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from nextcord import Embed, Interaction
+from nextcord.ui import Button
 
 from discordbot.cogs._games import blackjack_views
 from discordbot.typings.games import (
@@ -26,6 +28,8 @@ from discordbot.cogs._games.shoe import BlackjackShoeStore
 from discordbot.utils.discord_embeds import DEFAULT_EMBED_SPACER_FILENAME, embed_spacer_url
 from discordbot.cogs._games.blackjack import Card, BlackjackRound, BlackjackHandState
 from discordbot.cogs._games.blackjack_views import BlackjackView, build_in_progress_embeds
+
+from tests.helpers.casting import as_message
 
 
 def _participant(user_id: int, display_name: str, bet: int = 100) -> GameParticipant:
@@ -70,7 +74,7 @@ def _button_states(view: BlackjackView) -> dict[str, bool]:
     states: dict[str, bool] = {}
     for child in view.children:
         cid = getattr(child, "custom_id", None)
-        if cid is not None:
+        if cid is not None and isinstance(child, Button):
             states[cid] = bool(child.disabled)
     return states
 
@@ -350,7 +354,9 @@ async def test_interaction_check_sends_ephemeral_notice_when_settled(
 
     notices: list[str] = []
 
-    async def _fake_notice(*, interaction: Interaction, content: str, log_message: str) -> None:
+    async def _fake_notice(
+        *, interaction: Interaction[Any], content: str, log_message: str
+    ) -> None:
         notices.append(content)
 
     monkeypatch.setattr(
@@ -637,7 +643,7 @@ async def test_history_persistence_uses_scheduled_dealer_snapshot(
     monkeypatch.setattr(blackjack_views, "record_blackjack_history", fake_record_blackjack_history)
     round_state.dealer.append(Card(rank="K", suit="♣"))
     await view._record_history_later(
-        message=SimpleNamespace(id=999, guild=SimpleNamespace(id=888)),
+        message=as_message(fake=SimpleNamespace(id=999, guild=SimpleNamespace(id=888))),
         results=[
             BlackjackPlayerResult(
                 participant=round_state.players[0].participant,

--- a/tests/test_cogs_smoke.py
+++ b/tests/test_cogs_smoke.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Self, Unpack, TypedDict, cast, get_args
 from datetime import UTC, datetime, timedelta
 
 import nextcord
-from nextcord import Guild, Embed, Member
+from nextcord import Embed, Guild, Member
 from nextcord.ext import commands
 from logfire._internal.constants import LEVEL_NUMBERS
 
@@ -28,7 +28,7 @@ from discordbot.cogs._economy import views, interactions
 from discordbot.cogs.template import TemplateCogs
 from discordbot.typings.games import GameParticipant
 from discordbot.typings.stock import StockPortfolioView, StockPortfolioHolding
-from discordbot.utils.threads import ThreadsOutput
+from discordbot.utils.threads import ThreadsOutput, ThreadsDownloader
 from discordbot.typings.config import LoggingConfig
 from discordbot.typings.economy import (
     PortfolioView,
@@ -53,11 +53,7 @@ from discordbot.cogs._games.wagers import parse_wager_amount
 from discordbot.cogs.parse_threads import ThreadsCogs
 from discordbot.cogs._economy.views import CreditLoanDecisionView, CentralBankLoanDecisionView
 from discordbot.utils.discord_embeds import DEFAULT_EMBED_SPACER_FILENAME, embed_spacer_url
-from discordbot.utils.media_delivery import (
-    MediaHostingConfig,
-    MediaHostingService,
-    MediaDeliveryPlanner,
-)
+from discordbot.utils.media_delivery import MediaHostingService, MediaDeliveryPlanner
 from discordbot.cogs._games.blackjack import Card
 from discordbot.cogs._economy.database import (
     VIP_PURCHASE_COST,
@@ -71,6 +67,7 @@ from discordbot.cogs._games.blackjack_views import BlackjackLobbyView
 from discordbot.cogs._games.dragon_gate_views import DragonGateLobbyView
 
 from tests.helpers.embeds import assert_embed_has_field, assert_embed_title_prefix
+from tests.helpers.casting import as_bot, as_message, as_interaction, make_media_hosting_config
 from tests.helpers.discord_mocks import (
     FakeUser,
     DiscordPayload,
@@ -225,17 +222,17 @@ def _thread_output(
 
 async def test_template_on_message_and_ping() -> None:
     """Verifies template debug reaction and ping command response."""
-    cog = TemplateCogs(bot=SimpleNamespace(latency=0.123))
+    cog = TemplateCogs(bot=as_bot(fake=SimpleNamespace(latency=0.123)))
     message = FakeDiscordMessage()
-    message.author = FakeUser(bot=False)
-    message.content = "debug"
-    await cog.on_message(message=message)
+    message.__dict__["author"] = FakeUser(bot=False)
+    message.__dict__["content"] = "debug"
+    await cog.on_message(message=as_message(fake=message))
     assert message.reactions == ["🤬"]
 
     bot_message = FakeDiscordMessage()
-    bot_message.author = FakeUser(bot=True)
-    bot_message.content = "debug"
-    await cog.on_message(message=bot_message)
+    bot_message.__dict__["author"] = FakeUser(bot=True)
+    bot_message.__dict__["content"] = "debug"
+    await cog.on_message(message=as_message(fake=bot_message))
     assert bot_message.reactions == []
 
     interaction = FakeInteraction(user=FakeUser(display_name="Alice"))
@@ -249,15 +246,13 @@ async def test_video_deliver_and_download_branches(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Verifies video delivery, oversize URL fallback, hosting-off, and download error branches."""
-    cog = VideoCogs(bot=SimpleNamespace())
+    cog = VideoCogs(bot=as_bot(fake=SimpleNamespace()))
     serve_dir = tmp_path / "serve"
     serve_dir.mkdir()  # the serve dir is a pre-existing host mount; the bot never creates it
     cog.media_delivery = MediaDeliveryPlanner(
         media_hosting=MediaHostingService(
-            config=MediaHostingConfig(
-                MEDIA_HOSTING_ENABLED=True,
-                MEDIA_HOSTING_BASE_URL="https://media.test",
-                MEDIA_HOSTING_SERVE_DIR=str(serve_dir),
+            config=make_media_hosting_config(
+                enabled=True, base_url="https://media.test", serve_dir=str(serve_dir)
             )
         )
     )
@@ -268,7 +263,7 @@ async def test_video_deliver_and_download_branches(
 
     interaction = FakeInteraction()
     await cog._deliver(
-        interaction=interaction,
+        interaction=as_interaction(fake=interaction),
         file_size_mb=1.25,
         file_path=small,
         url="https://source.test/video",
@@ -297,9 +292,7 @@ async def test_video_deliver_and_download_branches(
     # Too big + hosting unavailable: fall back to the "file too large" message.
     cog.media_delivery = MediaDeliveryPlanner(
         media_hosting=MediaHostingService(
-            config=MediaHostingConfig(
-                MEDIA_HOSTING_ENABLED=True, MEDIA_HOSTING_BASE_URL="", MEDIA_HOSTING_SERVE_DIR=""
-            )
+            config=make_media_hosting_config(enabled=True, base_url="", serve_dir="")
         )
     )
     big2 = tmp_path / "big2.mp4"
@@ -334,7 +327,7 @@ class _RaiseDownloader:
 async def test_threads_cog_builds_embeds_and_handles_messages(tmp_path: Path) -> None:
     """Verifies Threads embed building and on_message success/warning/error paths."""
     bot = SimpleNamespace(user=SimpleNamespace(id=999))
-    cog = ThreadsCogs(bot=bot)
+    cog = ThreadsCogs(bot=as_bot(fake=bot))
     video_file = tmp_path / "clip.mp4"
     video_file.write_bytes(data=b"123")
 
@@ -344,63 +337,70 @@ async def test_threads_cog_builds_embeds_and_handles_messages(tmp_path: Path) ->
     )
     embeds = cog._build_embeds(results=[parent, target])
     assert len(embeds) == 3
-    assert "點此觀看影片" in embeds[0].description
+    first_description = embeds[0].description
+    assert first_description is not None
+    assert "點此觀看影片" in first_description
     assert ThreadsCogs._gradient_color(index=0, total=1) == nextcord.Color.default()
 
     no_match = FakeDiscordMessage()
-    no_match.author = FakeUser(bot=False)
-    no_match.content = "hello"
-    await cog.on_message(message=no_match)
+    no_match.__dict__["author"] = FakeUser(bot=False)
+    no_match.__dict__["content"] = "hello"
+    await cog.on_message(message=as_message(fake=no_match))
     assert no_match.reactions == []
 
     success_message = FakeDiscordMessage()
-    success_message.author = FakeUser(bot=False)
-    success_message.content = "https://www.threads.net/@alice/post/abc"
-    success_message.guild = SimpleNamespace(filesize_limit=25 * 1024 * 1024)
-    cog.downloader = ThreadsDownloaderStub(
-        results=[_thread_output(video_paths=[video_file], image_urls=[])]
+    success_message.__dict__["author"] = FakeUser(bot=False)
+    success_message.__dict__["content"] = "https://www.threads.net/@alice/post/abc"
+    success_message.__dict__["guild"] = SimpleNamespace(filesize_limit=25 * 1024 * 1024)
+    cog.downloader = cast(
+        "ThreadsDownloader",
+        ThreadsDownloaderStub(results=[_thread_output(video_paths=[video_file], image_urls=[])]),
     )
-    await cog.on_message(message=success_message)
+    await cog.on_message(message=as_message(fake=success_message))
     assert success_message.suppressed
     assert success_message.replies[0]["files"]
     assert success_message.reactions[-1] == "<:greencheck:1517565102424068226>"
 
     warning_message = FakeDiscordMessage()
-    warning_message.author = FakeUser(bot=False)
-    warning_message.content = "https://www.threads.net/@alice/post/abc"
-    warning_message.guild = SimpleNamespace(filesize_limit=25 * 1024 * 1024)
-    cog.downloader = ThreadsDownloaderStub(results=[])
-    await cog.on_message(message=warning_message)
+    warning_message.__dict__["author"] = FakeUser(bot=False)
+    warning_message.__dict__["content"] = "https://www.threads.net/@alice/post/abc"
+    warning_message.__dict__["guild"] = SimpleNamespace(filesize_limit=25 * 1024 * 1024)
+    cog.downloader = cast("ThreadsDownloader", ThreadsDownloaderStub(results=[]))
+    await cog.on_message(message=as_message(fake=warning_message))
     assert warning_message.reactions[-1] == "⚠️"
 
     error_message = FakeDiscordMessage()
-    error_message.author = FakeUser(bot=False)
-    error_message.content = "https://www.threads.net/@alice/post/abc"
-    error_message.guild = SimpleNamespace(filesize_limit=25 * 1024 * 1024)
-    cog.downloader = ThreadsDownloaderStub(results=RuntimeError("parse failed"))
-    await cog.on_message(message=error_message)
+    error_message.__dict__["author"] = FakeUser(bot=False)
+    error_message.__dict__["content"] = "https://www.threads.net/@alice/post/abc"
+    error_message.__dict__["guild"] = SimpleNamespace(filesize_limit=25 * 1024 * 1024)
+    cog.downloader = cast(
+        "ThreadsDownloader", ThreadsDownloaderStub(results=RuntimeError("parse failed"))
+    )
+    await cog.on_message(message=as_message(fake=error_message))
     assert error_message.reactions[-1] == "<:redcross:1517565100838355016>"
 
 
 async def test_threads_cog_skips_a_message_addressed_to_the_bot() -> None:
     """A mention (or a DM) hands the link to gen_reply, so the cog must not also expand it."""
     bot = SimpleNamespace(user=SimpleNamespace(id=999))
-    cog = ThreadsCogs(bot=bot)
-    cog.downloader = ThreadsDownloaderStub(results=RuntimeError("must not be called"))
+    cog = ThreadsCogs(bot=as_bot(fake=bot))
+    cog.downloader = cast(
+        "ThreadsDownloader", ThreadsDownloaderStub(results=RuntimeError("must not be called"))
+    )
 
     mentioned = FakeDiscordMessage()
-    mentioned.author = FakeUser(bot=False)
-    mentioned.content = "<@999> https://www.threads.net/@alice/post/abc"
-    mentioned.guild = SimpleNamespace(filesize_limit=25 * 1024 * 1024)
-    await cog.on_message(message=mentioned)
+    mentioned.__dict__["author"] = FakeUser(bot=False)
+    mentioned.__dict__["content"] = "<@999> https://www.threads.net/@alice/post/abc"
+    mentioned.__dict__["guild"] = SimpleNamespace(filesize_limit=25 * 1024 * 1024)
+    await cog.on_message(message=as_message(fake=mentioned))
     assert mentioned.reactions == []
     assert mentioned.replies == []
 
     direct_message = FakeDiscordMessage()
-    direct_message.author = FakeUser(bot=False)
-    direct_message.content = "https://www.threads.net/@alice/post/abc"
-    direct_message.guild = None  # a DM always reaches gen_reply, mention or not
-    await cog.on_message(message=direct_message)
+    direct_message.__dict__["author"] = FakeUser(bot=False)
+    direct_message.__dict__["content"] = "https://www.threads.net/@alice/post/abc"
+    direct_message.__dict__["guild"] = None  # a DM always reaches gen_reply, mention or not
+    await cog.on_message(message=as_message(fake=direct_message))
     assert direct_message.reactions == []
     assert direct_message.replies == []
 
@@ -408,14 +408,12 @@ async def test_threads_cog_skips_a_message_addressed_to_the_bot() -> None:
 async def test_threads_cog_hosts_oversized_video(tmp_path: Path) -> None:
     """A Threads video too big to attach is hosted as a URL instead of a ⚠️ refusal."""
     bot = SimpleNamespace(user=SimpleNamespace(id=999))
-    cog = ThreadsCogs(bot=bot)
+    cog = ThreadsCogs(bot=as_bot(fake=bot))
     (tmp_path / "serve").mkdir()  # pre-existing host mount; the bot never creates the serve dir
     cog.media_delivery = MediaDeliveryPlanner(
         media_hosting=MediaHostingService(
-            config=MediaHostingConfig(
-                MEDIA_HOSTING_ENABLED=True,
-                MEDIA_HOSTING_BASE_URL="https://media.test",
-                MEDIA_HOSTING_SERVE_DIR=str(tmp_path / "serve"),
+            config=make_media_hosting_config(
+                enabled=True, base_url="https://media.test", serve_dir=str(tmp_path / "serve")
             )
         )
     )
@@ -423,15 +421,16 @@ async def test_threads_cog_hosts_oversized_video(tmp_path: Path) -> None:
     video_file.write_bytes(data=b"123")
 
     message = FakeDiscordMessage()
-    message.author = FakeUser(bot=False)
-    message.content = "https://www.threads.net/@alice/post/abc"
+    message.__dict__["author"] = FakeUser(bot=False)
+    message.__dict__["content"] = "https://www.threads.net/@alice/post/abc"
     # A tiny ceiling drives max_size negative, so the 3-byte video counts as oversized.
-    message.guild = SimpleNamespace(filesize_limit=4)
-    cog.downloader = ThreadsDownloaderStub(
-        results=[_thread_output(video_paths=[video_file], image_urls=[])]
+    message.__dict__["guild"] = SimpleNamespace(filesize_limit=4)
+    cog.downloader = cast(
+        "ThreadsDownloader",
+        ThreadsDownloaderStub(results=[_thread_output(video_paths=[video_file], image_urls=[])]),
     )
 
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     # The video was hosted (its URL rides the reply content) and moved out of the temp dir.
     content = message.replies[0].get("content") or ""
@@ -443,14 +442,12 @@ async def test_threads_cog_hosts_oversized_video(tmp_path: Path) -> None:
 async def test_threads_cog_mixes_native_and_hosted_videos(tmp_path: Path) -> None:
     """A post with one small and one oversize video attaches the small and links only the big one."""
     bot = SimpleNamespace(user=SimpleNamespace(id=999))
-    cog = ThreadsCogs(bot=bot)
+    cog = ThreadsCogs(bot=as_bot(fake=bot))
     (tmp_path / "serve").mkdir()  # pre-existing host mount; the bot never creates the serve dir
     cog.media_delivery = MediaDeliveryPlanner(
         media_hosting=MediaHostingService(
-            config=MediaHostingConfig(
-                MEDIA_HOSTING_ENABLED=True,
-                MEDIA_HOSTING_BASE_URL="https://media.test",
-                MEDIA_HOSTING_SERVE_DIR=str(tmp_path / "serve"),
+            config=make_media_hosting_config(
+                enabled=True, base_url="https://media.test", serve_dir=str(tmp_path / "serve")
             )
         )
     )
@@ -460,16 +457,17 @@ async def test_threads_cog_mixes_native_and_hosted_videos(tmp_path: Path) -> Non
     big.write_bytes(data=b"0" * (2 * 1024 * 1024))
 
     message = FakeDiscordMessage()
-    message.author = FakeUser(bot=False)
-    message.content = "https://www.threads.net/@alice/post/abc"
+    message.__dict__["author"] = FakeUser(bot=False)
+    message.__dict__["content"] = "https://www.threads.net/@alice/post/abc"
     # The ceiling clears the small clip plus the 1 MiB envelope margin but not the 2 MiB clip,
     # so only the big one is peeled to a hosted URL while the small one attaches natively.
-    message.guild = SimpleNamespace(filesize_limit=1024 * 1024 + 200)
-    cog.downloader = ThreadsDownloaderStub(
-        results=[_thread_output(video_paths=[small, big], image_urls=[])]
+    message.__dict__["guild"] = SimpleNamespace(filesize_limit=1024 * 1024 + 200)
+    cog.downloader = cast(
+        "ThreadsDownloader",
+        ThreadsDownloaderStub(results=[_thread_output(video_paths=[small, big], image_urls=[])]),
     )
 
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     content = message.replies[0].get("content") or ""
     hosted = [line for line in content.splitlines() if line.startswith("https://media.test/")]
@@ -482,24 +480,25 @@ async def test_threads_cog_mixes_native_and_hosted_videos(tmp_path: Path) -> Non
 async def test_threads_cog_refuses_oversized_video_when_hosting_off(tmp_path: Path) -> None:
     """With hosting off, an oversize Threads video refuses the whole post (pre-#325 ⚠️ behavior)."""
     bot = SimpleNamespace(user=SimpleNamespace(id=999))
-    cog = ThreadsCogs(bot=bot)
+    cog = ThreadsCogs(bot=as_bot(fake=bot))
     # Explicitly disabled planner — never the no-arg default, whose config is `available` on a dev
     # box where .env enables hosting (it would write into the live serve dir).
     cog.media_delivery = MediaDeliveryPlanner(
-        media_hosting=MediaHostingService(config=MediaHostingConfig(MEDIA_HOSTING_ENABLED=False))
+        media_hosting=MediaHostingService(config=make_media_hosting_config(enabled=False))
     )
     video_file = tmp_path / "clip.mp4"
     video_file.write_bytes(data=b"123")
 
     message = FakeDiscordMessage()
-    message.author = FakeUser(bot=False)
-    message.content = "https://www.threads.net/@alice/post/abc"
-    message.guild = SimpleNamespace(filesize_limit=4)  # tiny ceiling -> the video is oversize
-    cog.downloader = ThreadsDownloaderStub(
-        results=[_thread_output(video_paths=[video_file], image_urls=[])]
+    message.__dict__["author"] = FakeUser(bot=False)
+    message.__dict__["content"] = "https://www.threads.net/@alice/post/abc"
+    message.__dict__["guild"] = SimpleNamespace(filesize_limit=4)  # tiny ceiling -> video oversize
+    cog.downloader = cast(
+        "ThreadsDownloader",
+        ThreadsDownloaderStub(results=[_thread_output(video_paths=[video_file], image_urls=[])]),
     )
 
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     # No host available + oversize -> whole-post ⚠️ refusal, no reply, and the file is left in place.
     assert message.reactions[-1] == "⚠️"
@@ -517,18 +516,23 @@ async def test_auto_unmute_tracks_audit_and_generates_reply(
     channel = FakeSendChannel(sent=sent)
     bot_user = FakeUser(user_id=999, name="bot", display_name="Bot")
     bot = SimpleNamespace(user=bot_user)
-    cog = AutoUnmuteCogs(bot=bot)
+    cog = AutoUnmuteCogs(bot=as_bot(fake=bot))
 
-    guild = SimpleNamespace(
-        id=123,
-        name="Guild",
-        get_channel=lambda channel_id: channel,
-        system_channel=None,
-        audit_logs=lambda action, limit: _audit_entries(bot_user),
+    guild = cast(
+        "Guild",
+        SimpleNamespace(
+            id=123,
+            name="Guild",
+            get_channel=lambda channel_id: channel,
+            system_channel=None,
+            audit_logs=lambda action, limit: _audit_entries(bot_user),
+        ),
     )
     await cog.on_message(
-        message=SimpleNamespace(
-            guild=guild, author=FakeUser(bot=False), channel=SimpleNamespace(id=456)
+        message=as_message(
+            fake=SimpleNamespace(
+                guild=guild, author=FakeUser(bot=False), channel=SimpleNamespace(id=456)
+            )
         )
     )
     assert cog._last_active_channel == {123: 456}
@@ -536,6 +540,7 @@ async def test_auto_unmute_tracks_audit_and_generates_reply(
     monkeypatch.setattr(auto_unmute, "Messageable", FakeSendChannel)
     assert cog._resolve_channel(guild=guild) is channel
     moderator, reason = await cog._lookup_audit(guild=guild)
+    assert moderator is not None
     assert moderator.name == "moderator"
     assert reason == "testing"
 
@@ -550,16 +555,20 @@ async def test_auto_unmute_tracks_audit_and_generates_reply(
     )
     assert reply == "not today"
 
-    member = SimpleNamespace(
-        id=999,
-        guild=guild,
-        communication_disabled_until=datetime.now(tz=UTC) + timedelta(minutes=5),
-        edit=lambda **kwargs: _async_none(),
+    self_timeout_until = datetime.now(tz=UTC) + timedelta(minutes=5)
+    member = cast(
+        "Member",
+        SimpleNamespace(
+            id=999,
+            guild=guild,
+            communication_disabled_until=self_timeout_until,
+            edit=lambda **kwargs: _async_none(),
+        ),
     )
-    await cog._handle_self_timeout(member=member, until=member.communication_disabled_until)
+    await cog._handle_self_timeout(member=member, until=self_timeout_until)
     assert sent == ["not today"]
 
-    before = SimpleNamespace(communication_disabled_until=None)
+    before = cast("Member", SimpleNamespace(communication_disabled_until=None))
     after = member
     handled: list[SelfTimeoutCall] = []
 
@@ -638,7 +647,7 @@ async def test_economy_commands_use_database_facade(  # noqa: PLR0915 -- command
     monkeypatch.setattr(economy, "checkin", fake_checkin)
     monkeypatch.setattr(economy, "buy_vip", fake_buy_vip)
     bot = SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer"))
-    cog = EconomyCogs(bot=bot)
+    cog = EconomyCogs(bot=as_bot(fake=bot))
     interaction = FakeInteraction(user=FakeUser(user_id=1))
     await EconomyCogs.balance.callback(cog, interaction, member=None)
     await EconomyCogs.leaderboard.callback(cog, interaction)
@@ -702,10 +711,18 @@ async def test_economy_commands_use_database_facade(  # noqa: PLR0915 -- command
     # localized title/labels: cash 150, debt principal 30, stock net 200, total 315, BCAT position.
     assert_embed_title_prefix(embed=balance_embed, prefix="💰")
     assert "315" in (balance_embed.description or "")
-    assert "150" in assert_embed_has_field(embed=balance_embed, name="現金").value
-    assert "30" in assert_embed_has_field(embed=balance_embed, name="債務").value
-    assert "200" in assert_embed_has_field(embed=balance_embed, name="股票淨值").value
-    assert "BCAT" in assert_embed_has_field(embed=balance_embed, name="股票部位").value
+    cash_value = assert_embed_has_field(embed=balance_embed, name="現金").value
+    assert cash_value is not None
+    assert "150" in cash_value
+    debt_value = assert_embed_has_field(embed=balance_embed, name="債務").value
+    assert debt_value is not None
+    assert "30" in debt_value
+    stock_net_value = assert_embed_has_field(embed=balance_embed, name="股票淨值").value
+    assert stock_net_value is not None
+    assert "200" in stock_net_value
+    stock_position_value = assert_embed_has_field(embed=balance_embed, name="股票部位").value
+    assert stock_position_value is not None
+    assert "BCAT" in stock_position_value
     borrow_embed = interaction.followup.sent[8]["embed"]
     # The footer explains the loan-decision timeout; assert the behavioral 180s, not the copy.
     assert "180" in (borrow_embed.footer.text or "")
@@ -721,13 +738,17 @@ async def test_economy_commands_use_database_facade(  # noqa: PLR0915 -- command
     await EconomyCogs.balance.callback(
         cog, inspected_member, member=FakeUser(user_id=2, name="bob", display_name="Bob")
     )
-    assert "Bob" in inspected_member.followup.sent[0]["embed"].description
+    inspected_description = inspected_member.followup.sent[0]["embed"].description
+    assert inspected_description is not None
+    assert "Bob" in inspected_description
 
     bot_receiver = FakeInteraction(user=FakeUser(user_id=1))
     await EconomyCogs.give.callback(
         cog, bot_receiver, member=FakeUser(user_id=3, name="bot", bot=True), amount="1"
     )
-    assert "轉帳完成" in bot_receiver.followup.sent[0]["embed"].title
+    bot_receiver_title = bot_receiver.followup.sent[0]["embed"].title
+    assert bot_receiver_title is not None
+    assert "轉帳完成" in bot_receiver_title
 
 
 async def test_central_bank_decision_buttons_require_banker_and_allow_self_approval(
@@ -755,7 +776,7 @@ async def test_central_bank_decision_buttons_require_banker_and_allow_self_appro
     monkeypatch.setattr(views, "accept_loan_proposal", fake_accept_for_button)
     monkeypatch.setattr(views, "cancel_loan_proposal", fake_cancel_for_button)
     view = CentralBankLoanDecisionView(
-        bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")),
+        bot=as_bot(fake=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer"))),
         proposal_id=42,
         creator_id=1,
         allow_self_approval=True,
@@ -767,19 +788,19 @@ async def test_central_bank_decision_buttons_require_banker_and_allow_self_appro
     )
 
     denied = FakeInteraction(user=FakeUser(user_id=2, name="bob"))
-    await approve_button.callback(denied)
+    await approve_button.callback(as_interaction(fake=denied))
     assert denied.response.sent[0]["ephemeral"] is True
     assert captured_accept_kwargs == {}
 
     allowed = FakeInteraction(user=FakeUser(user_id=1, name="alice"))
-    await approve_button.callback(allowed)
+    await approve_button.callback(as_interaction(fake=allowed))
     assert captured_accept_kwargs["proposal_id"] == 42
     assert captured_accept_kwargs["actor_id"] == 1
     assert captured_accept_kwargs["allow_central_bank_self_approval"] is True
     assert allowed.response.edited[0]["view"] is None
 
     cancel_view = CentralBankLoanDecisionView(
-        bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")),
+        bot=as_bot(fake=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer"))),
         proposal_id=43,
         creator_id=1,
     )
@@ -789,12 +810,12 @@ async def test_central_bank_decision_buttons_require_banker_and_allow_self_appro
         if getattr(child, "custom_id", "") == "central_bank:cancel"
     )
     denied_cancel = FakeInteraction(user=FakeUser(user_id=2, name="bob"))
-    await cancel_button.callback(denied_cancel)
+    await cancel_button.callback(as_interaction(fake=denied_cancel))
     assert denied_cancel.response.sent[0]["ephemeral"] is True
     assert captured_cancel_kwargs == {}
 
     allowed_cancel = FakeInteraction(user=FakeUser(user_id=1, name="alice"))
-    await cancel_button.callback(allowed_cancel)
+    await cancel_button.callback(as_interaction(fake=allowed_cancel))
     assert captured_cancel_kwargs == {"proposal_id": 43, "actor_id": 1}
     assert allowed_cancel.response.edited[0]["view"] is None
 
@@ -831,12 +852,12 @@ async def test_credit_decision_buttons_gate_lender_and_creator(
     )
 
     denied_approve = FakeInteraction(user=FakeUser(user_id=3, name="charlie"))
-    await approve_button.callback(denied_approve)
+    await approve_button.callback(as_interaction(fake=denied_approve))
     assert denied_approve.response.sent[0]["ephemeral"] is True
     assert captured_accept_kwargs == {}
 
     allowed_approve = FakeInteraction(user=FakeUser(user_id=2, name="bob"))
-    await approve_button.callback(allowed_approve)
+    await approve_button.callback(as_interaction(fake=allowed_approve))
     assert captured_accept_kwargs["proposal_id"] == 42
     assert captured_accept_kwargs["actor_id"] == 2
     assert allowed_approve.response.edited[0]["view"] is None
@@ -848,12 +869,12 @@ async def test_credit_decision_buttons_gate_lender_and_creator(
         if getattr(child, "custom_id", "") == "credit:reject"
     )
     denied_reject = FakeInteraction(user=FakeUser(user_id=3, name="charlie"))
-    await reject_button.callback(denied_reject)
+    await reject_button.callback(as_interaction(fake=denied_reject))
     assert denied_reject.response.sent[0]["ephemeral"] is True
     assert captured_reject_kwargs == {}
 
     allowed_reject = FakeInteraction(user=FakeUser(user_id=2, name="bob"))
-    await reject_button.callback(allowed_reject)
+    await reject_button.callback(as_interaction(fake=allowed_reject))
     assert captured_reject_kwargs == {"proposal_id": 43, "actor_id": 2}
     assert allowed_reject.response.edited[0]["view"] is None
 
@@ -864,12 +885,12 @@ async def test_credit_decision_buttons_gate_lender_and_creator(
         if getattr(child, "custom_id", "") == "credit:cancel"
     )
     denied_cancel = FakeInteraction(user=FakeUser(user_id=2, name="bob"))
-    await cancel_button.callback(denied_cancel)
+    await cancel_button.callback(as_interaction(fake=denied_cancel))
     assert denied_cancel.response.sent[0]["ephemeral"] is True
     assert captured_cancel_kwargs == {}
 
     allowed_cancel = FakeInteraction(user=FakeUser(user_id=1, name="alice"))
-    await cancel_button.callback(allowed_cancel)
+    await cancel_button.callback(as_interaction(fake=allowed_cancel))
     assert captured_cancel_kwargs == {"proposal_id": 44, "actor_id": 1}
     assert allowed_cancel.response.edited[0]["view"] is None
 
@@ -900,24 +921,28 @@ async def test_loan_decision_timeout_rejects_and_schedules_cleanup(
 
     credit_message = FakeDiscordMessage()
     credit_view = CreditLoanDecisionView(proposal_id=42, lender_id=2, creator_id=1)
-    credit_view.message = credit_message
+    credit_view.message = as_message(fake=credit_message)
     await credit_view.on_timeout()
 
     central_message = FakeDiscordMessage()
     central_view = CentralBankLoanDecisionView(
-        bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")),
+        bot=as_bot(fake=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer"))),
         proposal_id=43,
         creator_id=1,
     )
-    central_view.message = central_message
+    central_view.message = as_message(fake=central_message)
     await central_view.on_timeout()
 
     assert rejected == [42, 43]
     assert scheduled == [credit_message, central_message]
     assert credit_message.edits[0]["view"] is None
     assert central_message.edits[0]["view"] is None
-    assert "逾時" in credit_message.edits[0]["embed"].title
-    assert "逾時" in central_message.edits[0]["embed"].title
+    credit_timeout_title = credit_message.edits[0]["embed"].title
+    assert credit_timeout_title is not None
+    assert "逾時" in credit_timeout_title
+    central_timeout_title = central_message.edits[0]["embed"].title
+    assert central_timeout_title is not None
+    assert "逾時" in central_timeout_title
 
 
 async def test_economy_admin_rejects_non_admin(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -936,7 +961,9 @@ async def test_economy_admin_rejects_non_admin(monkeypatch: pytest.MonkeyPatch) 
 
     monkeypatch.setattr(economy, "get_admin", fake_get_admin_false)
     monkeypatch.setattr(economy, "adjust_balance", fake_adjust_balance_guard)
-    cog = EconomyCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    cog = EconomyCogs(
+        bot=as_bot(fake=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    )
     interaction = FakeInteraction(user=FakeUser(user_id=1))
 
     await EconomyCogs.admin_refund_tax.callback(
@@ -945,7 +972,9 @@ async def test_economy_admin_rejects_non_admin(monkeypatch: pytest.MonkeyPatch) 
 
     assert called is False
     assert interaction.followup.sent[0].get("ephemeral") is True
-    assert "權限不足" in interaction.followup.sent[0]["embed"].title
+    admin_rejection_title = interaction.followup.sent[0]["embed"].title
+    assert admin_rejection_title is not None
+    assert "權限不足" in admin_rejection_title
 
 
 def test_parse_admin_amount_accepts_formatted_text() -> None:
@@ -976,7 +1005,9 @@ async def test_economy_admin_tax_accepts_string_amounts(monkeypatch: pytest.Monk
     monkeypatch.setattr(
         interactions, "schedule_public_message_delete", ignore_scheduled_public_message
     )
-    cog = EconomyCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    cog = EconomyCogs(
+        bot=as_bot(fake=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    )
     interaction = FakeInteraction(user=FakeUser(user_id=1))
 
     await EconomyCogs.admin_refund_tax.callback(
@@ -1006,7 +1037,9 @@ async def test_economy_admin_tax_allows_bot_target(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(
         interactions, "schedule_public_message_delete", ignore_scheduled_public_message
     )
-    cog = EconomyCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    cog = EconomyCogs(
+        bot=as_bot(fake=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    )
     interaction = FakeInteraction(user=FakeUser(user_id=1))
     bot_member = FakeUser(user_id=999, name="discordbot", display_name="Dealer", bot=True)
 
@@ -1033,7 +1066,9 @@ async def test_economy_admin_tax_rejects_invalid_amount_text(
         return BalanceAdjustmentResult(new_balance=0, applied_delta=0)
 
     monkeypatch.setattr(economy, "adjust_balance", fake_adjust_balance_guard)
-    cog = EconomyCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    cog = EconomyCogs(
+        bot=as_bot(fake=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    )
     interaction = FakeInteraction(user=FakeUser(user_id=1))
 
     await EconomyCogs.admin_collect_tax.callback(
@@ -1043,7 +1078,9 @@ async def test_economy_admin_tax_rejects_invalid_amount_text(
     assert called is False
     assert interaction.response.sent[0]["ephemeral"] is True
     assert interaction.response.sent[0]["embed"].title == "收稅失敗"
-    assert "金額格式錯誤" in interaction.response.sent[0]["embed"].description
+    collect_tax_description = interaction.response.sent[0]["embed"].description
+    assert collect_tax_description is not None
+    assert "金額格式錯誤" in collect_tax_description
     assert interaction.followup.sent == []
 
 
@@ -1073,9 +1110,13 @@ async def test_give_passes_guild_avatar_urls_to_database(monkeypatch: pytest.Mon
     sender = FakeUser(user_id=1, name="alice")
     receiver = FakeUser(user_id=2, name="bob")
     cached_sender = FakeUser(user_id=1, name="alice")
-    cached_sender.guild_avatar = SimpleNamespace(url="https://example.test/alice-server.png")
+    cached_sender.__dict__["guild_avatar"] = SimpleNamespace(
+        url="https://example.test/alice-server.png"
+    )
     cached_receiver = FakeUser(user_id=2, name="bob")
-    cached_receiver.guild_avatar = SimpleNamespace(url="https://example.test/bob-server.png")
+    cached_receiver.__dict__["guild_avatar"] = SimpleNamespace(
+        url="https://example.test/bob-server.png"
+    )
     members = {cached_sender.id: cached_sender, cached_receiver.id: cached_receiver}
 
     async def fail_fetch_member(user_id: int) -> FakeUser:
@@ -1089,7 +1130,9 @@ async def test_give_passes_guild_avatar_urls_to_database(monkeypatch: pytest.Mon
     monkeypatch.setattr(
         interactions, "schedule_public_message_delete", ignore_scheduled_public_message
     )
-    cog = EconomyCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    cog = EconomyCogs(
+        bot=as_bot(fake=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    )
 
     await EconomyCogs.give.callback(cog, interaction, member=receiver, amount="100")
 
@@ -1130,7 +1173,7 @@ async def test_give_allows_bot_receiver(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setattr(
         interactions, "schedule_public_message_delete", ignore_scheduled_public_message
     )
-    cog = EconomyCogs(bot=SimpleNamespace(user=bot_receiver))
+    cog = EconomyCogs(bot=as_bot(fake=SimpleNamespace(user=bot_receiver)))
 
     await EconomyCogs.give.callback(cog, interaction, member=bot_receiver, amount="100")
 
@@ -1141,7 +1184,9 @@ async def test_give_allows_bot_receiver(monkeypatch: pytest.MonkeyPatch) -> None
         "receiver_name": "discordbot",
         "amount": 100,
     }
-    assert "轉帳完成" in interaction.followup.sent[0]["embed"].title
+    give_bot_receiver_title = interaction.followup.sent[0]["embed"].title
+    assert give_bot_receiver_title is not None
+    assert "轉帳完成" in give_bot_receiver_title
 
 
 async def test_economy_money_commands_accept_large_string_amounts(
@@ -1192,7 +1237,9 @@ async def test_economy_money_commands_accept_large_string_amounts(
     monkeypatch.setattr(
         interactions, "schedule_public_message_delete", ignore_scheduled_public_message
     )
-    cog = EconomyCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    cog = EconomyCogs(
+        bot=as_bot(fake=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    )
     interaction = FakeInteraction(user=FakeUser(user_id=1, name="alice"))
     big_text = "9,007,199,254,740,993"
     member = FakeUser(user_id=2, name="bob")
@@ -1261,14 +1308,18 @@ async def test_economy_money_commands_reject_invalid_amount_text(
     monkeypatch.setattr(economy, "call_personal_loans", guard_payment)
     monkeypatch.setattr(economy, "call_central_bank_loans", guard_payment)
     monkeypatch.setattr(economy, "get_central_banker", fake_get_central_banker)
-    cog = EconomyCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    cog = EconomyCogs(
+        bot=as_bot(fake=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    )
     member = FakeUser(user_id=2, name="bob")
 
     def assert_rejected(interaction: FakeInteraction, expected_title: str) -> None:
         """Asserts an ephemeral malformed-amount rejection with no mutation followup."""
         assert interaction.response.sent[0]["ephemeral"] is True
         assert interaction.response.sent[0]["embed"].title == expected_title
-        assert "金額格式錯誤" in interaction.response.sent[0]["embed"].description
+        rejection_description = interaction.response.sent[0]["embed"].description
+        assert rejection_description is not None
+        assert "金額格式錯誤" in rejection_description
         assert interaction.followup.sent == []
 
     rejections: list[tuple[str, Callable[[FakeInteraction], Awaitable[None]]]] = [
@@ -1328,15 +1379,20 @@ async def test_loss_leaderboard_uses_daily_loss_copy(monkeypatch: pytest.MonkeyP
 
     monkeypatch.setattr(economy, "top_losers", daily_losses)
     monkeypatch.setattr(interactions, "schedule_public_message_delete", record_scheduled)
-    cog = EconomyCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    cog = EconomyCogs(
+        bot=as_bot(fake=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    )
     interaction = FakeInteraction(user=FakeUser(user_id=1))
 
     await EconomyCogs.loss_leaderboard.callback(cog, interaction)
 
     embed = interaction.followup.sent[0]["embed"]
+    assert embed.title is not None
     assert "今日輸局累計" in embed.title
+    assert embed.description is not None
     assert "累計輸" in embed.description
     assert interaction.followup.sent[0]["files"][0].filename == "economy_loss_leaderboard.png"
+    assert embed.footer.text is not None
     assert "贏回來不抵扣" in embed.footer.text
     assert len(scheduled) == 1
 
@@ -1359,13 +1415,17 @@ async def test_loss_leaderboard_empty_state_copy(monkeypatch: pytest.MonkeyPatch
 
     monkeypatch.setattr(economy, "top_losers", no_daily_losses)
     monkeypatch.setattr(interactions, "schedule_public_message_delete", record_scheduled)
-    cog = EconomyCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    cog = EconomyCogs(
+        bot=as_bot(fake=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    )
     interaction = FakeInteraction(user=FakeUser(user_id=1))
 
     await EconomyCogs.loss_leaderboard.callback(cog, interaction)
 
     embed = interaction.followup.sent[0]["embed"]
+    assert embed.title is not None
     assert "今日輸局累計" in embed.title
+    assert embed.description is not None
     assert "今天還沒有人輸錢" in embed.description
     assert len(scheduled) == 1
 
@@ -1650,7 +1710,9 @@ async def test_bot_blackjack_participant_spreads_bet_by_true_count(
     """The bot's Kelly wager rises with a favorable channel true count."""
     monkeypatch.setenv(name="OPENAI_BASE_URL", value="https://example.test/v1")
     monkeypatch.setenv(name="OPENAI_API_KEY", value="test-key")
-    cog = GamesCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    cog = GamesCogs(
+        bot=as_bot(fake=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    )
 
     async def fake_get_account(*, user_id: int) -> object:
         return SimpleNamespace(balance=1_000_000, total_earned=0, total_spent=0)
@@ -1696,7 +1758,9 @@ def test_games_commands_are_grouped_under_games() -> None:
 
 async def test_blackjack_history_missing_user_sends_notice() -> None:
     """A missing interaction user gets feedback instead of an empty deferred response."""
-    cog = GamesCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    cog = GamesCogs(
+        bot=as_bot(fake=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    )
     interaction = FakeInteraction()
     cast("Any", interaction).user = None
 
@@ -1728,7 +1792,9 @@ async def test_games_commands_run_with_patched_settlement(
     monkeypatch.setattr(games, "schedule_public_message_delete", ignore_scheduled_public_message)
     monkeypatch.setattr(games, "get_balance", fake_game_balance)
 
-    cog = GamesCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    cog = GamesCogs(
+        bot=as_bot(fake=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    )
 
     blackjack_interaction = FakeInteraction(user=FakeUser(user_id=1))
     await GamesCogs.blackjack.callback(cog, blackjack_interaction, bet="10")
@@ -1763,7 +1829,9 @@ async def test_blackjack_lobby_start_is_owner_only(
     monkeypatch.setenv(name="OPENAI_API_KEY", value="test-key")
     monkeypatch.setattr(games, "get_balance", fake_game_balance)
 
-    cog = GamesCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    cog = GamesCogs(
+        bot=as_bot(fake=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    )
 
     owner_interaction = FakeInteraction(user=FakeUser(user_id=1))
     await GamesCogs.blackjack.callback(cog, owner_interaction, bet="10")
@@ -1774,7 +1842,7 @@ async def test_blackjack_lobby_start_is_owner_only(
         child for child in lobby_view.children if getattr(child, "label", "") == "開始"
     )
     other_interaction = FakeInteraction(user=FakeUser(user_id=2, name="bob", display_name="Bob"))
-    await start_button.callback(other_interaction)
+    await start_button.callback(as_interaction(fake=other_interaction))
 
     assert other_interaction.response.sent
     assert isinstance(other_interaction.response.sent[0]["content"], str)
@@ -1793,7 +1861,9 @@ async def test_blackjack_owner_overbet_sets_table_bet_to_balance(
 
     monkeypatch.setattr(games, "get_balance", balance_by_user)
 
-    cog = GamesCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    cog = GamesCogs(
+        bot=as_bot(fake=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    )
 
     owner_interaction = FakeInteraction(user=FakeUser(user_id=1))
     await GamesCogs.blackjack.callback(cog, owner_interaction, bet="1,000,000")
@@ -1807,8 +1877,8 @@ async def test_blackjack_owner_overbet_sets_table_bet_to_balance(
         child for child in lobby_view.children if getattr(child, "label", "") == "加入"
     )
     join_interaction = FakeInteraction(user=FakeUser(user_id=2, name="bob", display_name="Bob"))
-    join_interaction.message = FakeDiscordMessage()
-    await join_button.callback(join_interaction)
+    join_interaction.message = as_message(fake=FakeDiscordMessage())
+    await join_button.callback(as_interaction(fake=join_interaction))
 
     bob = lobby_view.participants[1]
     assert bob.display_name == "Bob"
@@ -1829,7 +1899,9 @@ async def test_refresh_participants_preserves_existing_blackjack_wagers(
         return {1: 500, 999: 1_000}[user_id]
 
     monkeypatch.setattr(games, "get_balance", balance_by_user)
-    cog = GamesCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    cog = GamesCogs(
+        bot=as_bot(fake=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    )
     owner = GameParticipant(
         user_id=1,
         account_name="alice",
@@ -1868,7 +1940,9 @@ async def test_blackjack_string_bet_accepts_large_formatted_amount(
 
     monkeypatch.setattr(games, "get_balance", balance_by_user)
 
-    cog = GamesCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    cog = GamesCogs(
+        bot=as_bot(fake=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    )
 
     owner_interaction = FakeInteraction(user=FakeUser(user_id=1))
     await GamesCogs.blackjack.callback(cog, owner_interaction, bet="9,007,199,254,740,993")
@@ -1882,7 +1956,9 @@ async def test_blackjack_string_bet_accepts_large_formatted_amount(
 
 async def test_blackjack_string_bet_rejects_invalid_text() -> None:
     """Verifies invalid text is rejected before wager preparation."""
-    cog = GamesCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    cog = GamesCogs(
+        bot=as_bot(fake=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    )
 
     owner_interaction = FakeInteraction(user=FakeUser(user_id=1))
     await GamesCogs.blackjack.callback(cog, owner_interaction, bet="not a number")
@@ -1908,7 +1984,9 @@ async def test_blackjack_owner_zero_bet_caps_all_in_at_max_single_bet(
 
     monkeypatch.setattr(games, "get_balance", balance_by_user)
 
-    cog = GamesCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    cog = GamesCogs(
+        bot=as_bot(fake=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    )
 
     owner_interaction = FakeInteraction(user=FakeUser(user_id=1))
     await GamesCogs.blackjack.callback(cog, owner_interaction, bet="0")
@@ -1927,7 +2005,9 @@ async def test_blackjack_zero_bet_rejects_empty_balance(monkeypatch: pytest.Monk
     monkeypatch.setattr(games, "schedule_public_message_delete", ignore_scheduled_public_message)
     monkeypatch.setattr(games, "get_balance", _empty_game_balance)
 
-    cog = GamesCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    cog = GamesCogs(
+        bot=as_bot(fake=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    )
 
     owner_interaction = FakeInteraction(user=FakeUser(user_id=1))
     await GamesCogs.blackjack.callback(cog, owner_interaction, bet="0")
@@ -1948,7 +2028,9 @@ async def test_dragon_gate_rejects_empty_balance_with_spacer(
     monkeypatch.setattr(games, "schedule_public_message_delete", ignore_scheduled_public_message)
     monkeypatch.setattr(games, "get_balance", _empty_game_balance)
 
-    cog = GamesCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    cog = GamesCogs(
+        bot=as_bot(fake=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    )
 
     owner_interaction = FakeInteraction(user=FakeUser(user_id=1))
     await GamesCogs.dragon_gate.callback(cog, owner_interaction)
@@ -1969,7 +2051,9 @@ async def test_dragon_gate_lobby_start_is_owner_only(monkeypatch: pytest.MonkeyP
         games, "fetch_dragon_gate_jackpot_snapshot", fake_dragon_gate_jackpot_snapshot
     )
 
-    cog = GamesCogs(bot=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    cog = GamesCogs(
+        bot=as_bot(fake=SimpleNamespace(user=FakeUser(user_id=999, display_name="Dealer")))
+    )
 
     owner_interaction = FakeInteraction(user=FakeUser(user_id=1))
     await GamesCogs.dragon_gate.callback(cog, owner_interaction)
@@ -1980,7 +2064,7 @@ async def test_dragon_gate_lobby_start_is_owner_only(monkeypatch: pytest.MonkeyP
         child for child in lobby_view.children if getattr(child, "label", "") == "開始"
     )
     other_interaction = FakeInteraction(user=FakeUser(user_id=2, name="bob", display_name="Bob"))
-    await start_button.callback(other_interaction)
+    await start_button.callback(as_interaction(fake=other_interaction))
 
     assert other_interaction.response.sent
     assert isinstance(other_interaction.response.sent[0]["content"], str)
@@ -1998,12 +2082,22 @@ async def test_games_on_ready_cleans_stale_messages_once(monkeypatch: pytest.Mon
         calls.append(bot)
 
     monkeypatch.setattr(games, "delete_tracked_public_messages", record_cleanup)
-    cog = GamesCogs(bot=bot)
+    cog = GamesCogs(bot=as_bot(fake=bot))
 
     await cog.on_ready()
     await cog.on_ready()
 
     assert calls == [bot]
+
+
+def _as_discord_bot(fake: object) -> cli.DiscordBot:
+    """Views a bot double as cli.DiscordBot for its own unbound method calls."""
+    return cast("cli.DiscordBot", fake)
+
+
+def _as_command_context(fake: object) -> commands.Context[commands.Bot]:
+    """Views a context double as commands.Context for on_command_error."""
+    return cast("commands.Context[commands.Bot]", fake)
 
 
 def test_setup_functions_register_cogs(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2038,7 +2132,7 @@ def test_setup_functions_register_cogs(monkeypatch: pytest.MonkeyPatch) -> None:
     for module in [video, games, economy, template, parse_threads, parse_douyin, auto_unmute]:
         monkeypatch.setenv(name="OPENAI_BASE_URL", value="https://example.test/v1")
         monkeypatch.setenv(name="OPENAI_API_KEY", value="test-key")
-        module.setup(bot=bot)
+        module.setup(bot=as_bot(fake=bot))
     assert [type(item[0]) for item in added] == [
         VideoCogs,
         GamesCogs,
@@ -2059,7 +2153,7 @@ def test_cli_loads_cogs_and_handles_command_errors(tmp_path: Path) -> None:
         loaded.append((modules, stop_at_error))
 
     bot = SimpleNamespace(load_extensions=record_load_extensions)
-    cli.DiscordBot._load_cogs_sync(bot)
+    cli.DiscordBot._load_cogs_sync(_as_discord_bot(fake=bot))
     assert loaded[0][1] is True
     assert "discordbot.cogs.template" in loaded[0][0]
 
@@ -2087,10 +2181,14 @@ async def test_cli_message_and_command_error_branches(monkeypatch: pytest.Monkey
         _message_reward_at={},
     )
     user_message = SimpleNamespace(author=FakeUser(user_id=1, bot=False))
-    await cli.DiscordBot.on_message(bot, message=user_message)
+    await cli.DiscordBot.on_message(
+        _as_discord_bot(fake=bot), message=as_message(fake=user_message)
+    )
     assert processed == [user_message]
     assert rewards[0]["amount"] == cli.BASE_MESSAGE_REWARD_AMOUNT
-    await cli.DiscordBot.on_message(bot, message=SimpleNamespace(author=bot.user))
+    await cli.DiscordBot.on_message(
+        _as_discord_bot(fake=bot), message=as_message(fake=SimpleNamespace(author=bot.user))
+    )
     assert len(processed) == 1
     assert len(rewards) == 1
 
@@ -2106,14 +2204,24 @@ async def test_cli_message_and_command_error_branches(monkeypatch: pytest.Monkey
         author=FakeUser(user_id=1),
         command=SimpleNamespace(qualified_name="demo"),
     )
-    await cli.DiscordBot.on_command_error(bot, context, commands.NotOwner())
     await cli.DiscordBot.on_command_error(
-        bot, context, commands.MissingPermissions(missing_permissions=["kick_members"])
+        _as_discord_bot(fake=bot), _as_command_context(fake=context), commands.NotOwner()
     )
     await cli.DiscordBot.on_command_error(
-        bot, context, commands.BotMissingPermissions(missing_permissions=["send_messages"])
+        _as_discord_bot(fake=bot),
+        _as_command_context(fake=context),
+        commands.MissingPermissions(missing_permissions=["kick_members"]),
     )
-    await cli.DiscordBot.on_command_error(bot, context, commands.CommandNotFound("nope"))
+    await cli.DiscordBot.on_command_error(
+        _as_discord_bot(fake=bot),
+        _as_command_context(fake=context),
+        commands.BotMissingPermissions(missing_permissions=["send_messages"]),
+    )
+    await cli.DiscordBot.on_command_error(
+        _as_discord_bot(fake=bot),
+        _as_command_context(fake=context),
+        commands.CommandNotFound("nope"),
+    )
     assert len(sent) == 4
 
     # An error the handler has no branch for used to vanish at no level at all; it now
@@ -2126,7 +2234,9 @@ async def test_cli_message_and_command_error_branches(monkeypatch: pytest.Monkey
 
     monkeypatch.setattr(cli.logfire, "error", record_error)
     await cli.DiscordBot.on_command_error(
-        bot, context, commands.CommandInvokeError(ValueError("boom"))
+        _as_discord_bot(fake=bot),
+        _as_command_context(fake=context),
+        commands.CommandInvokeError(ValueError("boom")),
     )
     assert len(sent) == 4
     assert logged[-1]["error_type"] == "ValueError"
@@ -2160,13 +2270,13 @@ async def test_cli_message_reward_cooldown_suppresses_rapid_repeat(
     )
     message = SimpleNamespace(author=FakeUser(user_id=1, bot=False))
 
-    await cli.DiscordBot.on_message(bot, message=message)
-    await cli.DiscordBot.on_message(bot, message=message)
+    await cli.DiscordBot.on_message(_as_discord_bot(fake=bot), message=as_message(fake=message))
+    await cli.DiscordBot.on_message(_as_discord_bot(fake=bot), message=as_message(fake=message))
     assert len(rewards) == 1
 
     # Backdate the last-reward stamp so the cooldown window has elapsed.
     bot._message_reward_at[1] -= cli.MESSAGE_REWARD_COOLDOWN_SECONDS + 1
-    await cli.DiscordBot.on_message(bot, message=message)
+    await cli.DiscordBot.on_message(_as_discord_bot(fake=bot), message=as_message(fake=message))
     assert len(rewards) == 2
 
 
@@ -2195,7 +2305,8 @@ async def test_cli_message_reward_cooldown_prunes_expired_users(
     )
 
     await cli.DiscordBot.on_message(
-        bot, message=SimpleNamespace(author=FakeUser(user_id=3, bot=False))
+        _as_discord_bot(fake=bot),
+        message=as_message(fake=SimpleNamespace(author=FakeUser(user_id=3, bot=False))),
     )
 
     assert 1 not in bot._message_reward_at
@@ -2228,9 +2339,9 @@ async def test_cli_message_reward_cooldown_rolls_back_on_credit_failure(
     )
     message = SimpleNamespace(author=FakeUser(user_id=1, bot=False))
 
-    await cli.DiscordBot.on_message(bot, message=message)
+    await cli.DiscordBot.on_message(_as_discord_bot(fake=bot), message=as_message(fake=message))
     # The first credit failed, so the slot is rolled back and the next message retries.
     assert 1 not in bot._message_reward_at
-    await cli.DiscordBot.on_message(bot, message=message)
+    await cli.DiscordBot.on_message(_as_discord_bot(fake=bot), message=as_message(fake=message))
     assert attempts == 2
     assert bot._message_reward_at.get(1) is not None

--- a/tests/test_cogs_smoke.py
+++ b/tests/test_cogs_smoke.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Self, Unpack, TypedDict, cast, get_args
 from datetime import UTC, datetime, timedelta
 
 import nextcord
-from nextcord import Embed
+from nextcord import Guild, Embed, Member
 from nextcord.ext import commands
 from logfire._internal.constants import LEVEL_NUMBERS
 

--- a/tests/test_douyin.py
+++ b/tests/test_douyin.py
@@ -28,12 +28,9 @@ from discordbot.utils.douyin import (
     is_douyin_post_url,
 )
 from discordbot.typings.video import VideoQuality
-from discordbot.utils.media_delivery import (
-    MediaHostingConfig,
-    MediaHostingService,
-    MediaDeliveryPlanner,
-)
+from discordbot.utils.media_delivery import MediaHostingService, MediaDeliveryPlanner
 
+from tests.helpers.casting import as_bot, make_media_hosting_config
 from tests.helpers.discord_mocks import FakeInteraction
 
 # These downloaders are only ever asked to parse, never to write, so the folder is inert.
@@ -761,7 +758,8 @@ def test_local_write_failure_leaves_no_partial_file(
             original_write(data)
             raise OSError(28, "No space left on device")
 
-        handle.write = write  # type: ignore[assignment]  # simulating a mid-write disk failure
+        # simulating a mid-write disk failure
+        handle.write = write  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
         return handle
 
     monkeypatch.setattr(Path, "open", failing_open)
@@ -793,7 +791,7 @@ def _install_cog(
     monkeypatch: pytest.MonkeyPatch, outcome: DouyinDownload | BaseException
 ) -> tuple[VideoCogs, _StubDouyinDownloader]:
     """Builds a VideoCogs wired to a stub Douyin downloader."""
-    cog = VideoCogs(bot=object())
+    cog = VideoCogs(bot=as_bot(fake=object()))
     stub = _StubDouyinDownloader(outcome=outcome)
     monkeypatch.setattr(video, "DouyinDownloader", lambda output_folder: stub)
     return cog, stub
@@ -875,10 +873,8 @@ async def test_cog_keeps_every_url_when_a_whole_gallery_is_hosted(
     )
     cog.media_delivery = MediaDeliveryPlanner(
         media_hosting=MediaHostingService(
-            config=MediaHostingConfig(
-                MEDIA_HOSTING_ENABLED=True,
-                MEDIA_HOSTING_BASE_URL="https://media.test",
-                MEDIA_HOSTING_SERVE_DIR=serve_dir.as_posix(),
+            config=make_media_hosting_config(
+                enabled=True, base_url="https://media.test", serve_dir=serve_dir.as_posix()
             )
         )
     )
@@ -978,10 +974,8 @@ async def test_cog_posts_the_hosted_url_when_the_clip_is_oversize(
     )
     cog.media_delivery = MediaDeliveryPlanner(
         media_hosting=MediaHostingService(
-            config=MediaHostingConfig(
-                MEDIA_HOSTING_ENABLED=True,
-                MEDIA_HOSTING_BASE_URL="https://media.test",
-                MEDIA_HOSTING_SERVE_DIR=serve_dir.as_posix(),
+            config=make_media_hosting_config(
+                enabled=True, base_url="https://media.test", serve_dir=serve_dir.as_posix()
             )
         )
     )

--- a/tests/test_douyin.py
+++ b/tests/test_douyin.py
@@ -758,8 +758,9 @@ def test_local_write_failure_leaves_no_partial_file(
             original_write(data)
             raise OSError(28, "No space left on device")
 
-        # simulating a mid-write disk failure
-        handle.write = write  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+        # Simulate a mid-write disk failure; the instance-dict write shadows the
+        # bound method without tripping either checker's method-assign rule.
+        handle.__dict__["write"] = write
         return handle
 
     monkeypatch.setattr(Path, "open", failing_open)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -13,6 +13,8 @@ from discordbot.utils.douyin import DOUYIN_URL_RE, DouyinDownloader
 from discordbot.typings.video import VideoQuality
 from discordbot.utils.downloader import VideoDownloader, DownloadStoppedError
 
+from tests.helpers.casting import as_bot
+
 
 def _install_youtube_dl_stub(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -364,5 +366,5 @@ def test_every_quality_preset_is_answered_everywhere() -> None:
     assert set(DouyinDownloader.quality_ratios) == presets
     assert set(QUALITY_CHOICES.values()) == presets
 
-    cog = VideoCogs(bot=object())
+    cog = VideoCogs(bot=as_bot(fake=object()))
     assert cog.download_video.options["quality"].default in presets

--- a/tests/test_dragon_gate.py
+++ b/tests/test_dragon_gate.py
@@ -44,10 +44,14 @@ from discordbot.cogs._games.dragon_gate_views import (
     build_dragon_gate_in_progress_embed,
 )
 
+from tests.helpers.casting import as_message, as_interaction
+
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
 
     from _typeshed import SupportsLenAndGetItem
+
+    from discordbot.cogs._games.lobby import PrepareParticipant
 
 T = TypeVar("T")
 
@@ -315,7 +319,7 @@ def _component_rows(view: DragonGateView) -> dict[str, int | None]:
     return rows
 
 
-def _attached_button(view: DragonGateView, custom_id: str) -> Button:
+def _attached_button(view: DragonGateView, custom_id: str) -> Button[Any]:
     """Returns an attached button by custom ID."""
     for child in view.children:
         if isinstance(child, Button) and child.custom_id == custom_id:
@@ -323,7 +327,7 @@ def _attached_button(view: DragonGateView, custom_id: str) -> Button:
     raise AssertionError(f"Missing attached button: {custom_id}")
 
 
-def _attached_select(view: DragonGateView, custom_id: str) -> StringSelect:
+def _attached_select(view: DragonGateView, custom_id: str) -> StringSelect[Any]:
     """Returns an attached select menu by custom ID."""
     for child in view.children:
         if isinstance(child, StringSelect) and child.custom_id == custom_id:
@@ -547,7 +551,9 @@ async def test_edit_message_with_retry_rebuilds_payload_between_attempts(
         payloads.append(file_marker)
         return {"files": [file_marker]}
 
-    result = await edit_message_with_retry(message=message, kwargs_factory=kwargs_factory)
+    result = await edit_message_with_retry(
+        message=as_message(fake=message), kwargs_factory=kwargs_factory
+    )
 
     assert result is message
     assert sleep_delays == [0.5]
@@ -650,30 +656,30 @@ async def test_dragon_gate_lobby_join_leave_and_owner_start(
         rng=RiggedRandom(choices=("3", "♠", "9", "♥")),
         system_name="Dealer",
         system_avatar_url="",
-        prepare_participant=prepare_participant,
+        prepare_participant=cast("PrepareParticipant", prepare_participant),
         refresh_participants=refresh_participants,
         initial_jackpot=state.jackpot,
     )
-    view.message = message
+    view.message = as_message(fake=message)
 
     join_button = next(child for child in view.children if getattr(child, "label", "") == "加入")
-    await join_button.callback(InteractionStub(user_id=2, message=message))
+    await join_button.callback(as_interaction(fake=InteractionStub(user_id=2, message=message)))
     assert view.participants == [owner, bob]
     join_embed = message.edits[-1]["embed"]
     assert isinstance(join_embed, Embed)
     assert isinstance(join_embed.description, str)
 
     leave_button = next(child for child in view.children if getattr(child, "label", "") == "離開")
-    await leave_button.callback(InteractionStub(user_id=2, message=message))
+    await leave_button.callback(as_interaction(fake=InteractionStub(user_id=2, message=message)))
     assert view.participants == [owner]
 
     start_button = next(child for child in view.children if getattr(child, "label", "") == "開始")
     other_interaction = InteractionStub(user_id=2, message=message)
-    await start_button.callback(other_interaction)
+    await start_button.callback(as_interaction(fake=other_interaction))
     assert other_interaction.response.sent
 
     owner_interaction = InteractionStub(user_id=1, message=message)
-    await start_button.callback(owner_interaction)
+    await start_button.callback(as_interaction(fake=owner_interaction))
     assert isinstance(message.edits[-1]["view"], DragonGateView)
     assert state.calls == [
         {
@@ -732,16 +738,16 @@ async def test_dragon_gate_lobby_ante_rejection_keeps_lobby_open(
         rng=RiggedRandom(choices=("3", "♠", "9", "♥")),
         system_name="Dealer",
         system_avatar_url="",
-        prepare_participant=prepare_participant,
+        prepare_participant=cast("PrepareParticipant", prepare_participant),
         refresh_participants=refresh_participants,
         initial_jackpot=100_000,
     )
-    view.message = message
+    view.message = as_message(fake=message)
 
     join_button = next(child for child in view.children if getattr(child, "label", "") == "加入")
-    await join_button.callback(InteractionStub(user_id=2, message=message))
+    await join_button.callback(as_interaction(fake=InteractionStub(user_id=2, message=message)))
     start_button = next(child for child in view.children if getattr(child, "label", "") == "開始")
-    await start_button.callback(InteractionStub(user_id=1, message=message))
+    await start_button.callback(as_interaction(fake=InteractionStub(user_id=1, message=message)))
 
     assert view.participants == [owner]
     assert view._started is False
@@ -771,14 +777,14 @@ async def test_dragon_gate_view_pair_choice_bet_settles_immediately(
         jackpot_snapshot=state.jackpot,
         final_balances={1: 1_000_000},
     )
-    view.message = message
+    view.message = as_message(fake=message)
     view.sync_controls()
     assert _component_ids(view=view) == {"dg:higher", "dg:lower", "dg:leave"}
     assert _attached_button(view=view, custom_id="dg:higher").disabled is False
 
     choose_higher = _attached_button(view=view, custom_id="dg:higher")
     await choose_higher.callback(
-        InteractionStub(user_id=1, message=message, custom_id="dg:higher")
+        as_interaction(fake=InteractionStub(user_id=1, message=message, custom_id="dg:higher"))
     )
     assert round_state.active_turn is not None
     assert round_state.active_turn.direction == "higher"
@@ -786,7 +792,10 @@ async def test_dragon_gate_view_pair_choice_bet_settles_immediately(
     assert _attached_select(view=view, custom_id="dg:bet").disabled is False
 
     await view._handle_bet_choice(
-        choice="min", interaction=InteractionStub(user_id=1, message=message, custom_id="dg:bet")
+        choice="min",
+        interaction=as_interaction(
+            fake=InteractionStub(user_id=1, message=message, custom_id="dg:bet")
+        ),
     )
 
     # 7-pair, higher, third = 8 → pair_win at +bet (MIN_BET = 20)
@@ -814,14 +823,17 @@ async def test_dragon_gate_view_max_bet_is_bounded_by_player_balance(
         jackpot_snapshot=state.jackpot,
         final_balances={1: 100},
     )
-    view.message = message
+    view.message = as_message(fake=message)
     view.sync_controls()
 
     # The 100,000 pool is bounded down to the player's 100 balance.
     assert view._active_max_bet() == 100
 
     await view._handle_bet_choice(
-        choice="max", interaction=InteractionStub(user_id=1, message=message, custom_id="dg:bet")
+        choice="max",
+        interaction=as_interaction(
+            fake=InteractionStub(user_id=1, message=message, custom_id="dg:bet")
+        ),
     )
 
     # Gate win pays only the balance-bounded 100, closing the free-option.
@@ -848,7 +860,7 @@ async def test_dragon_gate_view_sub_min_balance_cannot_bet_above_wallet(
         jackpot_snapshot=state.jackpot,
         final_balances={1: 15},
     )
-    view.message = message
+    view.message = as_message(fake=message)
     view.sync_controls()
 
     # Balance 15 is below the 20 minimum, so betting is unavailable instead of
@@ -857,7 +869,7 @@ async def test_dragon_gate_view_sub_min_balance_cannot_bet_above_wallet(
     assert _component_ids(view=view) == {"dg:leave"}
 
     interaction = InteractionStub(user_id=1, message=message, custom_id="dg:bet")
-    await view._handle_bet_choice(choice="min", interaction=interaction)
+    await view._handle_bet_choice(choice="min", interaction=as_interaction(fake=interaction))
     assert state.calls == []
     assert interaction.followup.sent[-1]["content"] == "餘額不足以下注，請先離桌"
 
@@ -882,11 +894,14 @@ async def test_dragon_gate_view_pool_emptied_replenishes_and_finalises_without_c
         jackpot_snapshot=state.jackpot,
         final_balances={1: 500_000},
     )
-    view.message = message
+    view.message = as_message(fake=message)
     view.sync_controls()
 
     await view._handle_bet_choice(
-        choice="max", interaction=InteractionStub(user_id=1, message=message, custom_id="dg:bet")
+        choice="max",
+        interaction=as_interaction(
+            fake=InteractionStub(user_id=1, message=message, custom_id="dg:bet")
+        ),
     )
 
     # gate_win for the full pot → pool replenished, table finalised, no refund follow-up
@@ -946,11 +961,14 @@ async def test_dragon_gate_view_uses_capped_jackpot_settlement_delta(
         jackpot_generation=2,
         final_balances={1: 500_000},
     )
-    view.message = message
+    view.message = as_message(fake=message)
     view.sync_controls()
 
     await view._handle_bet_choice(
-        choice="max", interaction=InteractionStub(user_id=1, message=message, custom_id="dg:bet")
+        choice="max",
+        interaction=as_interaction(
+            fake=InteractionStub(user_id=1, message=message, custom_id="dg:bet")
+        ),
     )
 
     assert round_state.player_delta(user_id=1) == 7_000
@@ -985,11 +1003,14 @@ async def test_dragon_gate_view_single_player_zero_balance_finalizes(
         jackpot_snapshot=state.jackpot,
         final_balances={1: 30},
     )
-    view.message = message
+    view.message = as_message(fake=message)
     view.sync_controls()
 
     await view._handle_bet_choice(
-        choice="min", interaction=InteractionStub(user_id=1, message=message, custom_id="dg:bet")
+        choice="min",
+        interaction=as_interaction(
+            fake=InteractionStub(user_id=1, message=message, custom_id="dg:bet")
+        ),
     )
 
     # MIN_BET 20 pillar hit (-40) clamps to the 30 balance, busting the player.
@@ -1035,11 +1056,14 @@ async def test_dragon_gate_view_zero_balance_withdraws_only_that_player(
         jackpot_snapshot=state.jackpot,
         final_balances={1: 30, 2: 100_000},
     )
-    view.message = message
+    view.message = as_message(fake=message)
     view.sync_controls()
 
     await view._handle_bet_choice(
-        choice="min", interaction=InteractionStub(user_id=1, message=message, custom_id="dg:bet")
+        choice="min",
+        interaction=as_interaction(
+            fake=InteractionStub(user_id=1, message=message, custom_id="dg:bet")
+        ),
     )
 
     # MIN_BET 20 pillar hit (-40) clamps to the 30 balance, busting only Alice.
@@ -1076,16 +1100,21 @@ async def test_dragon_gate_view_leave_refunds_running_winnings(
         jackpot_snapshot=state.jackpot,
         final_balances={1: 1_000_000, 2: 1_000_000},
     )
-    view.message = message
+    view.message = as_message(fake=message)
     view.sync_controls()
 
     await view._handle_bet_choice(
-        choice="min", interaction=InteractionStub(user_id=1, message=message, custom_id="dg:bet")
+        choice="min",
+        interaction=as_interaction(
+            fake=InteractionStub(user_id=1, message=message, custom_id="dg:bet")
+        ),
     )
     assert round_state.player_delta(user_id=1) == 20
 
     leave_button = _attached_button(view=view, custom_id="dg:leave")
-    await leave_button.callback(InteractionStub(user_id=1, message=message, custom_id="dg:leave"))
+    await leave_button.callback(
+        as_interaction(fake=InteractionStub(user_id=1, message=message, custom_id="dg:leave"))
+    )
 
     # Bet settled +20 into Alice. Leave refunds 20 back into the pool.
     assert [call["player_delta"] for call in state.calls] == [20, -20]
@@ -1118,12 +1147,13 @@ async def test_dragon_gate_view_bet_uses_live_wallet_not_stale_cache(
         jackpot_snapshot=state.jackpot,
         final_balances={1: 1_000},
     )
-    view.message = message
+    view.message = as_message(fake=message)
     view.sync_controls()
 
     # 500 is under the stale 1,000 cache but over the live 100 balance, so it is rejected.
     await view.submit_custom_bet(
-        interaction=InteractionStub(user_id=1, message=message), raw_amount="500"
+        interaction=as_interaction(fake=InteractionStub(user_id=1, message=message)),
+        raw_amount="500",
     )
 
     assert state.calls == []
@@ -1152,16 +1182,21 @@ async def test_dragon_gate_view_leave_without_winnings_does_not_refund(
         jackpot_snapshot=state.jackpot,
         final_balances={1: 1_000_000, 2: 1_000_000},
     )
-    view.message = message
+    view.message = as_message(fake=message)
     view.sync_controls()
 
     await view._handle_bet_choice(
-        choice="min", interaction=InteractionStub(user_id=1, message=message, custom_id="dg:bet")
+        choice="min",
+        interaction=as_interaction(
+            fake=InteractionStub(user_id=1, message=message, custom_id="dg:bet")
+        ),
     )
     assert round_state.player_delta(user_id=1) == -20
 
     leave_button = _attached_button(view=view, custom_id="dg:leave")
-    await leave_button.callback(InteractionStub(user_id=1, message=message, custom_id="dg:leave"))
+    await leave_button.callback(
+        as_interaction(fake=InteractionStub(user_id=1, message=message, custom_id="dg:leave"))
+    )
 
     # Single bet settled -20; leave path does not append another settlement.
     assert [call["player_delta"] for call in state.calls] == [-20]
@@ -1188,14 +1223,16 @@ async def test_dragon_gate_view_rejects_non_active_and_invalid_custom_bet(
     )
 
     non_active = InteractionStub(user_id=2, message=MessageStub(), custom_id="dg:bet")
-    assert await view.interaction_check(interaction=non_active) is False
+    assert await view.interaction_check(interaction=as_interaction(fake=non_active)) is False
     assert non_active.response.sent
 
     leave_ok = InteractionStub(user_id=2, message=MessageStub(), custom_id="dg:leave")
-    assert await view.interaction_check(interaction=leave_ok) is True
+    assert await view.interaction_check(interaction=as_interaction(fake=leave_ok)) is True
 
     invalid = InteractionStub(user_id=1, message=MessageStub())
-    await view.submit_custom_bet(interaction=invalid, raw_amount="not a number")
+    await view.submit_custom_bet(
+        interaction=as_interaction(fake=invalid), raw_amount="not a number"
+    )
     assert invalid.response.sent
 
 
@@ -1238,11 +1275,14 @@ async def test_dragon_gate_view_timeout_refunds_remaining_winners(
         jackpot_snapshot=state.jackpot,
         final_balances={1: 1_000_000},
     )
-    view.message = message
+    view.message = as_message(fake=message)
     view.sync_controls()
 
     await view._handle_bet_choice(
-        choice="min", interaction=InteractionStub(user_id=1, message=message, custom_id="dg:bet")
+        choice="min",
+        interaction=as_interaction(
+            fake=InteractionStub(user_id=1, message=message, custom_id="dg:bet")
+        ),
     )
     assert round_state.player_delta(user_id=1) == 20
 

--- a/tests/test_economy.py
+++ b/tests/test_economy.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta
 
 import pytest
 from sqlalchemy import text, select, update
+from nextcord.ui import Button
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from discordbot.typings.games import (
@@ -68,6 +69,7 @@ from discordbot.cogs._economy.database import (
 from discordbot.cogs._games.settlement import settle_wager, settle_blackjack_player
 from discordbot.cogs._games.blackjack_views import BlackjackView, build_final_embeds
 
+from tests.helpers.casting import as_message, as_interaction
 from tests.helpers.economy_invariants import (
     assert_wallet_consistent,
     assert_daily_casino_stats,
@@ -853,7 +855,10 @@ async def test_blackjack_view_finalizes_once_when_called_concurrently(
         author_name="alice",
     )
 
-    await asyncio.gather(view.finalize(message=message), view.finalize(message=message))
+    await asyncio.gather(
+        view.finalize(message=as_message(fake=message)),
+        view.finalize(message=as_message(fake=message)),
+    )
 
     assert await get_balance(user_id=1) == 150
     _ledger = await get_casino_ledger()
@@ -895,7 +900,7 @@ async def test_blackjack_view_timeout_auto_stands_and_settles(
         starter_id=1,
         author_name="alice",
     )
-    view.message = message
+    view.message = as_message(fake=message)
 
     await view.on_timeout()
 
@@ -943,7 +948,7 @@ async def test_blackjack_view_dealer_plays_h17_rule(monkeypatch: pytest.MonkeyPa
     message = _MessageStub()
     view = BlackjackView(round_state=round_state, starter_id=1, author_name="alice")
 
-    await view.finalize(message=message)
+    await view.finalize(message=as_message(fake=message))
 
     assert [str(card) for card in view.round_state.dealer] == ["10♣", "3♦", "5♣"]
     assert view.round_state.dealer_played is True
@@ -1020,7 +1025,7 @@ async def test_blackjack_view_dealer_hits_soft_17(monkeypatch: pytest.MonkeyPatc
     message = _MessageStub()
     view = BlackjackView(round_state=round_state, starter_id=1, author_name="alice")
 
-    await view.finalize(message=message)
+    await view.finalize(message=as_message(fake=message))
 
     # Soft 17 must trigger at least one draw, landing the dealer above 17.
     assert len(view.round_state.dealer) >= 3
@@ -1090,16 +1095,28 @@ async def test_blackjack_view_locks_actions_while_finalizing(
         author_name="alice",
     )
 
-    hit_button = next(child for child in view.children if child.custom_id == "bj:hit")
-    stand_button = next(child for child in view.children if child.custom_id == "bj:stand")
-    stand_task = asyncio.create_task(coro=stand_button.callback(_InteractionStub(message=message)))
+    hit_button = next(
+        child
+        for child in view.children
+        if isinstance(child, Button) and child.custom_id == "bj:hit"
+    )
+    stand_button = next(
+        child
+        for child in view.children
+        if isinstance(child, Button) and child.custom_id == "bj:stand"
+    )
+    stand_task = asyncio.create_task(
+        coro=stand_button.callback(as_interaction(fake=_InteractionStub(message=message)))
+    )
     await settlement_started.wait()
 
     assert message.edit_calls == 1
     in_flight_view = cast("BlackjackView", message.edits[0]["view"])
-    assert all(child.disabled for child in in_flight_view.children)
+    assert all(child.disabled for child in in_flight_view.children if isinstance(child, Button))
 
-    hit_task = asyncio.create_task(coro=hit_button.callback(_InteractionStub(message=message)))
+    hit_task = asyncio.create_task(
+        coro=hit_button.callback(as_interaction(fake=_InteractionStub(message=message)))
+    )
     await asyncio.sleep(delay=0)
 
     assert len(view.round_state.players[0].hands[0].cards) == 2
@@ -1135,9 +1152,13 @@ async def test_blackjack_view_rejects_stale_double_without_mutating_next_player(
     message = _MessageStub()
     view = BlackjackView(round_state=round_state, starter_id=1, author_name="alice")
 
-    double_button = next(child for child in view.children if child.custom_id == "bj:double")
+    double_button = next(
+        child
+        for child in view.children
+        if isinstance(child, Button) and child.custom_id == "bj:double"
+    )
     interaction = _InteractionStub(message=message, user_id=1)
-    await double_button.callback(interaction)
+    await double_button.callback(as_interaction(fake=interaction))
 
     assert bob.bet == 50
     assert [str(card) for card in bob.cards] == ["5♣", "6♦"]
@@ -1176,9 +1197,13 @@ async def test_blackjack_view_rejects_stale_hit_without_drawing_for_next_player(
     message = _MessageStub()
     view = BlackjackView(round_state=round_state, starter_id=1, author_name="alice")
 
-    hit_button = next(child for child in view.children if child.custom_id == "bj:hit")
+    hit_button = next(
+        child
+        for child in view.children
+        if isinstance(child, Button) and child.custom_id == "bj:hit"
+    )
     interaction = _InteractionStub(message=message, user_id=1)
-    await hit_button.callback(interaction)
+    await hit_button.callback(as_interaction(fake=interaction))
 
     assert [str(card) for card in bob.cards] == ["5♣", "6♦"]
     assert interaction.followup.sent[0]["content"] == "這個操作已經失效，請看最新牌桌"
@@ -1222,8 +1247,12 @@ async def test_blackjack_view_hit_draws_for_active_split_hand(
     message = _MessageStub()
     view = BlackjackView(round_state=round_state, starter_id=1, author_name="alice")
 
-    hit_button = next(child for child in view.children if child.custom_id == "bj:hit")
-    await hit_button.callback(_InteractionStub(message=message, user_id=1))
+    hit_button = next(
+        child
+        for child in view.children
+        if isinstance(child, Button) and child.custom_id == "bj:hit"
+    )
+    await hit_button.callback(as_interaction(fake=_InteractionStub(message=message, user_id=1)))
 
     assert [str(card) for card in player.hands[1].cards] == ["9♣", "2♦", "5♣"]
     assert message.edit_calls == 1

--- a/tests/test_files_api.py
+++ b/tests/test_files_api.py
@@ -2,9 +2,11 @@
 
 import io
 from types import SimpleNamespace
+from typing import cast
 import asyncio
 from pathlib import Path
 
+from google import genai
 from google.genai.types import FileState
 
 from discordbot.cogs._gen_reply.files_api import (
@@ -45,9 +47,9 @@ class _Files:
         return self._file(FileState.PROCESSING if self._remaining > 0 else self.final_state)
 
 
-def _client(files: _Files) -> SimpleNamespace:
+def _client(files: _Files) -> genai.Client:
     """Wraps a fake Files resource in the client shape the helper reaches through."""
-    return SimpleNamespace(aio=SimpleNamespace(files=files))
+    return cast("genai.Client", SimpleNamespace(aio=SimpleNamespace(files=files)))
 
 
 async def test_upload_returns_the_active_uri() -> None:

--- a/tests/test_fishing_views.py
+++ b/tests/test_fishing_views.py
@@ -47,6 +47,8 @@ from discordbot.cogs._fishing.presentation import (
     build_leaderboard_embed,
 )
 
+from tests.helpers.casting import as_interaction
+
 _GRADE_MAP = {grade.grade: grade for grade in build_default_catalog().grades}
 
 
@@ -128,7 +130,7 @@ class InteractionStub:
 
 
 def _panel(
-    rod: GearView | None = None, durability: int = 0, baits: tuple = ()
+    rod: GearView | None = None, durability: int = 0, baits: tuple[BaitStackView, ...] = ()
 ) -> FishingPanelData:
     """Builds a panel payload for embed tests."""
     return FishingPanelData(
@@ -234,9 +236,12 @@ def test_casting_stats_error_embeds_within_limits() -> None:
 async def test_interaction_check_allows_owner_blocks_others() -> None:
     """Only the panel owner passes the interaction check."""
     view = FishingPanelView(owner_id=1)
-    assert await view.interaction_check(interaction=InteractionStub(user_id=1)) is True
+    assert (
+        await view.interaction_check(interaction=as_interaction(fake=InteractionStub(user_id=1)))
+        is True
+    )
     intruder = InteractionStub(user_id=2, name="bob")
-    assert await view.interaction_check(interaction=intruder) is False
+    assert await view.interaction_check(interaction=as_interaction(fake=intruder)) is False
     assert intruder.response.sent  # an ephemeral notice was sent
 
 
@@ -244,7 +249,7 @@ async def test_interaction_check_allows_owner_blocks_others() -> None:
 async def test_show_panel_builds_panel_view() -> None:
     """show_panel edits the message with a panel view owned by the caller."""
     interaction = InteractionStub(user_id=1)
-    await show_panel(interaction=interaction, owner_id=1)
+    await show_panel(interaction=as_interaction(fake=interaction), owner_id=1)
     assert interaction.response.sent
     assert interaction.response.sent[-1]["view"].owner_id == 1
 
@@ -260,7 +265,7 @@ async def test_show_shop_and_leaderboard_and_stats_render() -> None:
         await fdb.upsert_gear(gear=gear)
     for nav in (show_shop, show_leaderboard, show_stats):
         interaction = InteractionStub(user_id=1)
-        await nav(interaction=interaction, owner_id=1)
+        await nav(interaction=as_interaction(fake=interaction), owner_id=1)
         assert interaction.response.sent[-1]["view"].owner_id == 1
 
 
@@ -284,7 +289,7 @@ async def test_begin_cast_runs_two_beat_animation(monkeypatch: pytest.MonkeyPatc
     await purchase_gear(user_id=1, name="alice", gear_id="bait_worm", quantity=5)
 
     interaction = InteractionStub(user_id=1)
-    await begin_cast(interaction=interaction, owner_id=1)
+    await begin_cast(interaction=as_interaction(fake=interaction), owner_id=1)
     assert interaction.response.sent  # casting beat used the component response
     assert interaction.message.edits  # reveal edited the original message
     assert interaction.message.edits[-1]["view"].__class__.__name__ == "FishingPostCastView"
@@ -294,5 +299,5 @@ async def test_begin_cast_runs_two_beat_animation(monkeypatch: pytest.MonkeyPatc
 async def test_begin_cast_without_rod_shows_error() -> None:
     """Casting with no rod routes to the error view."""
     interaction = InteractionStub(user_id=1)
-    await begin_cast(interaction=interaction, owner_id=1)
+    await begin_cast(interaction=as_interaction(fake=interaction), owner_id=1)
     assert interaction.response.sent[-1]["view"].__class__.__name__ == "FishingErrorView"

--- a/tests/test_game_cleanup.py
+++ b/tests/test_game_cleanup.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 import pytest
 import nextcord
-from nextcord import Message, Interaction
+from nextcord import Message
+from nextcord.abc import Messageable
 
 from discordbot.cogs._economy import interactions
 from discordbot.utils.message_cleanup import (
@@ -19,15 +20,10 @@ from discordbot.utils.message_cleanup import (
     schedule_public_message_delete,
 )
 
+from tests.helpers.casting import as_message, as_interaction, make_not_found
+
 if TYPE_CHECKING:
     from nextcord.ext import commands
-
-
-class _ResponseStub:
-    """Minimal HTTP response shape used by nextcord exceptions."""
-
-    status = 404
-    reason = "Not Found"
 
 
 class _DeletableMessageStub:
@@ -62,7 +58,7 @@ class _AlreadyDeletedMessageStub:
 
     async def delete(self) -> None:
         """Raises the same exception nextcord raises for missing messages."""
-        raise nextcord.NotFound(response=_ResponseStub(), message="missing")
+        raise make_not_found()
 
 
 class _ChannelStub:
@@ -99,18 +95,24 @@ class _FetchedMessageStub:
         self.deleted.append((self.channel_id, self.message_id))
 
 
-class _FetchMessageChannelStub:
-    """Minimal message channel returned by the fake bot."""
+class _FetchMessageChannelStub(Messageable):
+    """Minimal message channel returned by the fake bot.
+
+    Subclasses ``Messageable`` because production code narrows channels with
+    ``isinstance(channel, Messageable)`` before fetching.
+    """
 
     def __init__(self, channel_id: int, deleted: list[tuple[int, int]]) -> None:
         """Stores channel identity and the shared deletion recorder."""
         self.channel_id = channel_id
         self.deleted = deleted
 
-    async def fetch_message(self, message_id: int, /) -> _FetchedMessageStub:
-        """Returns a fetched message stub."""
-        return _FetchedMessageStub(
-            channel_id=self.channel_id, message_id=message_id, deleted=self.deleted
+    async def fetch_message(self, message_id: int, /) -> Message:
+        """Returns a fetched message stub typed as the Message the base declares."""
+        return as_message(
+            fake=_FetchedMessageStub(
+                channel_id=self.channel_id, message_id=message_id, deleted=self.deleted
+            )
         )
 
 
@@ -318,7 +320,7 @@ async def test_send_expiring_followup_waits_for_message_and_schedules_cleanup(
     embed = nextcord.Embed(title="balance")
 
     await interactions.send_expiring_followup(
-        interaction=cast("Interaction", interaction), embed=embed
+        interaction=as_interaction(fake=interaction), embed=embed
     )
 
     assert interaction.followup.sent_wait is True
@@ -349,7 +351,7 @@ async def test_send_private_followup_is_ephemeral_and_not_scheduled(
     embed = nextcord.Embed(title="balance")
 
     await interactions.send_private_followup(
-        interaction=cast("Interaction", interaction), embed=embed
+        interaction=as_interaction(fake=interaction), embed=embed
     )
 
     assert interaction.followup.sent_ephemeral is True

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -38,11 +38,7 @@ from discordbot.typings.models import (
 )
 from discordbot.utils.reactions import ReactionStatusChain
 from discordbot.cogs._memory.store import user_scope, write_tone, server_scope, write_main_memory
-from discordbot.utils.media_delivery import (
-    MediaHostingConfig,
-    MediaHostingService,
-    MediaDeliveryPlanner,
-)
+from discordbot.utils.media_delivery import MediaHostingService, MediaDeliveryPlanner
 from discordbot.cogs._gen_reply.input import USAGE_FOOTER_RE, MessageInputBuilder
 from discordbot.cogs._gen_reply.context import ReplyContext
 from discordbot.cogs._gen_reply.markers import (
@@ -94,6 +90,7 @@ from discordbot.cogs._gen_reply.attachment.grok_file_api import GrokFileUploader
 from discordbot.cogs._gen_reply.attachment.gemini_file_api import PendingUpload, GeminiFileUploader
 from discordbot.cogs._gen_reply.attachment.openai_file_api import OpenAIFileUploader
 
+from tests.helpers.casting import as_bot, as_message, step_dicts, make_media_hosting_config
 from tests.helpers.llm_input import (
     request_index,
     request_input,
@@ -119,6 +116,9 @@ if TYPE_CHECKING:
     from pathlib import Path
     from collections.abc import AsyncIterator
 
+    from aiohttp import ClientResponse
+    from nextcord import Attachment
+    from openai.types.responses import ResponseStreamEvent
     from openai.types.responses.response_input_param import ResponseInputParam
 
 
@@ -517,9 +517,9 @@ class FakeGeminiVideoClient:
 
     def __init__(self) -> None:
         """Initializes call records and the async-namespace resources."""
-        self.create_inputs: list[object] = []
-        self.create_response_formats: list[object] = []
-        self.create_configs: list[object] = []
+        self.create_inputs: list[Any] = []
+        self.create_response_formats: list[Any] = []
+        self.create_configs: list[Any] = []
         self.aio = SimpleNamespace(
             interactions=SimpleNamespace(create=self._interactions_create),
             files=SimpleNamespace(
@@ -760,23 +760,49 @@ def _cog(bot_user_id: int = 999) -> ReplyGeneratorCogs:
     return cog
 
 
+def _recorded(cog: ReplyGeneratorCogs) -> FakeClient:
+    """Reads the recorder client back off the cog's typed openai_client slot."""
+    return cast("FakeClient", cog.openai_client)
+
+
+def _recorded_video(cog: ReplyGeneratorCogs) -> FakeGeminiVideoClient:
+    """Reads the recorder video client back off the cog's typed gemini_client slot."""
+    return cast("FakeGeminiVideoClient", cog.gemini_client)
+
+
+def _config_stub(**flags: object) -> LLMConfig:
+    """Views a namespace carrying just the flags a test toggles as the cog's LLMConfig."""
+    return cast("LLMConfig", SimpleNamespace(**flags))
+
+
+def _att(
+    filename: str = "file.txt", content_type: str | None = "text/plain", payload: bytes = b"hello"
+) -> Attachment:
+    """Builds a FakeAttachment viewed as the nextcord Attachment a renderer expects."""
+    return cast(
+        "Attachment", FakeAttachment(filename=filename, content_type=content_type, payload=payload)
+    )
+
+
 async def _route(cog: ReplyGeneratorCogs, message: FakeMessage) -> RouteClassification:
     """Classifies a message after building the shared text-only reference/current parts."""
+    msg = as_message(fake=message)
     reference_messages, current_message = await cog._get_reference_and_current(
-        message=message, text_only=True
+        message=msg, text_only=True
     )
     return await cog._route_classify(
-        message=message, reference_messages=reference_messages, current_message=current_message
+        message=msg, reference_messages=reference_messages, current_message=current_message
     )
 
 
 async def _grade(cog: ReplyGeneratorCogs, message: FakeMessage) -> EffortGrade:
     """Grades a message's answer effort after building the shared text-only parts."""
+    msg = as_message(fake=message)
     reference_messages, current_message = await cog._get_reference_and_current(
-        message=message, text_only=True
+        message=msg, text_only=True
     )
     return await cog._grade_effort(
-        message=message, reference_messages=reference_messages, current_message=current_message
+        message=msg, reference_messages=reference_messages, current_message=current_message
     )
 
 
@@ -789,12 +815,13 @@ async def _reply_via_pipeline(  # noqa: PLR0913 -- mirrors _handle_message_reply
     effort: Literal["low", "medium", "high"] = "high",
 ) -> None:
     """Drives prepare-context plus answer the way on_message does for the QA route."""
-    parts_task = asyncio.create_task(coro=cog._get_reference_and_current(message=message))
-    text_parts = await cog._get_reference_and_current(message=message, text_only=True)
+    msg = as_message(fake=message)
+    parts_task = asyncio.create_task(coro=cog._get_reference_and_current(message=msg))
+    text_parts = await cog._get_reference_and_current(message=msg, text_only=True)
     route_done = asyncio.Event()
     route_done.set()
     context = await cog._prepare_reply_context(
-        message=message,
+        message=msg,
         history_limit=history_limit,
         memory_enabled=memory_enabled,
         parts_task=parts_task,
@@ -802,7 +829,7 @@ async def _reply_via_pipeline(  # noqa: PLR0913 -- mirrors _handle_message_reply
         route_done=route_done,
     )
     await cog._handle_message_reply(
-        message=message,
+        message=msg,
         system_prompt=system_prompt,
         context=context,
         memory_enabled=memory_enabled,
@@ -822,7 +849,9 @@ def test_build_runtime_instructions_adds_request_time_context() -> None:
     """Request time context uses Discord's message creation timestamp."""
     message = FakeMessage(content="hi")
 
-    instructions = _build_runtime_instructions(system_prompt="SYS", message=message)
+    instructions = _build_runtime_instructions(
+        system_prompt="SYS", message=as_message(fake=message)
+    )
 
     _assert_runtime_time_context(instructions=instructions, system_prompt="SYS")
 
@@ -834,34 +863,52 @@ def test_build_runtime_instructions_names_conversation_location() -> None:
     the developer-authority instructions, so it must never appear there.
     """
     guild_message = FakeMessage(content="hi")
-    instructions = _build_runtime_instructions(system_prompt="SYS", message=guild_message)
+    instructions = _build_runtime_instructions(
+        system_prompt="SYS", message=as_message(fake=guild_message)
+    )
     assert "Current conversation location:" in instructions
     assert "a Discord server (guild id 1)" in instructions
     assert "Test Guild" not in instructions
 
     dm_message = FakeMessage(content="hi")
     dm_message.guild = None
-    dm_instructions = _build_runtime_instructions(system_prompt="SYS", message=dm_message)
+    dm_instructions = _build_runtime_instructions(
+        system_prompt="SYS", message=as_message(fake=dm_message)
+    )
     assert "Current conversation location:" in dm_instructions
     assert "a Discord direct message (DM)" in dm_instructions
 
 
-async def _stream_events() -> AsyncIterator[SimpleNamespace]:
+def _stream_events() -> AsyncIterator[ResponseStreamEvent]:
     """Yields a minimal streaming completion with token usage."""
-    yield SimpleNamespace(type="response.output_text.delta", delta="hello from stream")
-    yield SimpleNamespace(
-        type="response.completed",
-        response=SimpleNamespace(
-            model=TEST_LLM_MODEL,
-            usage=SimpleNamespace(input_tokens=12, output_tokens=34, output_tokens_details=None),
-        ),
+    return _stream_events_from(
+        events=[
+            SimpleNamespace(type="response.output_text.delta", delta="hello from stream"),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(
+                    model=TEST_LLM_MODEL,
+                    usage=SimpleNamespace(
+                        input_tokens=12, output_tokens=34, output_tokens_details=None
+                    ),
+                ),
+            ),
+        ]
     )
 
 
-async def _stream_events_from(events: list[SimpleNamespace]) -> AsyncIterator[SimpleNamespace]:
-    """Yields the provided fake streaming events in order."""
-    for event in events:
-        yield event
+def _stream_events_from(events: list[SimpleNamespace]) -> AsyncIterator[ResponseStreamEvent]:
+    """Yields the provided fake streaming events in order.
+
+    Typed as the SDK stream union: production discriminates on the `.type` string, so
+    fabricated SimpleNamespace events stand in for the real stream events.
+    """
+
+    async def _iter() -> AsyncIterator[SimpleNamespace]:
+        for event in events:
+            yield event
+
+    return cast("AsyncIterator[ResponseStreamEvent]", _iter())
 
 
 def _text_event(delta: str) -> SimpleNamespace:
@@ -950,13 +997,13 @@ async def test_handle_streaming_continues_long_reply_as_reply_chain(
 
     chain_chunks = [parent.content, first_follow_up.content, second_follow_up.content]
     assert all(len(chunk) <= DISCORD_MESSAGE_LIMIT for chunk in chain_chunks)
-    assert cog.openai_client.responses.create_models == []
+    assert _recorded(cog).responses.create_models == []
 
 
 def _deleted_source_error() -> nextcord.HTTPException:
     """Builds the Discord 400 50035 raised when replying to a since-deleted source."""
     return nextcord.HTTPException(
-        SimpleNamespace(status=400, reason="Bad Request"),
+        cast("ClientResponse", SimpleNamespace(status=400, reason="Bad Request")),
         {"code": 50035, "message": "Invalid Form Body"},
     )
 
@@ -964,7 +1011,7 @@ def _deleted_source_error() -> nextcord.HTTPException:
 def _unknown_message_notfound() -> nextcord.NotFound:
     """Builds the 404 10008 a deleted source can raise on some Discord paths."""
     return nextcord.NotFound(
-        SimpleNamespace(status=404, reason="Not Found"),
+        cast("ClientResponse", SimpleNamespace(status=404, reason="Not Found")),
         {"code": 10008, "message": "Unknown Message"},
     )
 
@@ -1011,7 +1058,7 @@ async def test_streaming_reraises_non_deletion_http_errors(economy_isolated_db: 
     del economy_isolated_db
     message = FakeMessage()
     message.reply_error = nextcord.HTTPException(
-        SimpleNamespace(status=403, reason="Forbidden"),
+        cast("ClientResponse", SimpleNamespace(status=403, reason="Forbidden")),
         {"code": 50013, "message": "Missing Permissions"},
     )
 
@@ -1046,7 +1093,7 @@ async def test_streaming_reraises_non_deletion_edit_errors(economy_isolated_db: 
     message = FakeMessage()
     reply = FakeReply()
     reply.edit_error = nextcord.HTTPException(
-        SimpleNamespace(status=403, reason="Forbidden"),
+        cast("ClientResponse", SimpleNamespace(status=403, reason="Forbidden")),
         {"code": 50013, "message": "Missing Permissions"},
     )
 
@@ -1062,9 +1109,9 @@ async def test_deleted_reply_skips_media_attach_without_hint(economy_isolated_db
     reply.edit_error = _unknown_message_notfound()
     synthesizer = _FakeVoiceGenerator()
 
-    await ResponseStreamer(message=message, reply=reply, voice_generator=synthesizer).stream(
-        responses=_stream_events_from(_voice_marker_events())
-    )
+    await ResponseStreamer(
+        message=message, reply=reply, voice_generator=cast("VoiceGenerator", synthesizer)
+    ).stream(responses=_stream_events_from(_voice_marker_events()))
 
     assert synthesizer.calls == []
     assert message.added_reactions == []
@@ -1112,9 +1159,9 @@ async def test_voice_marker_triggers_synthesis_and_strips_tag(economy_isolated_d
     message = FakeMessage()
     synthesizer = _FakeVoiceGenerator()
 
-    result = await ResponseStreamer(message=message, voice_generator=synthesizer).stream(
-        responses=_stream_events_from(_voice_marker_events())
-    )
+    result = await ResponseStreamer(
+        message=message, voice_generator=cast("VoiceGenerator", synthesizer)
+    ).stream(responses=_stream_events_from(_voice_marker_events()))
 
     _assert_no_voice_tags(result)
     # The wrapped content stays visible alongside the rest of the reply.
@@ -1134,9 +1181,9 @@ async def test_voice_marker_absent_no_synthesis(economy_isolated_db: None) -> No
     message = FakeMessage()
     synthesizer = _FakeVoiceGenerator()
 
-    await ResponseStreamer(message=message, voice_generator=synthesizer).stream(
-        responses=_stream_events()
-    )
+    await ResponseStreamer(
+        message=message, voice_generator=cast("VoiceGenerator", synthesizer)
+    ).stream(responses=_stream_events())
 
     assert synthesizer.calls == []
     assert message.replies[0].file is None
@@ -1164,9 +1211,9 @@ async def test_voice_synthesis_failure_leaves_text_reply(economy_isolated_db: No
     message = FakeMessage()
     synthesizer = _FakeVoiceGenerator(audio=None, outcome=VoiceOutcome.ERROR)
 
-    result = await ResponseStreamer(message=message, voice_generator=synthesizer).stream(
-        responses=_stream_events_from(_voice_marker_events())
-    )
+    result = await ResponseStreamer(
+        message=message, voice_generator=cast("VoiceGenerator", synthesizer)
+    ).stream(responses=_stream_events_from(_voice_marker_events()))
 
     _assert_no_voice_tags(result)
     assert message.replies[0].file is None
@@ -1180,9 +1227,9 @@ async def test_voice_synthesis_timeout_hints_with_clock(economy_isolated_db: Non
     message = FakeMessage()
     synthesizer = _FakeVoiceGenerator(audio=None, outcome=VoiceOutcome.TIMEOUT)
 
-    result = await ResponseStreamer(message=message, voice_generator=synthesizer).stream(
-        responses=_stream_events_from(_voice_marker_events())
-    )
+    result = await ResponseStreamer(
+        message=message, voice_generator=cast("VoiceGenerator", synthesizer)
+    ).stream(responses=_stream_events_from(_voice_marker_events()))
 
     _assert_no_voice_tags(result)
     assert message.replies[0].file is None
@@ -1199,16 +1246,14 @@ async def test_voice_too_big_falls_back_to_hosted_url(
     message.guild = FakeGuild(filesize_limit=4)
     synthesizer = _FakeVoiceGenerator()
     service = MediaHostingService(
-        config=MediaHostingConfig(
-            MEDIA_HOSTING_ENABLED=True,
-            MEDIA_HOSTING_BASE_URL="https://media.test",
-            MEDIA_HOSTING_SERVE_DIR=str(tmp_path),
+        config=make_media_hosting_config(
+            enabled=True, base_url="https://media.test", serve_dir=str(tmp_path)
         )
     )
 
     result = await ResponseStreamer(
         message=message,
-        voice_generator=synthesizer,
+        voice_generator=cast("VoiceGenerator", synthesizer),
         media_delivery=MediaDeliveryPlanner(media_hosting=service),
     ).stream(responses=_stream_events_from(_voice_marker_events()))
 
@@ -1237,9 +1282,9 @@ async def test_voice_too_big_without_hosting_drops_with_hint(economy_isolated_db
     message.guild = FakeGuild(filesize_limit=4)
     synthesizer = _FakeVoiceGenerator()
 
-    result = await ResponseStreamer(message=message, voice_generator=synthesizer).stream(
-        responses=_stream_events_from(_voice_marker_events())
-    )
+    result = await ResponseStreamer(
+        message=message, voice_generator=cast("VoiceGenerator", synthesizer)
+    ).stream(responses=_stream_events_from(_voice_marker_events()))
 
     _assert_no_voice_tags(result)
     assert message.replies[0].file is None
@@ -1249,10 +1294,8 @@ async def test_voice_too_big_without_hosting_drops_with_hint(economy_isolated_db
 def _hosting_service(*, serve_dir: Path) -> MediaHostingService:
     """Builds a real media-hosting service writing into a temp serve dir for streamer tests."""
     return MediaHostingService(
-        config=MediaHostingConfig(
-            MEDIA_HOSTING_ENABLED=True,
-            MEDIA_HOSTING_BASE_URL="https://media.test",
-            MEDIA_HOSTING_SERVE_DIR=str(serve_dir),
+        config=make_media_hosting_config(
+            enabled=True, base_url="https://media.test", serve_dir=str(serve_dir)
         )
     )
 
@@ -1264,11 +1307,11 @@ async def test_finalize_media_edit_posts_followup_when_content_would_overflow(
     del economy_isolated_db
     streamer = ResponseStreamer(message=FakeMessage())
     reply = FakeReply()
-    streamer.reply = reply
+    streamer.reply = as_message(fake=reply)
     streamer.stored_content = "x" * (DISCORD_MESSAGE_LIMIT - 10)
 
     await streamer._finalize_media_edit(
-        reply=reply, files=[], hosted_urls=["https://media.test/abc.wav"]
+        reply=as_message(fake=reply), files=[], hosted_urls=["https://media.test/abc.wav"]
     )
 
     # The URL did not fit the main content, so it was posted as a follow-up reply (which must keep
@@ -1287,11 +1330,11 @@ async def test_finalize_media_edit_hints_when_the_hosted_followup_fails(
     streamer = ResponseStreamer(message=message)
     reply = FakeReply()
     reply.reply_error = RuntimeError("follow-up refused")
-    streamer.reply = reply
+    streamer.reply = as_message(fake=reply)
     streamer.stored_content = "x" * (DISCORD_MESSAGE_LIMIT - 10)
 
     await streamer._finalize_media_edit(
-        reply=reply, files=[], hosted_urls=["https://media.test/abc.wav"]
+        reply=as_message(fake=reply), files=[], hosted_urls=["https://media.test/abc.wav"]
     )
 
     assert reply.replies == []
@@ -1478,9 +1521,9 @@ async def test_voice_text_strips_discord_markup(economy_isolated_db: None) -> No
     message.guild = FakeGuild(members={239270225441193986: SimpleNamespace(display_name="小明")})
     synthesizer = _FakeVoiceGenerator()
 
-    result = await ResponseStreamer(message=message, voice_generator=synthesizer).stream(
-        responses=_stream_events_from(_voice_marker_mention_events())
-    )
+    result = await ResponseStreamer(
+        message=message, voice_generator=cast("VoiceGenerator", synthesizer)
+    ).stream(responses=_stream_events_from(_voice_marker_mention_events()))
 
     # The visible reply keeps the clickable mention; only the spoken text is normalised.
     assert "<@239270225441193986>" in result
@@ -1547,9 +1590,9 @@ async def test_image_marker_generates_and_attaches(economy_isolated_db: None) ->
     message = FakeMessage()
     generator = _FakeImageGenerator()
 
-    result = await ResponseStreamer(message=message, image_generator=generator).stream(
-        responses=_stream_events_from(_image_marker_events())
-    )
+    result = await ResponseStreamer(
+        message=message, image_generator=cast("ImageGenerator", generator)
+    ).stream(responses=_stream_events_from(_image_marker_events()))
 
     # The block (tags AND description) never shows in chat.
     assert "<generate-image>" not in result
@@ -1583,7 +1626,9 @@ async def test_image_marker_edits_uploaded_image_with_source_bytes(
     builder = SimpleNamespace(get_image_sources_with_mime=_load)
 
     await ResponseStreamer(
-        message=message, image_generator=generator, input_builder=builder
+        message=message,
+        image_generator=cast("ImageGenerator", generator),
+        input_builder=cast("MessageInputBuilder", builder),
     ).stream(responses=_stream_events_from(_image_marker_events()))
 
     # The uploaded bytes (mime stripped for the edit path) ride through to generate, so the inline
@@ -1615,9 +1660,9 @@ async def test_image_generation_failure_hints(economy_isolated_db: None) -> None
     message = FakeMessage()
     generator = _FakeImageGenerator(image=None)
 
-    result = await ResponseStreamer(message=message, image_generator=generator).stream(
-        responses=_stream_events_from(_image_marker_events())
-    )
+    result = await ResponseStreamer(
+        message=message, image_generator=cast("ImageGenerator", generator)
+    ).stream(responses=_stream_events_from(_image_marker_events()))
 
     assert "a cute black cat" not in result
     assert message.replies[0].file is None
@@ -1632,7 +1677,9 @@ async def test_voice_and_image_attach_in_one_edit(economy_isolated_db: None) -> 
     generator = _FakeImageGenerator()
 
     result = await ResponseStreamer(
-        message=message, voice_generator=synthesizer, image_generator=generator
+        message=message,
+        voice_generator=cast("VoiceGenerator", synthesizer),
+        image_generator=cast("ImageGenerator", generator),
     ).stream(
         responses=_stream_events_from([
             _text_event(delta="看 <generate-voice>聽好</generate-voice> "),
@@ -1655,7 +1702,9 @@ async def test_multiple_image_markers_attach_distinct_files(economy_isolated_db:
     message = FakeMessage()
     generator = _FakeImageGenerator()
 
-    result = await ResponseStreamer(message=message, image_generator=generator).stream(
+    result = await ResponseStreamer(
+        message=message, image_generator=cast("ImageGenerator", generator)
+    ).stream(
         responses=_stream_events_from([
             _text_event(delta="兩張圖 "),
             _text_event(
@@ -1682,7 +1731,9 @@ async def test_image_markers_capped_at_limit(economy_isolated_db: None) -> None:
         f"<generate-image>image {index}</generate-image>" for index in range(MAX_INLINE_IMAGES + 3)
     )
 
-    await ResponseStreamer(message=message, image_generator=generator).stream(
+    await ResponseStreamer(
+        message=message, image_generator=cast("ImageGenerator", generator)
+    ).stream(
         responses=_stream_events_from([
             _text_event(delta=f"好多圖 {blocks}"),
             _completed_event(input_tokens=3, output_tokens=4),
@@ -1730,9 +1781,9 @@ async def test_music_marker_generates_and_attaches(economy_isolated_db: None) ->
     message = FakeMessage()
     generator = _FakeMusicGenerator()
 
-    result = await ResponseStreamer(message=message, music_generator=generator).stream(
-        responses=_stream_events_from(_music_marker_events())
-    )
+    result = await ResponseStreamer(
+        message=message, music_generator=cast("MusicGenerator", generator)
+    ).stream(responses=_stream_events_from(_music_marker_events()))
 
     # The block (tags AND description) never shows in chat.
     assert "<generate-music>" not in result
@@ -1766,9 +1817,9 @@ async def test_music_generation_failure_hints(economy_isolated_db: None) -> None
     message = FakeMessage()
     generator = _FakeMusicGenerator(audio=None)
 
-    result = await ResponseStreamer(message=message, music_generator=generator).stream(
-        responses=_stream_events_from(_music_marker_events())
-    )
+    result = await ResponseStreamer(
+        message=message, music_generator=cast("MusicGenerator", generator)
+    ).stream(responses=_stream_events_from(_music_marker_events()))
 
     assert "anime" not in result
     assert message.replies[0].file is None
@@ -1793,9 +1844,9 @@ async def test_voice_music_image_attach_in_one_edit(economy_isolated_db: None) -
 
     result = await ResponseStreamer(
         message=message,
-        voice_generator=synthesizer,
-        music_generator=music_generator,
-        image_generator=image_generator,
+        voice_generator=cast("VoiceGenerator", synthesizer),
+        music_generator=cast("MusicGenerator", music_generator),
+        image_generator=cast("ImageGenerator", image_generator),
     ).stream(
         responses=_stream_events_from([
             _text_event(delta="來囉 <generate-voice>聽好</generate-voice> "),
@@ -1871,9 +1922,9 @@ async def test_video_marker_generates_and_attaches(economy_isolated_db: None) ->
     message = FakeMessage()
     generator = _FakeVideoGenerator()
 
-    result = await ResponseStreamer(message=message, video_generator=generator).stream(
-        responses=_stream_events_from(_video_marker_events())
-    )
+    result = await ResponseStreamer(
+        message=message, video_generator=cast("VideoGenerator", generator)
+    ).stream(responses=_stream_events_from(_video_marker_events()))
 
     # The block (tags AND description) never shows in chat.
     assert "<generate-video>" not in result
@@ -1903,7 +1954,9 @@ async def test_video_marker_uses_uploaded_image_as_reference(economy_isolated_db
     builder = SimpleNamespace(get_image_sources_with_mime=_load)
 
     await ResponseStreamer(
-        message=message, video_generator=generator, input_builder=builder
+        message=message,
+        video_generator=cast("VideoGenerator", generator),
+        input_builder=cast("MessageInputBuilder", builder),
     ).stream(responses=_stream_events_from(_video_marker_events()))
 
     # The uploaded (bytes, mime) pair rides through to generate, so the inline <generate-video>
@@ -1934,9 +1987,9 @@ async def test_video_generation_failure_hints(economy_isolated_db: None) -> None
     message = FakeMessage()
     generator = _FakeVideoGenerator(video=None)
 
-    result = await ResponseStreamer(message=message, video_generator=generator).stream(
-        responses=_stream_events_from(_video_marker_events())
-    )
+    result = await ResponseStreamer(
+        message=message, video_generator=cast("VideoGenerator", generator)
+    ).stream(responses=_stream_events_from(_video_marker_events()))
 
     assert "wave" not in result
     assert message.replies[0].file is None
@@ -1954,10 +2007,10 @@ async def test_voice_music_video_image_attach_in_one_edit(economy_isolated_db: N
 
     result = await ResponseStreamer(
         message=message,
-        voice_generator=voice_generator,
-        music_generator=music_generator,
-        video_generator=video_generator,
-        image_generator=image_generator,
+        voice_generator=cast("VoiceGenerator", voice_generator),
+        music_generator=cast("MusicGenerator", music_generator),
+        video_generator=cast("VideoGenerator", video_generator),
+        image_generator=cast("ImageGenerator", image_generator),
     ).stream(
         responses=_stream_events_from([
             _text_event(delta="來囉 <generate-voice>聽好</generate-voice> "),
@@ -2016,7 +2069,7 @@ class _FakeSpeech:
         """Stores the bytes to return and an optional error to raise."""
         self.data = data
         self.error = error
-        self.calls: list[dict[str, object]] = []
+        self.calls: list[dict[str, Any]] = []
 
     async def create(self, **kwargs: object) -> _FakeSpeechResponse:
         """Records the call and returns the preset response or raises the preset error."""
@@ -2077,9 +2130,9 @@ async def test_voice_oversized_clip_not_attached(economy_isolated_db: None) -> N
     message.guild = FakeGuild(filesize_limit=8)
     synthesizer = _FakeVoiceGenerator(audio=b"x" * 16)
 
-    result = await ResponseStreamer(message=message, voice_generator=synthesizer).stream(
-        responses=_stream_events_from(_voice_marker_events())
-    )
+    result = await ResponseStreamer(
+        message=message, voice_generator=cast("VoiceGenerator", synthesizer)
+    ).stream(responses=_stream_events_from(_voice_marker_events()))
 
     _assert_no_voice_tags(result)
     assert message.replies[0].file is None
@@ -2093,7 +2146,7 @@ async def test_voice_config_gate_controls_synthesizer(
 ) -> None:
     """config.inline_voice_enabled gates whether the QA streamer receives a synthesizer."""
     cog = _cog()
-    cog.config = SimpleNamespace(inline_voice_enabled=enabled)
+    cog.config = _config_stub(inline_voice_enabled=enabled)
     captured: list[object] = []
 
     class FakeResponder:
@@ -2128,7 +2181,7 @@ async def test_voice_config_gate_controls_synthesizer(
 
     message = FakeMessage(content="<@999> hi", author=FakeAuthor(user_id=1))
     await cog._handle_message_reply(
-        message=message,
+        message=as_message(fake=message),
         system_prompt="SYS",
         context=ReplyContext(),
         memory_enabled=False,
@@ -2146,7 +2199,7 @@ async def test_image_config_gate_controls_generator(
 ) -> None:
     """config.inline_image_enabled gates whether the QA streamer receives an image generator."""
     cog = _cog()
-    cog.config = SimpleNamespace(inline_voice_enabled=False, inline_image_enabled=enabled)
+    cog.config = _config_stub(inline_voice_enabled=False, inline_image_enabled=enabled)
     captured: list[object] = []
 
     class FakeResponder:
@@ -2181,7 +2234,7 @@ async def test_image_config_gate_controls_generator(
 
     message = FakeMessage(content="<@999> hi", author=FakeAuthor(user_id=1))
     await cog._handle_message_reply(
-        message=message,
+        message=as_message(fake=message),
         system_prompt="SYS",
         context=ReplyContext(),
         memory_enabled=False,
@@ -2210,7 +2263,7 @@ class _FakeInteractionsResource:
         generation_config: object,
         tools: list[object],
         stream: bool,
-    ) -> AsyncIterator[SimpleNamespace]:
+    ) -> AsyncIterator[ResponseStreamEvent]:
         """Records the call and returns the fake Interactions event stream."""
         del environment, tools, stream
         self.calls.append(
@@ -2259,7 +2312,7 @@ async def test_youtube_qa_uses_interactions_backend(
     """A watched YouTube URL streams the answer through Interactions, not Responses."""
     del economy_isolated_db
     cog = _cog()
-    cog.config = SimpleNamespace(
+    cog.config = _config_stub(
         inline_voice_enabled=False,
         inline_image_enabled=False,
         youtube_video_enabled=True,
@@ -2272,7 +2325,7 @@ async def test_youtube_qa_uses_interactions_backend(
     url = "https://youtu.be/jNQXAC9IVRw"
     message = FakeMessage(content=f"<@999> 總結這影片 {url}", author=FakeAuthor(user_id=1))
     await cog._handle_message_reply(
-        message=message,
+        message=as_message(fake=message),
         system_prompt="SYS",
         context=ReplyContext(),
         memory_enabled=False,
@@ -2280,7 +2333,7 @@ async def test_youtube_qa_uses_interactions_backend(
     )
 
     # The Responses answer stream was never used; the Interactions one was, with the video part.
-    assert cog.openai_client.responses.create_streams == []
+    assert _recorded(cog).responses.create_streams == []
     assert len(fake.recorder.calls) == 1
     last_step_parts = fake.recorder.calls[0].input[-1]["content"]
     assert {"type": "video", "uri": url} in last_step_parts
@@ -2298,7 +2351,7 @@ async def test_youtube_interactions_passes_effort_as_thinking_level(
     """The graded effort is sent straight through as the Interactions thinking_level."""
     del economy_isolated_db
     cog = _cog()
-    cog.config = SimpleNamespace(
+    cog.config = _config_stub(
         inline_voice_enabled=False,
         inline_image_enabled=False,
         youtube_video_enabled=True,
@@ -2311,7 +2364,7 @@ async def test_youtube_interactions_passes_effort_as_thinking_level(
     url = "https://youtu.be/jNQXAC9IVRw"
     message = FakeMessage(content=f"<@999> {url}", author=FakeAuthor(user_id=1))
     await cog._handle_message_reply(
-        message=message,
+        message=as_message(fake=message),
         system_prompt="SYS",
         context=ReplyContext(),
         memory_enabled=False,
@@ -2329,7 +2382,7 @@ async def test_youtube_qa_falls_back_to_responses(
     """Without a watchable Gemini video turn, the answer stays on the Responses path."""
     del economy_isolated_db
     cog = _cog()
-    cog.config = SimpleNamespace(
+    cog.config = _config_stub(
         inline_voice_enabled=False,
         inline_image_enabled=False,
         youtube_video_enabled=scenario != "kill_switch_off",
@@ -2349,7 +2402,7 @@ async def test_youtube_qa_falls_back_to_responses(
     yt_url = None if scenario == "no_url" else url
     message = FakeMessage(content=f"<@999> {url}", author=FakeAuthor(user_id=1))
     await cog._handle_message_reply(
-        message=message,
+        message=as_message(fake=message),
         system_prompt="SYS",
         context=ReplyContext(),
         memory_enabled=False,
@@ -2357,7 +2410,7 @@ async def test_youtube_qa_falls_back_to_responses(
     )
 
     assert fake.recorder.calls == []
-    assert cog.openai_client.responses.create_streams == [True]
+    assert _recorded(cog).responses.create_streams == [True]
 
 
 def test_find_youtube_url_searches_reference_chain(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2369,7 +2422,7 @@ def test_find_youtube_url_searches_reference_chain(monkeypatch: pytest.MonkeyPat
     message = FakeMessage(content="<@999> 總結這影片")
     message.reference = FakeReference(resolved=referenced)
 
-    assert _find_youtube_url(message=message) == url
+    assert _find_youtube_url(message=as_message(fake=message)) == url
 
 
 def test_find_youtube_url_none_without_link(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2378,7 +2431,7 @@ def test_find_youtube_url_none_without_link(monkeypatch: pytest.MonkeyPatch) -> 
     message = FakeMessage(content="<@999> hi")
     message.reference = FakeReference(resolved=FakeMessage(content="just chatting"))
 
-    assert _find_youtube_url(message=message) is None
+    assert _find_youtube_url(message=as_message(fake=message)) is None
 
 
 def test_find_youtube_url_in_forwarded_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2388,7 +2441,7 @@ def test_find_youtube_url_in_forwarded_snapshot(monkeypatch: pytest.MonkeyPatch)
     message = FakeMessage(content="")  # pure forward: empty top-level content
     message.snapshots = [FakeSnapshot(content=f"summarize this {url}")]
 
-    assert _find_youtube_url(message=message) == url
+    assert _find_youtube_url(message=as_message(fake=message)) == url
 
 
 def test_find_youtube_url_in_forwarded_embed_title(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2398,7 +2451,7 @@ def test_find_youtube_url_in_forwarded_embed_title(monkeypatch: pytest.MonkeyPat
     message = FakeMessage(content="")
     message.snapshots = [FakeSnapshot(embeds=[Embed(title=f"watch {url}")])]
 
-    assert _find_youtube_url(message=message) == url
+    assert _find_youtube_url(message=as_message(fake=message)) == url
 
 
 def test_find_youtube_url_in_forwarded_embed_url(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2408,7 +2461,7 @@ def test_find_youtube_url_in_forwarded_embed_url(monkeypatch: pytest.MonkeyPatch
     message = FakeMessage(content="")
     message.snapshots = [FakeSnapshot(embeds=[Embed(url=url)])]  # bare link card, no caption
 
-    assert _find_youtube_url(message=message) == url
+    assert _find_youtube_url(message=as_message(fake=message)) == url
 
 
 def test_find_youtube_url_skips_captioned_forward_embed(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2419,7 +2472,7 @@ def test_find_youtube_url_skips_captioned_forward_embed(monkeypatch: pytest.Monk
     # Snapshot has its own caption, so the embed (where the URL lives) is not rendered to the model.
     message.snapshots = [FakeSnapshot(content="lol look at this", embeds=[Embed(url=url)])]
 
-    assert _find_youtube_url(message=message) is None
+    assert _find_youtube_url(message=as_message(fake=message)) is None
 
 
 def _media_builder() -> MessageInputBuilder:
@@ -2441,14 +2494,18 @@ def test_collect_sources_skips_bot_own_voice_clip() -> None:
         FakeAttachment(filename="note.txt", content_type="text/plain", attachment_id=2),
     ]
     # The bot's voice clip is skipped; a normal attachment on its message is kept.
-    assert [s.cache_key for s in builder.collect_attachment_sources(message=bot_msg)] == [2]
+    assert [
+        s.cache_key for s in builder.collect_attachment_sources(message=as_message(fake=bot_msg))
+    ] == [2]
 
     # The same filename on a human's message is NOT skipped (only the bot's own clip is).
     user_msg = FakeMessage(author=FakeAuthor(user_id=1))
     user_msg.attachments = [
         FakeAttachment(filename="reply.wav", content_type="audio/wav", attachment_id=3)
     ]
-    assert [s.cache_key for s in builder.collect_attachment_sources(message=user_msg)] == [3]
+    assert [
+        s.cache_key for s in builder.collect_attachment_sources(message=as_message(fake=user_msg))
+    ] == [3]
 
 
 def test_collect_sources_keeps_bot_own_music_clip() -> None:
@@ -2466,7 +2523,9 @@ def test_collect_sources_keeps_bot_own_music_clip() -> None:
         FakeAttachment(filename="reply.wav", content_type="audio/wav", attachment_id=2),
     ]
     # The music clip is kept (cache_key 1); only the voice clip (cache_key 2) is skipped.
-    assert [s.cache_key for s in builder.collect_attachment_sources(message=bot_msg)] == [1]
+    assert [
+        s.cache_key for s in builder.collect_attachment_sources(message=as_message(fake=bot_msg))
+    ] == [1]
 
 
 def test_collect_sources_includes_forwarded_snapshot_media() -> None:
@@ -2486,7 +2545,9 @@ def test_collect_sources_includes_forwarded_snapshot_media() -> None:
             ],
         )
     ]
-    assert [s.cache_key for s in builder.collect_attachment_sources(message=msg)] == [1, 2]
+    assert [
+        s.cache_key for s in builder.collect_attachment_sources(message=as_message(fake=msg))
+    ] == [1, 2]
 
 
 async def test_cleaned_content_includes_forwarded_snapshot_text() -> None:
@@ -2496,14 +2557,14 @@ async def test_cleaned_content_includes_forwarded_snapshot_text() -> None:
     # Text-only forward: the snapshot content surfaces under the tag.
     forward_only = FakeMessage(author=FakeAuthor(user_id=1))
     forward_only.snapshots = [FakeSnapshot(content="hello from elsewhere")]
-    rendered = await builder.get_cleaned_content(message=forward_only)
+    rendered = await builder.get_cleaned_content(message=as_message(fake=forward_only))
     assert "[forwarded message]" in rendered
     assert "hello from elsewhere" in rendered
 
     # The forwarder's own comment is kept alongside the forwarded body (append, not replace).
     with_comment = FakeMessage(content="look at this", author=FakeAuthor(user_id=1))
     with_comment.snapshots = [FakeSnapshot(content="original text")]
-    rendered = await builder.get_cleaned_content(message=with_comment)
+    rendered = await builder.get_cleaned_content(message=as_message(fake=with_comment))
     assert "look at this" in rendered
     assert "original text" in rendered
 
@@ -2516,14 +2577,17 @@ async def test_cleaned_content_includes_forwarded_snapshot_text() -> None:
             ]
         )
     ]
-    assert await builder.get_cleaned_content(message=media_only) == "[forwarded message]"
+    assert (
+        await builder.get_cleaned_content(message=as_message(fake=media_only))
+        == "[forwarded message]"
+    )
 
     # Forwarding the bot's own reply (snapshot has no author) still strips the usage footer.
     forwarded_bot_reply = FakeMessage(author=FakeAuthor(user_id=1))
     forwarded_bot_reply.snapshots = [
         FakeSnapshot(content="real answer\n\n-# model · ⬆ 1 ⬇ 2 · $0.0 · +3")
     ]
-    rendered = await builder.get_cleaned_content(message=forwarded_bot_reply)
+    rendered = await builder.get_cleaned_content(message=as_message(fake=forwarded_bot_reply))
     assert "real answer" in rendered
     assert "⬆" not in rendered
 
@@ -2532,7 +2596,7 @@ async def test_cleaned_content_includes_forwarded_snapshot_text() -> None:
     captioned.snapshots = [
         FakeSnapshot(content="funny", embeds=[Embed(url="https://youtu.be/jNQXAC9IVRw")])
     ]
-    rendered = await builder.get_cleaned_content(message=captioned)
+    rendered = await builder.get_cleaned_content(message=as_message(fake=captioned))
     assert "funny" in rendered
     assert "youtu.be" not in rendered
 
@@ -2543,10 +2607,10 @@ def test_forwarded_request_text_is_untagged() -> None:
 
     forward = FakeMessage(author=FakeAuthor(user_id=1))
     forward.snapshots = [FakeSnapshot(content="draw a cat")]
-    assert builder.forwarded_request_text(message=forward) == "draw a cat"
+    assert builder.forwarded_request_text(message=as_message(fake=forward)) == "draw a cat"
 
     # A normal message (no snapshots) yields no forwarded request text.
-    assert builder.forwarded_request_text(message=FakeMessage(content="hi")) == ""
+    assert builder.forwarded_request_text(message=as_message(fake=FakeMessage(content="hi"))) == ""
 
 
 def test_extract_embed_text_includes_embed_url() -> None:
@@ -2687,30 +2751,39 @@ async def test_gen_reply_message_content_and_attachment_helpers(
 
     self_mention = FakeMessage(content="你的審美跟 <@999> 一樣", author=FakeAuthor(user_id=1))
     assert (
-        await cog.input_builder.get_cleaned_content(message=self_mention) == self_mention.content
+        await cog.input_builder.get_cleaned_content(message=as_message(fake=self_mention))
+        == self_mention.content
     )
 
     bot_message = FakeMessage(
         content="answer\n\n-# model · ⬆ 1 ⬇ 2 · $0.0 · +3",
         author=FakeAuthor(bot=True, user_id=999),
     )
-    assert await cog.input_builder.get_cleaned_content(message=bot_message) == "answer"
+    assert (
+        await cog.input_builder.get_cleaned_content(message=as_message(fake=bot_message))
+        == "answer"
+    )
     assert USAGE_FOOTER_RE.search(string=bot_message.content)
 
     embed_message = FakeMessage()
     embed_message.embeds = [embed]
-    assert "Title" in await cog.input_builder.get_cleaned_content(message=embed_message)
+    assert "Title" in await cog.input_builder.get_cleaned_content(
+        message=as_message(fake=embed_message)
+    )
 
     system_message = FakeMessage()
     system_message.system_content = "joined"
-    assert await cog.input_builder.get_cleaned_content(message=system_message) == "joined"
+    assert (
+        await cog.input_builder.get_cleaned_content(message=as_message(fake=system_message))
+        == "joined"
+    )
 
     assert cog.input_builder.required_modality(content_type="video/mp4") == "video"
     assert cog.input_builder.required_modality(content_type="audio/mpeg") == "audio"
     assert cog.input_builder.required_modality(content_type="application/pdf") == "image"
 
     file_rendered = await cog.input_builder.attachment_handler.render_file(
-        attachment=FakeAttachment(filename="note.txt", content_type="text/plain", payload=b"abc"),
+        attachment=_att(filename="note.txt", content_type="text/plain", payload=b"abc"),
         cache_key="note.txt",
     )
     assert file_rendered is not None
@@ -2720,7 +2793,7 @@ async def test_gen_reply_message_content_and_attachment_helpers(
     assert file_expiry == datetime(2099, 1, 1, tzinfo=UTC)
 
     image_rendered = await cog.input_builder.attachment_handler.render_image(
-        source=FakeAttachment(
+        source=_att(
             filename="pixel.png", content_type="image/png", payload=base64.b64decode(_png_b64())
         ),
         cache_key="pixel.png",
@@ -2752,7 +2825,7 @@ async def test_gen_reply_message_content_and_attachment_helpers(
         "discordbot.cogs._gen_reply.attachment.loaders.get_image_data",
         lambda image_file: base64.b64decode(_png_b64()),
     )
-    parts = await cog.input_builder.get_attachment_parts(message=message)
+    parts = await cog.input_builder.get_attachment_parts(message=as_message(fake=message))
     assert [part["type"] for part in parts] == ["input_file", "input_file", "input_file"]
 
 
@@ -2894,7 +2967,7 @@ async def test_openai_file_uploader_renders_image_and_file_parts(
     renderer = _fake_openai_uploader(files=files)
 
     image_rendered = await renderer.render_image(
-        source=FakeAttachment(
+        source=_att(
             filename="pic.png", content_type="image/png", payload=base64.b64decode(_png_b64())
         ),
         cache_key="pic.png",
@@ -2917,9 +2990,7 @@ async def test_openai_file_uploader_renders_image_and_file_parts(
     assert url_image_part["file_id"] == "file-test"
 
     file_rendered = await renderer.render_file(
-        attachment=FakeAttachment(
-            filename="notes.txt", content_type="text/plain", payload=b"hello world"
-        ),
+        attachment=_att(filename="notes.txt", content_type="text/plain", payload=b"hello world"),
         cache_key="notes.txt",
     )
     assert file_rendered is not None
@@ -2998,9 +3069,7 @@ async def test_grok_file_uploader_uploads_files_and_inlines_images() -> None:
     renderer = _fake_grok_uploader(files=files)
 
     file_rendered = await renderer.render_file(
-        attachment=FakeAttachment(
-            filename="notes.txt", content_type="text/plain", payload=b"hello world"
-        ),
+        attachment=_att(filename="notes.txt", content_type="text/plain", payload=b"hello world"),
         cache_key="notes.txt",
     )
     assert file_rendered is not None
@@ -3012,7 +3081,7 @@ async def test_grok_file_uploader_uploads_files_and_inlines_images() -> None:
 
     # xAI resolves no file id for image input, so an image is inlined instead of uploaded.
     image_rendered = await renderer.render_image(
-        source=FakeAttachment(
+        source=_att(
             filename="pic.png", content_type="image/png", payload=base64.b64decode(_png_b64())
         ),
         cache_key="pic.png",
@@ -3020,7 +3089,9 @@ async def test_grok_file_uploader_uploads_files_and_inlines_images() -> None:
     assert image_rendered is not None
     image_part, _image_expiry = image_rendered
     assert image_part["type"] == "input_image"
-    assert image_part["image_url"].startswith("data:image/")
+    image_url = image_part["image_url"]
+    assert image_url is not None
+    assert image_url.startswith("data:image/")
 
     assert files.create_calls == [
         (
@@ -3094,7 +3165,7 @@ async def test_non_gemini_answer_model_inlines_attachments() -> None:
 
     # Image -> base64 input_image (no Files API upload).
     image_rendered = await renderer.render_image(
-        source=FakeAttachment(
+        source=_att(
             filename="pic.png", content_type="image/png", payload=base64.b64decode(_png_b64())
         ),
         cache_key="pic.png",
@@ -3102,14 +3173,14 @@ async def test_non_gemini_answer_model_inlines_attachments() -> None:
     assert image_rendered is not None
     image_part, _image_expiry = image_rendered
     assert image_part["type"] == "input_image"
-    assert image_part["image_url"].startswith("data:image/")
-    assert ";base64," in image_part["image_url"]
+    image_url = image_part["image_url"]
+    assert image_url is not None
+    assert image_url.startswith("data:image/")
+    assert ";base64," in image_url
 
     # Text/code file -> inlined as input_text with a filename header.
     text_rendered = await renderer.render_file(
-        attachment=FakeAttachment(
-            filename="notes.txt", content_type="text/plain", payload=b"hello world"
-        ),
+        attachment=_att(filename="notes.txt", content_type="text/plain", payload=b"hello world"),
         cache_key="notes.txt",
     )
     assert text_rendered is not None
@@ -3120,7 +3191,7 @@ async def test_non_gemini_answer_model_inlines_attachments() -> None:
 
     # PDF -> inlined as base64 input_file file_data (not a Files-API file_id).
     pdf_rendered = await renderer.render_file(
-        attachment=FakeAttachment(
+        attachment=_att(
             filename="doc.pdf", content_type="application/pdf", payload=b"%PDF-1.4 fake"
         ),
         cache_key="doc.pdf",
@@ -3133,7 +3204,7 @@ async def test_non_gemini_answer_model_inlines_attachments() -> None:
 
     # Non-text, non-PDF binary -> dropped.
     binary_rendered = await renderer.render_file(
-        attachment=FakeAttachment(
+        attachment=_att(
             filename="blob.bin", content_type="application/octet-stream", payload=b"\x00\x01\xff"
         ),
         cache_key="blob.bin",
@@ -3155,9 +3226,15 @@ async def test_gen_reply_processes_history_reference_and_current_messages(
     with_attachment = FakeMessage(content="see file", author=FakeAuthor(user_id=2))
     with_attachment.attachments = [FakeAttachment(filename="note.txt", content_type="text/plain")]
 
-    bot_processed = await cog.input_builder.process_single_message(message=bot_msg)
-    user_processed = await cog.input_builder.process_single_message(message=user_msg)
-    attachment_processed = await cog.input_builder.process_single_message(message=with_attachment)
+    bot_processed = await cog.input_builder.process_single_message(
+        message=as_message(fake=bot_msg)
+    )
+    user_processed = await cog.input_builder.process_single_message(
+        message=as_message(fake=user_msg)
+    )
+    attachment_processed = await cog.input_builder.process_single_message(
+        message=as_message(fake=with_attachment)
+    )
     assert bot_processed["role"] == "assistant"
     assert user_processed["role"] == "user"
     assert attachment_processed["role"] == "user"
@@ -3172,7 +3249,7 @@ async def test_gen_reply_processes_history_reference_and_current_messages(
 
     current = FakeMessage(content="current", author=FakeAuthor(user_id=3))
     current.channel = FakeChannel(history=fake_history)
-    raw_history = await cog._fetch_history(message=current, limit=30)
+    raw_history = await cog._fetch_history(message=as_message(fake=current), limit=30)
     rendered = await cog._render_history(raw_history, text_only=False)
     assert len(rendered) == 3
     assert rendered[0]["role"] == "system"
@@ -3185,10 +3262,10 @@ async def test_gen_reply_processes_history_reference_and_current_messages(
     parent.reference = FakeReference(resolved=grandparent)
     current.reference = FakeReference(resolved=parent)
     monkeypatch.setattr("discordbot.cogs.gen_reply.Message", FakeMessage)
-    reference = await cog._get_reference_message(message=current)
+    reference = await cog._get_reference_message(message=as_message(fake=current))
     assert len(reference) == 4
     assert reference[0]["role"] == "system"
-    assert len(await cog._get_current_message(message=current)) == 2
+    assert len(await cog._get_current_message(message=as_message(fake=current))) == 2
 
 
 async def test_gen_reply_preserves_bot_mention_in_text_context() -> None:
@@ -3198,7 +3275,7 @@ async def test_gen_reply_preserves_bot_mention_in_text_context() -> None:
         content="你的審美跟 <@999> 一樣 這樣算誇獎嗎", author=FakeAuthor(user_id=1)
     )
 
-    processed = await cog.input_builder.process_single_message(message=message)
+    processed = await cog.input_builder.process_single_message(message=as_message(fake=message))
     rendered = processed["content"]
 
     assert isinstance(rendered, str)
@@ -3210,38 +3287,36 @@ async def test_gen_reply_routes_and_handlers_without_api(monkeypatch: pytest.Mon
     cog = _cog()
     message = FakeMessage(content="make a summary", author=FakeAuthor(user_id=1))
     assert (await _route(cog=cog, message=message)).decision == "SUMMARY"
-    assert cog.openai_client.responses.parse_models[0] == cog.runtime_models.fast_model.name
+    assert _recorded(cog).responses.parse_models[0] == cog.runtime_models.fast_model.name
 
     async def fake_sleep(delay: float) -> None:
         """Skips video polling delay."""
 
     monkeypatch.setattr("discordbot.cogs.gen_reply.asyncio.sleep", fake_sleep)
     await cog._handle_video_reply(
-        message=message,
+        message=as_message(fake=message),
         user_prompt="video",
         context_task=asyncio.create_task(_ready_reply_context()),
     )
     assert len(message.replies) == 1
     # Text-to-video: the (director-expanded) request reaches omni as the interaction input text.
-    create_input = cog.gemini_client.create_inputs[0]
+    create_input = _recorded_video(cog).create_inputs[0]
     assert [part["text"] for part in create_input if part["type"] == "text"] == ["video"]
 
     await cog._handle_image_reply(
-        message=message,
+        message=as_message(fake=message),
         user_prompt="image",
         context_task=asyncio.create_task(_ready_reply_context()),
     )
-    assert cog.openai_client.images.generate_calls
+    assert _recorded(cog).images.generate_calls
     # No director: the raw request reaches images.generate directly.
-    assert cog.openai_client.images.generate_prompts == ["image"]
+    assert _recorded(cog).images.generate_prompts == ["image"]
     # The image is delivered first, then a conversational reply streams onto that same
     # message via the flash media_reply_model with no tools.
     assert message.replies[-1].file is not None
-    assert (
-        cog.openai_client.responses.create_models[-1] == cog.runtime_models.media_reply_model.name
-    )
-    assert cog.openai_client.responses.create_streams[-1] is True
-    assert cog.openai_client.responses.create_tools[-1] is None
+    assert _recorded(cog).responses.create_models[-1] == cog.runtime_models.media_reply_model.name
+    assert _recorded(cog).responses.create_streams[-1] is True
+    assert _recorded(cog).responses.create_tools[-1] is None
 
     streamed: list[FakeMessage] = []
 
@@ -3286,7 +3361,7 @@ async def test_gen_reply_routes_and_handlers_without_api(monkeypatch: pytest.Mon
     await _reply_via_pipeline(
         cog=cog, message=message, system_prompt="system", memory_enabled=False
     )
-    assert cog.openai_client.responses.create_streams[-1] is True
+    assert _recorded(cog).responses.create_streams[-1] is True
     assert streamed[-1] is message
 
 
@@ -3309,10 +3384,12 @@ async def test_uploaded_image_without_extension_marks_as_image(
     ]
 
     # Classification is by content_type, not filename, so the marker render needs no upload.
-    rendered = await cog.input_builder.process_single_message_text_only(message=message)
+    rendered = await cog.input_builder.process_single_message_text_only(
+        message=as_message(fake=message)
+    )
     parts = rendered["content"]
     assert isinstance(parts, list)
-    assert parts[-1]["text"] == "[attachment: image]"
+    assert step_dicts(steps=parts)[-1]["text"] == "[attachment: image]"
 
 
 async def test_text_only_and_full_render_agree_on_attachment_count(
@@ -3331,8 +3408,10 @@ async def test_text_only_and_full_render_agree_on_attachment_count(
         FakeAttachment(filename="clip.mp4", content_type="video/mp4", payload=b"v"),
     ]
 
-    text_only = await cog.input_builder.process_single_message_text_only(message=message)
-    full = await cog.input_builder.process_single_message(message=message)
+    text_only = await cog.input_builder.process_single_message_text_only(
+        message=as_message(fake=message)
+    )
+    full = await cog.input_builder.process_single_message(message=as_message(fake=message))
 
     text_markers = [
         part
@@ -3364,7 +3443,9 @@ async def test_text_only_render_degrades_when_modality_lookup_fails(
         FakeAttachment(filename="pic.png", content_type="image/png", payload=b"x")
     ]
 
-    rendered = await cog.input_builder.process_single_message_text_only(message=message)
+    rendered = await cog.input_builder.process_single_message_text_only(
+        message=as_message(fake=message)
+    )
 
     assert rendered == EasyInputMessageParam(role="user", content="")
 
@@ -3426,7 +3507,7 @@ async def test_prompt_generator_error_falls_back_to_raw() -> None:
         del args, kwargs
         raise RuntimeError("director boom")
 
-    client.responses.create = _boom  # type: ignore[method-assign]  # simulating a failing call
+    client.responses.__dict__["create"] = _boom  # instance attr shadows the recorder method
     generator = PromptGenerator(client=client, prompt_model=RuntimeModelCatalog().prompt_model)
 
     refined = await generator.refine(
@@ -3469,43 +3550,40 @@ async def test_handle_image_reply_edits_attached_image(monkeypatch: pytest.Monke
     ]
 
     await cog._handle_image_reply(
-        message=message,
+        message=as_message(fake=message),
         user_prompt="make it blue",
         context_task=asyncio.create_task(_ready_reply_context()),
     )
 
-    assert cog.openai_client.images.edit_calls == 1
-    assert cog.openai_client.images.generate_calls == 0
+    assert _recorded(cog).images.edit_calls == 1
+    assert _recorded(cog).images.generate_calls == 0
 
 
 async def test_handle_image_reply_refines_prompt_before_generate() -> None:
     """The prompt director expands the raw request and the refined prompt reaches images.generate."""
     cog = _cog()
-    cog.openai_client.responses.refine_output_text = "a photorealistic tabby cat, studio lighting"
+    _recorded(cog).responses.refine_output_text = "a photorealistic tabby cat, studio lighting"
     message = FakeMessage(content="畫一隻貓", author=FakeAuthor(user_id=1))
 
     await cog._handle_image_reply(
-        message=message,
+        message=as_message(fake=message),
         user_prompt="draw a cat",
         context_task=asyncio.create_task(_ready_reply_context()),
     )
 
     # The refined prompt (not the raw request) reaches images.generate.
-    assert cog.openai_client.images.generate_prompts == [
+    assert _recorded(cog).images.generate_prompts == [
         "a photorealistic tabby cat, studio lighting"
     ]
     # Two responses.create calls: the non-streaming director first, then the streaming persona reply.
-    assert cog.openai_client.responses.create_streams == [False, True]
-    assert cog.openai_client.responses.create_models == [
+    assert _recorded(cog).responses.create_streams == [False, True]
+    assert _recorded(cog).responses.create_models == [
         cog.runtime_models.prompt_model.name,
         cog.runtime_models.media_reply_model.name,
     ]
     # The director runs on IMAGE_PROMPT with the grounding tools available.
-    assert cog.openai_client.responses.create_instructions[0] == IMAGE_PROMPT
-    assert cog.openai_client.responses.create_tools[0] == [
-        {"googleSearch": {}},
-        {"urlContext": {}},
-    ]
+    assert _recorded(cog).responses.create_instructions[0] == IMAGE_PROMPT
+    assert _recorded(cog).responses.create_tools[0] == [{"googleSearch": {}}, {"urlContext": {}}]
 
 
 async def test_handle_image_reply_refine_disabled_sends_raw_prompt() -> None:
@@ -3515,15 +3593,15 @@ async def test_handle_image_reply_refine_disabled_sends_raw_prompt() -> None:
     message = FakeMessage(content="畫一隻貓", author=FakeAuthor(user_id=1))
 
     await cog._handle_image_reply(
-        message=message,
+        message=as_message(fake=message),
         user_prompt="draw a cat",
         context_task=asyncio.create_task(_ready_reply_context()),
     )
 
     # The raw prompt reaches images.generate; the only create is the streaming persona reply.
-    assert cog.openai_client.images.generate_prompts == ["draw a cat"]
-    assert cog.openai_client.responses.create_streams == [True]
-    assert cog.openai_client.responses.create_models == [cog.runtime_models.media_reply_model.name]
+    assert _recorded(cog).images.generate_prompts == ["draw a cat"]
+    assert _recorded(cog).responses.create_streams == [True]
+    assert _recorded(cog).responses.create_models == [cog.runtime_models.media_reply_model.name]
 
 
 async def test_handle_image_reply_injects_only_user_memory() -> None:
@@ -3541,12 +3619,14 @@ async def test_handle_image_reply_injects_only_user_memory() -> None:
         return context
 
     await cog._handle_image_reply(
-        message=message, user_prompt="draw a cat", context_task=asyncio.create_task(_ready())
+        message=as_message(fake=message),
+        user_prompt="draw a cat",
+        context_task=asyncio.create_task(_ready()),
     )
 
     # The streamed reply is the last create; the user memory block rides in it, then the
     # tone note, mirroring the answer path's order; the server memory never does.
-    reply_input = cog.openai_client.responses.create_inputs[-1]
+    reply_input = step_dicts(steps=_recorded(cog).responses.create_inputs[-1])
     contents = [block.get("content") for block in reply_input]
     assert "USER_MEM_MARKER" in contents
     assert "TONE_MARKER" in contents
@@ -3576,7 +3656,7 @@ async def test_handle_image_reply_best_effort_when_reply_fails(
     monkeypatch.setattr("discordbot.cogs.gen_reply.ResponseStreamer", BoomResponder)
 
     await cog._handle_image_reply(
-        message=message,
+        message=as_message(fake=message),
         user_prompt="draw a cat",
         context_task=asyncio.create_task(_ready_reply_context()),
     )
@@ -3597,7 +3677,7 @@ async def test_handle_image_reply_hosts_oversized_image_on_separate_message(
     message.guild = FakeGuild(filesize_limit=4)  # tiny ceiling -> the generated PNG is oversized
 
     await cog._handle_image_reply(
-        message=message,
+        message=as_message(fake=message),
         user_prompt="draw a cat",
         context_task=asyncio.create_task(_ready_reply_context()),
     )
@@ -3643,7 +3723,7 @@ async def test_handle_image_reply_hosted_persona_failure_deletes_orphan_base(
     monkeypatch.setattr("discordbot.cogs.gen_reply.ResponseStreamer", _BoomStreamer)
 
     await cog._handle_image_reply(
-        message=message,
+        message=as_message(fake=message),
         user_prompt="draw a cat",
         context_task=asyncio.create_task(_ready_reply_context()),
     )
@@ -3667,19 +3747,19 @@ async def test_handle_image_reply_raises_when_oversized_and_hosting_off() -> Non
     """
     cog = _cog()
     cog.__dict__["media_delivery"] = MediaDeliveryPlanner(
-        media_hosting=MediaHostingService(config=MediaHostingConfig(MEDIA_HOSTING_ENABLED=False))
+        media_hosting=MediaHostingService(config=make_media_hosting_config(enabled=False))
     )
     message = FakeMessage(content="畫一隻貓", author=FakeAuthor(user_id=1))
     message.guild = FakeGuild(filesize_limit=4)  # tiny ceiling -> the generated PNG is oversized
     # The native attach of an oversized file 400s on real Discord; the fake raises it on reply.
     message.reply_error = nextcord.HTTPException(
-        SimpleNamespace(status=413, reason="Payload Too Large"),
+        cast("ClientResponse", SimpleNamespace(status=413, reason="Payload Too Large")),
         {"code": 40005, "message": "Request entity too large"},
     )
 
     with pytest.raises(nextcord.HTTPException):
         await cog._handle_image_reply(
-            message=message,
+            message=as_message(fake=message),
             user_prompt="draw a cat",
             context_task=asyncio.create_task(_ready_reply_context()),
         )
@@ -3709,7 +3789,7 @@ async def test_handle_video_reply_oversized_upload_failure_leaves_no_orphan(
     message.guild = FakeGuild(filesize_limit=1)  # below the 3-byte fake clip -> oversized
 
     await cog._handle_video_reply(
-        message=message,
+        message=as_message(fake=message),
         user_prompt="video",
         context_task=asyncio.create_task(_ready_reply_context()),
     )
@@ -3728,7 +3808,7 @@ async def test_handle_video_reply_refines_prompt_before_render(
 ) -> None:
     """The prompt director expands the raw request and the refined prompt reaches omni."""
     cog = _cog()
-    cog.openai_client.responses.refine_output_text = "a cat leaping in slow motion, camera pan"
+    _recorded(cog).responses.refine_output_text = "a cat leaping in slow motion, camera pan"
 
     async def fake_sleep(delay: float) -> None:
         """Skips video polling delay."""
@@ -3737,30 +3817,30 @@ async def test_handle_video_reply_refines_prompt_before_render(
     message = FakeMessage(content="拍一段影片", author=FakeAuthor(user_id=1))
 
     await cog._handle_video_reply(
-        message=message,
+        message=as_message(fake=message),
         user_prompt="video",
         context_task=asyncio.create_task(_ready_reply_context()),
     )
 
     # The director runs on VIDEO_PROMPT first, then the streaming reply about the video.
-    assert cog.openai_client.responses.create_streams == [False, True]
-    assert cog.openai_client.responses.create_models == [
+    assert _recorded(cog).responses.create_streams == [False, True]
+    assert _recorded(cog).responses.create_models == [
         cog.runtime_models.prompt_model.name,
         cog.runtime_models.media_reply_model.name,
     ]
-    assert cog.openai_client.responses.create_instructions[0] == VIDEO_PROMPT
+    assert _recorded(cog).responses.create_instructions[0] == VIDEO_PROMPT
     # The reply (the last create) watches the generated video: referenced as an input_file part.
-    reply_parts = cog.openai_client.responses.create_inputs[-1][-1]["content"]
+    reply_parts = step_dicts(steps=_recorded(cog).responses.create_inputs[-1])[-1]["content"]
     assert any(part.get("type") == "input_file" for part in reply_parts)
     # No attachments: the refined prompt reaches omni as input text; the task is omitted so omni
     # infers text_to_video, and the fixed 16:9 aspect ratio is still sent for pure text.
-    create_input = cog.gemini_client.create_inputs[0]
+    create_input = _recorded_video(cog).create_inputs[0]
     assert [part["text"] for part in create_input if part["type"] == "text"] == [
         "a cat leaping in slow motion, camera pan"
     ]
     assert not any(part["type"] == "image" for part in create_input)
-    assert cog.gemini_client.create_configs[0] is None
-    assert cog.gemini_client.create_response_formats[0]["aspect_ratio"] == "16:9"
+    assert _recorded_video(cog).create_configs[0] is None
+    assert _recorded_video(cog).create_response_formats[0]["aspect_ratio"] == "16:9"
     assert message.replies[-1].file is not None
 
 
@@ -3778,17 +3858,17 @@ async def test_handle_video_reply_refine_disabled_sends_raw_prompt(
     message = FakeMessage(content="拍一段影片", author=FakeAuthor(user_id=1))
 
     await cog._handle_video_reply(
-        message=message,
+        message=as_message(fake=message),
         user_prompt="video",
         context_task=asyncio.create_task(_ready_reply_context()),
     )
 
     # The raw prompt reaches omni as input text; the only create is the streaming persona reply
     # (no non-streaming refine call).
-    create_input = cog.gemini_client.create_inputs[0]
+    create_input = _recorded_video(cog).create_inputs[0]
     assert [part["text"] for part in create_input if part["type"] == "text"] == ["video"]
-    assert cog.openai_client.responses.create_streams == [True]
-    assert cog.openai_client.responses.create_models == [cog.runtime_models.media_reply_model.name]
+    assert _recorded(cog).responses.create_streams == [True]
+    assert _recorded(cog).responses.create_models == [cog.runtime_models.media_reply_model.name]
 
 
 async def test_handle_video_reply_edits_source_video(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -3811,21 +3891,21 @@ async def test_handle_video_reply_edits_source_video(monkeypatch: pytest.MonkeyP
     message = FakeMessage(content="把這部影片做成新的", author=FakeAuthor(user_id=1))
 
     await cog._handle_video_reply(
-        message=message,
+        message=as_message(fake=message),
         user_prompt="make it snowy",
         context_task=asyncio.create_task(_ready_reply_context()),
     )
 
-    create_input = cog.gemini_client.create_inputs[0]
+    create_input = _recorded_video(cog).create_inputs[0]
     # The actual clip rides as a video part (uploaded to the Files API), edited in place.
     assert any(part["type"] == "video" for part in create_input)
-    assert cog.gemini_client.create_configs[0]["video_config"]["task"] == "edit"
+    assert _recorded_video(cog).create_configs[0]["video_config"]["task"] == "edit"
     # The director is skipped for edits, so the raw request reaches omni unchanged and the proxy
     # only ever runs the streaming persona reply (never a non-streaming refine call).
     assert [part["text"] for part in create_input if part["type"] == "text"] == ["make it snowy"]
-    assert cog.openai_client.responses.create_streams == [True]
+    assert _recorded(cog).responses.create_streams == [True]
     # An edit keeps the source clip's ratio, so no aspect_ratio is sent (omni 400s it otherwise).
-    assert "aspect_ratio" not in cog.gemini_client.create_response_formats[0]
+    assert "aspect_ratio" not in _recorded_video(cog).create_response_formats[0]
 
 
 async def test_download_output_video_retries_until_ready(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -3875,19 +3955,19 @@ async def test_handle_video_reply_passes_reference_images(monkeypatch: pytest.Mo
     ]
 
     await cog._handle_video_reply(
-        message=message,
+        message=as_message(fake=message),
         user_prompt="video",
         context_task=asyncio.create_task(_ready_reply_context()),
     )
 
     # Images cap at three and each MUST carry a real, non-empty image mime (omni 400s an empty mime,
     # the reported bug); the task is omitted so omni infers image_to_video vs reference_to_video.
-    create_input = cog.gemini_client.create_inputs[0]
+    create_input = _recorded_video(cog).create_inputs[0]
     image_parts = [part for part in create_input if part["type"] == "image"]
     assert len(image_parts) == 3
     assert all(part["data"] for part in image_parts)
     assert all(part.get("mime_type", "").startswith("image/") for part in image_parts)
-    assert cog.gemini_client.create_configs[0] is None
+    assert _recorded_video(cog).create_configs[0] is None
 
 
 async def test_handle_video_reply_single_image_sends_mime_no_aspect_ratio(
@@ -3908,7 +3988,7 @@ async def test_handle_video_reply_single_image_sends_mime_no_aspect_ratio(
     ]
 
     await cog._handle_video_reply(
-        message=message,
+        message=as_message(fake=message),
         user_prompt="video",
         context_task=asyncio.create_task(_ready_reply_context()),
     )
@@ -3916,12 +3996,12 @@ async def test_handle_video_reply_single_image_sends_mime_no_aspect_ratio(
     # The single image carries its mime (this is exactly what was empty before, causing the 400);
     # no aspect_ratio is sent (omni may pick image_to_video, which follows the source frame's ratio),
     # and the task is omitted so omni infers image_to_video.
-    create_input = cog.gemini_client.create_inputs[0]
+    create_input = _recorded_video(cog).create_inputs[0]
     image_parts = [part for part in create_input if part["type"] == "image"]
     assert len(image_parts) == 1
     assert image_parts[0].get("mime_type", "").startswith("image/")
-    assert "aspect_ratio" not in cog.gemini_client.create_response_formats[0]
-    assert cog.gemini_client.create_configs[0] is None
+    assert "aspect_ratio" not in _recorded_video(cog).create_response_formats[0]
+    assert _recorded_video(cog).create_configs[0] is None
 
 
 @pytest.mark.parametrize(
@@ -3938,7 +4018,7 @@ async def test_gen_reply_routes_url_summary_requests_to_qa(content: str) -> None
 
     routed = await _route(cog=cog, message=message)
     assert routed.decision == "QA"
-    assert cog.openai_client.responses.parse_models[0] == cog.runtime_models.fast_model.name
+    assert _recorded(cog).responses.parse_models[0] == cog.runtime_models.fast_model.name
 
 
 @pytest.mark.parametrize(
@@ -3970,7 +4050,7 @@ async def test_gen_reply_routes_url_summary_requests_to_qa(content: str) -> None
 )
 async def test_gen_reply_on_message_dispatches_routes(  # noqa: PLR0913, PLR0915 -- parametrized columns; orchestrates per-route stubs
     monkeypatch: pytest.MonkeyPatch,
-    route: str,
+    route: Literal["IMAGE", "VIDEO", "QA", "SUMMARY"],
     expected_call: str,
     expected_prep: list[tuple[int, bool]],
     expected_flags: list[bool],
@@ -3983,7 +4063,7 @@ async def test_gen_reply_on_message_dispatches_routes(  # noqa: PLR0913, PLR0915
     cog = _cog()
     # Distinctive non-fallback grade so the effort reaching the answer model is checked to
     # be the graded value, not the "high" default that timeout/error would also produce.
-    cog.openai_client.responses.effort_parsed = EffortGrade(effort="low")
+    _recorded(cog).responses.effort_parsed = EffortGrade(effort="low")
     calls: list[str] = []
     prompts: list[str] = []
     prep_requests: list[tuple[int, bool]] = []
@@ -4076,7 +4156,7 @@ async def test_gen_reply_on_message_dispatches_routes(  # noqa: PLR0913, PLR0915
     monkeypatch.setattr(cog, "_handle_message_reply", fake_message_handler)
 
     message = FakeMessage(content="<@!999> hello", author=FakeAuthor(user_id=1))
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
     assert expected_call in calls
     assert calls[-1] == "reaction:<:greencheck:1517565102424068226>"
     # The speculative QA context always builds first; SUMMARY rebuilds at its own
@@ -4112,7 +4192,7 @@ async def test_prepare_reply_context_shields_shared_parts_task(
     cog = _cog()
     release = asyncio.Event()
 
-    async def slow_parts() -> tuple[list[object], list[object]]:
+    async def slow_parts() -> tuple[list[EasyInputMessageParam], list[EasyInputMessageParam]]:
         """Stands in for an upload still activating when the route is decided."""
         await release.wait()
         return ([], [])
@@ -4126,7 +4206,9 @@ async def test_prepare_reply_context_shields_shared_parts_task(
     parts_task = asyncio.create_task(coro=slow_parts())
     prep_task = asyncio.create_task(
         coro=cog._prepare_reply_context(
-            message=FakeMessage(content="<@999> hi", author=FakeAuthor(user_id=1)),
+            message=as_message(
+                fake=FakeMessage(content="<@999> hi", author=FakeAuthor(user_id=1))
+            ),
             history_limit=100,
             memory_enabled=False,
             parts_task=parts_task,
@@ -4152,16 +4234,16 @@ async def test_gen_reply_on_message_early_returns_and_errors(
     """Verifies bot messages, unmentioned guild messages, empty prompts, and errors."""
     cog = _cog()
     bot_authored = FakeMessage(content="<@999> hi", author=FakeAuthor(bot=True))
-    await cog.on_message(message=bot_authored)
+    await cog.on_message(message=as_message(fake=bot_authored))
     assert bot_authored.replies == []
 
     unmentioned = FakeMessage(content="hello", author=FakeAuthor(user_id=1))
-    await cog.on_message(message=unmentioned)
+    await cog.on_message(message=as_message(fake=unmentioned))
     assert unmentioned.replies == []
 
     dm_empty = FakeMessage(content="<@999>", author=FakeAuthor(user_id=1))
     dm_empty.guild = None
-    await cog.on_message(message=dm_empty)
+    await cog.on_message(message=as_message(fake=dm_empty))
     assert dm_empty.replies[0].content == "?"
 
     async def boom(
@@ -4186,13 +4268,13 @@ async def test_gen_reply_on_message_early_returns_and_errors(
     monkeypatch.setattr(cog, "_route_classify", boom)
     monkeypatch.setattr(cog, "_prepare_reply_context", fake_prepare)
     failed = FakeMessage(content="<@999> fail", author=FakeAuthor(user_id=1))
-    await cog.on_message(message=failed)
+    await cog.on_message(message=as_message(fake=failed))
     assert failed.replies[0].content is None
 
     # Source deleted before the error embed lands: it falls back to an unparented send.
     deleted = FakeMessage(content="<@999> fail", author=FakeAuthor(user_id=1))
     deleted.reply_error = _deleted_source_error()
-    await cog.on_message(message=deleted)
+    await cog.on_message(message=as_message(fake=deleted))
     assert deleted.replies == []
     assert deleted.channel.sent[0].embed is not None
 
@@ -4213,7 +4295,7 @@ async def test_on_message_forward_not_gated_as_empty(monkeypatch: pytest.MonkeyP
     dm_forward = FakeMessage(content="", author=FakeAuthor(user_id=1))
     dm_forward.guild = None
     dm_forward.snapshots = [FakeSnapshot(content="draw a cat")]
-    await cog.on_message(message=dm_forward)
+    await cog.on_message(message=as_message(fake=dm_forward))
 
     assert dm_forward.replies == []  # not gated out with "?"
     # The forwarded request reaches the pipeline as the prompt (so an IMAGE/VIDEO route is not blank).
@@ -4238,7 +4320,7 @@ async def test_on_message_commented_forward_merges_forwarded_text(
     # Guild forward: it can only trigger via the mention, so the comment survives as "please".
     message = FakeMessage(content="<@999> please", author=FakeAuthor(user_id=1))
     message.snapshots = [FakeSnapshot(content="draw a cat")]
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     # The forwarded request is merged after the comment, not dropped because the comment is non-empty.
     assert calls == [(message, "please\ndraw a cat")]
@@ -4317,7 +4399,7 @@ async def test_on_message_consumes_speculative_context_on_image_route(
     monkeypatch.setattr("discordbot.utils.reactions.update_reaction", fake_reaction)
 
     message = FakeMessage(content="<@!999> draw", author=FakeAuthor(user_id=1))
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
     assert received == [prepared]
 
 
@@ -4391,9 +4473,9 @@ def _bilibili_block(body: str = "MOCK BILIBILI VIDEO BODY") -> list[dict[str, ob
     ]
 
 
-def _link_config() -> SimpleNamespace:
+def _link_config() -> LLMConfig:
     """The config fields a QA reply carrying a linked post actually reads."""
-    return SimpleNamespace(
+    return _config_stub(
         inline_voice_enabled=False,
         inline_image_enabled=False,
         music_available=False,
@@ -4410,7 +4492,7 @@ async def test_on_message_injects_douyin_context_before_current(
 ) -> None:
     """A QA message with a Douyin URL injects the read post just before the current message."""
     cog = _cog()
-    cog.openai_client.responses.output_parsed = RouteClassification(decision="QA")
+    _recorded(cog).responses.output_parsed = RouteClassification(decision="QA")
     cog.config = _link_config()
     seen: list[tuple[str, bool]] = []
 
@@ -4429,10 +4511,10 @@ async def test_on_message_injects_douyin_context_before_current(
 
     url = "https://v.douyin.com/abc123"
     message = FakeMessage(content=f"<@999> 這在講什麼 {url}", author=FakeAuthor(user_id=1))
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     assert seen == [(url, True)]
-    answer = request_input(responses=cog.openai_client.responses, phase="answer")
+    answer = request_input(responses=_recorded(cog).responses, phase="answer")
     assert has_douyin_context_block(request=answer)
     assert extract_douyin_context_block(request=answer) == "MOCK DOUYIN POST BODY"
 
@@ -4453,7 +4535,7 @@ async def test_on_message_reads_a_linked_post_without_a_gemini_key(
     would fail the whole reply before the builder's own text-only degradation could run.
     """
     cog = _cog()
-    cog.openai_client.responses.output_parsed = RouteClassification(decision="QA")
+    _recorded(cog).responses.output_parsed = RouteClassification(decision="QA")
     cog.config = _link_config()
     cog.config.gemini_api_key = ""
     clients: list[object] = []
@@ -4474,10 +4556,10 @@ async def test_on_message_reads_a_linked_post_without_a_gemini_key(
     message = FakeMessage(
         content="<@999> 這在講什麼 https://v.douyin.com/abc123", author=FakeAuthor(user_id=1)
     )
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     assert clients == [None]
-    answer = request_input(responses=cog.openai_client.responses, phase="answer")
+    answer = request_input(responses=_recorded(cog).responses, phase="answer")
     assert has_douyin_context_block(request=answer)
 
 
@@ -4486,7 +4568,7 @@ async def test_on_message_skips_a_non_post_douyin_link(
 ) -> None:
     """A profile or live-room link is not a post, so reading it would only waste a request."""
     cog = _cog()
-    cog.openai_client.responses.output_parsed = RouteClassification(decision="QA")
+    _recorded(cog).responses.output_parsed = RouteClassification(decision="QA")
     cog.config = _link_config()
     calls: list[str] = []
 
@@ -4507,10 +4589,10 @@ async def test_on_message_skips_a_non_post_douyin_link(
         content="<@999> 這個人是誰 https://www.douyin.com/user/MS4wLjABAAAAxyz",
         author=FakeAuthor(user_id=1),
     )
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     assert calls == []
-    answer = request_input(responses=cog.openai_client.responses, phase="answer")
+    answer = request_input(responses=_recorded(cog).responses, phase="answer")
     assert not has_douyin_context_block(request=answer)
 
 
@@ -4519,7 +4601,7 @@ async def test_on_message_douyin_media_ingest_kill_switch(
 ) -> None:
     """With the switch off the builder still runs, but is told not to fetch the media."""
     cog = _cog()
-    cog.openai_client.responses.output_parsed = RouteClassification(decision="QA")
+    _recorded(cog).responses.output_parsed = RouteClassification(decision="QA")
     cog.config = _link_config()
     cog.config.douyin_video_enabled = False
     seen: list[bool] = []
@@ -4540,7 +4622,7 @@ async def test_on_message_douyin_media_ingest_kill_switch(
     message = FakeMessage(
         content="<@999> 這在講什麼 https://v.douyin.com/abc123", author=FakeAuthor(user_id=1)
     )
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     assert seen == [False]
 
@@ -4585,7 +4667,7 @@ async def test_on_message_cancels_douyin_context_on_image_route(
     message = FakeMessage(
         content="<@999> 畫這個 https://v.douyin.com/abc123", author=FakeAuthor(user_id=1)
     )
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     assert cancelled == [True]
 
@@ -4595,7 +4677,7 @@ async def test_on_message_douyin_grace_timeout_injects_notice(
 ) -> None:
     """A build slower than the post-route grace injects a timeout notice; the answer streams."""
     cog = _cog()
-    cog.openai_client.responses.output_parsed = RouteClassification(decision="QA")
+    _recorded(cog).responses.output_parsed = RouteClassification(decision="QA")
     cog.config = _link_config()
     monkeypatch.setattr("discordbot.cogs.gen_reply.LINK_CONTEXT_GRACE_SECONDS", 0.01)
 
@@ -4615,9 +4697,9 @@ async def test_on_message_douyin_grace_timeout_injects_notice(
     message = FakeMessage(
         content="<@999> 這在講什麼 https://v.douyin.com/abc123", author=FakeAuthor(user_id=1)
     )
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
-    answer = request_input(responses=cog.openai_client.responses, phase="answer")
+    answer = request_input(responses=_recorded(cog).responses, phase="answer")
     assert has_douyin_context_block(request=answer)
     assert "did not respond in time" in str(answer)
 
@@ -4627,7 +4709,7 @@ async def test_on_message_injects_threads_context_before_current(
 ) -> None:
     """A QA message with a Threads URL injects the parsed post just before the current message."""
     cog = _cog()
-    cog.openai_client.responses.output_parsed = RouteClassification(decision="QA")
+    _recorded(cog).responses.output_parsed = RouteClassification(decision="QA")
     cog.config = _link_config()
     seen_urls: list[str] = []
 
@@ -4646,10 +4728,10 @@ async def test_on_message_injects_threads_context_before_current(
 
     url = "https://www.threads.com/@a/post/ABC123"
     message = FakeMessage(content=f"<@999> what is this {url}", author=FakeAuthor(user_id=1))
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     assert seen_urls == [url]
-    answer = request_input(responses=cog.openai_client.responses, phase="answer")
+    answer = request_input(responses=_recorded(cog).responses, phase="answer")
     assert has_threads_context_block(request=answer)
     assert extract_threads_context_block(request=answer) == "MOCK THREADS POST BODY"
 
@@ -4703,7 +4785,7 @@ async def test_on_message_cancels_threads_context_on_image_route(
     message = FakeMessage(
         content="<@999> draw https://www.threads.com/@a/post/ABC123", author=FakeAuthor(user_id=1)
     )
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
     assert cancelled == [True]
 
 
@@ -4712,7 +4794,7 @@ async def test_on_message_skips_threads_context_without_url(
 ) -> None:
     """A message with no Threads URL never starts the parse and injects no block."""
     cog = _cog()
-    cog.openai_client.responses.output_parsed = RouteClassification(decision="QA")
+    _recorded(cog).responses.output_parsed = RouteClassification(decision="QA")
     cog.config = _link_config()
     called: list[str] = []
 
@@ -4728,11 +4810,11 @@ async def test_on_message_skips_threads_context_without_url(
     monkeypatch.setattr("discordbot.utils.reactions.update_reaction", _silent_reaction)
 
     message = FakeMessage(content="<@999> just a plain question", author=FakeAuthor(user_id=1))
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     assert called == []
     assert not has_threads_context_block(
-        request=request_input(responses=cog.openai_client.responses, phase="answer")
+        request=request_input(responses=_recorded(cog).responses, phase="answer")
     )
 
 
@@ -4741,7 +4823,7 @@ async def test_on_message_threads_context_grace_timeout_injects_notice(
 ) -> None:
     """A parse slower than the post-route grace injects a timeout notice; the answer streams."""
     cog = _cog()
-    cog.openai_client.responses.output_parsed = RouteClassification(decision="QA")
+    _recorded(cog).responses.output_parsed = RouteClassification(decision="QA")
     cog.config = _link_config()
     monkeypatch.setattr("discordbot.cogs.gen_reply.LINK_CONTEXT_GRACE_SECONDS", 0.01)
 
@@ -4762,11 +4844,11 @@ async def test_on_message_threads_context_grace_timeout_injects_notice(
         content="<@999> what is this https://www.threads.com/@a/post/ABC123",
         author=FakeAuthor(user_id=1),
     )
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     # The slow parse is dropped, but a deterministic timeout notice keeps the model from
     # claiming it cannot open the link, and the answer still streams.
-    answer = request_input(responses=cog.openai_client.responses, phase="answer")
+    answer = request_input(responses=_recorded(cog).responses, phase="answer")
     assert has_threads_context_block(request=answer)
     assert "did not respond in time" in str(answer)
 
@@ -4776,7 +4858,7 @@ async def test_on_message_injects_bilibili_context_before_current(
 ) -> None:
     """A QA message with a Bilibili URL injects the read video just before the current message."""
     cog = _cog()
-    cog.openai_client.responses.output_parsed = RouteClassification(decision="QA")
+    _recorded(cog).responses.output_parsed = RouteClassification(decision="QA")
     cog.config = _link_config()
     seen: list[tuple[str, bool]] = []
 
@@ -4795,10 +4877,10 @@ async def test_on_message_injects_bilibili_context_before_current(
 
     url = "https://www.bilibili.com/video/BV1jpK86hEc8"
     message = FakeMessage(content=f"<@999> 這在講什麼 {url}", author=FakeAuthor(user_id=1))
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     assert seen == [(url, True)]
-    answer = request_input(responses=cog.openai_client.responses, phase="answer")
+    answer = request_input(responses=_recorded(cog).responses, phase="answer")
     assert has_bilibili_context_block(request=answer)
     assert extract_bilibili_context_block(request=answer) == "MOCK BILIBILI VIDEO BODY"
 
@@ -4815,7 +4897,7 @@ async def test_on_message_skips_a_non_video_bilibili_link(
 ) -> None:
     """A live-room or space link is not a watchable video, so the build never starts."""
     cog = _cog()
-    cog.openai_client.responses.output_parsed = RouteClassification(decision="QA")
+    _recorded(cog).responses.output_parsed = RouteClassification(decision="QA")
     cog.config = _link_config()
     calls: list[str] = []
 
@@ -4836,10 +4918,10 @@ async def test_on_message_skips_a_non_video_bilibili_link(
         content="<@999> 這個直播間如何 https://live.bilibili.com/12345",
         author=FakeAuthor(user_id=1),
     )
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     assert calls == []
-    answer = request_input(responses=cog.openai_client.responses, phase="answer")
+    answer = request_input(responses=_recorded(cog).responses, phase="answer")
     assert not has_bilibili_context_block(request=answer)
 
 
@@ -4848,7 +4930,7 @@ async def test_on_message_bilibili_media_ingest_kill_switch(
 ) -> None:
     """With the switch off the builder still runs, but is told not to fetch the media."""
     cog = _cog()
-    cog.openai_client.responses.output_parsed = RouteClassification(decision="QA")
+    _recorded(cog).responses.output_parsed = RouteClassification(decision="QA")
     cog.config = _link_config()
     cog.config.bilibili_video_enabled = False
     seen: list[bool] = []
@@ -4870,7 +4952,7 @@ async def test_on_message_bilibili_media_ingest_kill_switch(
         content="<@999> 這在講什麼 https://www.bilibili.com/video/BV1jpK86hEc8",
         author=FakeAuthor(user_id=1),
     )
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     assert seen == [False]
 
@@ -4918,7 +5000,7 @@ async def test_on_message_cancels_bilibili_context_on_image_route(
         content="<@999> 畫這個 https://www.bilibili.com/video/BV1jpK86hEc8",
         author=FakeAuthor(user_id=1),
     )
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     assert cancelled == [True]
 
@@ -4932,7 +5014,7 @@ async def test_on_message_bilibili_keyless_disables_media_ingest(
     while holding no client to upload with.
     """
     cog = _cog()
-    cog.openai_client.responses.output_parsed = RouteClassification(decision="QA")
+    _recorded(cog).responses.output_parsed = RouteClassification(decision="QA")
     cog.config = _link_config()
     cog.config.gemini_api_key = ""
     seen: list[tuple[object, bool]] = []
@@ -4954,7 +5036,7 @@ async def test_on_message_bilibili_keyless_disables_media_ingest(
         content="<@999> 這在講什麼 https://www.bilibili.com/video/BV1jpK86hEc8",
         author=FakeAuthor(user_id=1),
     )
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     assert seen == [(None, False)]
 
@@ -5015,7 +5097,7 @@ async def test_on_message_finally_backstop_cancels_link_tasks(
         content="<@999> 這在講什麼 https://www.bilibili.com/video/BV1jpK86hEc8",
         author=FakeAuthor(user_id=1),
     )
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     assert cancelled == [True]
 
@@ -5025,7 +5107,7 @@ async def test_on_message_bilibili_grace_timeout_injects_notice(
 ) -> None:
     """A build slower than the post-route grace injects a timeout notice; the answer streams."""
     cog = _cog()
-    cog.openai_client.responses.output_parsed = RouteClassification(decision="QA")
+    _recorded(cog).responses.output_parsed = RouteClassification(decision="QA")
     cog.config = _link_config()
     monkeypatch.setattr("discordbot.cogs.gen_reply.LINK_CONTEXT_GRACE_SECONDS", 0.01)
 
@@ -5046,9 +5128,9 @@ async def test_on_message_bilibili_grace_timeout_injects_notice(
         content="<@999> 這在講什麼 https://www.bilibili.com/video/BV1jpK86hEc8",
         author=FakeAuthor(user_id=1),
     )
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
-    answer = request_input(responses=cog.openai_client.responses, phase="answer")
+    answer = request_input(responses=_recorded(cog).responses, phase="answer")
     assert has_bilibili_context_block(request=answer)
     assert "did not respond in time" in str(answer)
 
@@ -5063,7 +5145,7 @@ async def test_on_message_orders_link_blocks_in_registry_order(
     input stays deterministic however the user arranged the links.
     """
     cog = _cog()
-    cog.openai_client.responses.output_parsed = RouteClassification(decision="QA")
+    _recorded(cog).responses.output_parsed = RouteClassification(decision="QA")
     cog.config = _link_config()
 
     async def fake_threads_builder(
@@ -5107,9 +5189,9 @@ async def test_on_message_orders_link_blocks_in_registry_order(
         ),
         author=FakeAuthor(user_id=1),
     )
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
-    answer = request_input(responses=cog.openai_client.responses, phase="answer")
+    answer = request_input(responses=_recorded(cog).responses, phase="answer")
     headers = [text.split("\n", 1)[0] for _role, text in iter_text_blocks(request=answer)]
     threads_index = headers.index(THREADS_CONTEXT_SEPARATOR.split("\n", 1)[0])
     douyin_index = headers.index(DOUYIN_CONTEXT_SEPARATOR.split("\n", 1)[0])
@@ -5156,16 +5238,16 @@ async def test_handle_message_reply_orders_reference_after_memory_before_current
     parent.id = 988
     message.reference = FakeReference(resolved=parent)
 
-    cog.openai_client.responses.select_queue = [
+    _recorded(cog).responses.select_queue = [
         [_function_call_item(call_id="c0", arguments=json.dumps({"user_id_list": ["1"]}))]
     ]
-    cog.openai_client.responses.stream_queue = [
+    _recorded(cog).responses.stream_queue = [
         [_text_event(delta="好"), _completed_event(input_tokens=1, output_tokens=1)]
     ]
 
     await _reply_via_pipeline(cog=cog, message=message)
 
-    answer = request_input(responses=cog.openai_client.responses, phase="answer")
+    answer = request_input(responses=_recorded(cog).responses, phase="answer")
     blocks = list(iter_text_blocks(request=answer))
     memory_index = next(
         index
@@ -5207,16 +5289,16 @@ async def test_handle_message_reply_orders_server_memory_user_memory_then_tone(
     monkeypatch.setattr("discordbot.cogs.gen_reply.schedule_memory_update", lambda **kwargs: None)
 
     message = FakeMessage(content="<@999> hi", author=FakeAuthor(user_id=1))
-    cog.openai_client.responses.select_queue = [
+    _recorded(cog).responses.select_queue = [
         [_function_call_item(call_id="c0", arguments=json.dumps({"user_id_list": ["1"]}))]
     ]
-    cog.openai_client.responses.stream_queue = [
+    _recorded(cog).responses.stream_queue = [
         [_text_event(delta="好"), _completed_event(input_tokens=1, output_tokens=1)]
     ]
 
     await _reply_via_pipeline(cog=cog, message=message)
 
-    answer = request_input(responses=cog.openai_client.responses, phase="answer")
+    answer = request_input(responses=_recorded(cog).responses, phase="answer")
     tone = extract_tone_block(request=answer)
     assert tone is not None
     assert "語氣輕鬆" in tone
@@ -5254,13 +5336,13 @@ async def test_summary_route_still_injects_tone_block(
     monkeypatch.setattr("discordbot.cogs.gen_reply.schedule_memory_update", lambda **kwargs: None)
 
     message = FakeMessage(content="<@999> hi", author=FakeAuthor(user_id=1))
-    cog.openai_client.responses.stream_queue = [
+    _recorded(cog).responses.stream_queue = [
         [_text_event(delta="好"), _completed_event(input_tokens=1, output_tokens=1)]
     ]
 
     await _reply_via_pipeline(cog=cog, message=message, memory_enabled=False)
 
-    answer = request_input(responses=cog.openai_client.responses, phase="answer")
+    answer = request_input(responses=_recorded(cog).responses, phase="answer")
     assert not has_memory_context_block(request=answer)
     tone = extract_tone_block(request=answer)
     assert tone is not None
@@ -5272,7 +5354,7 @@ def test_model_settings_and_config_helpers(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setenv(name="OPENAI_BASE_URL", value="https://example.test/v1")
     monkeypatch.setenv(name="OPENAI_API_KEY", value="test-key")
     catalog = RuntimeModelCatalog()
-    cog = ReplyGeneratorCogs(bot=SimpleNamespace(user=SimpleNamespace(id=999)))
+    cog = ReplyGeneratorCogs(bot=as_bot(fake=SimpleNamespace(user=SimpleNamespace(id=999))))
     assert cog.runtime_models.fast_model == catalog.fast_model
     assert isinstance(catalog.fast_model, ModelSettings)
     assert "image" in catalog.image_model.name
@@ -5378,36 +5460,35 @@ async def test_handle_message_reply_selection_offers_tool_then_answers_with_buil
     await _reply_via_pipeline(cog=cog, message=message)
 
     # Two requests: selection (non-streaming) then the answer (streaming).
-    assert cog.openai_client.responses.create_streams == [False, True]
+    assert _recorded(cog).responses.create_streams == [False, True]
 
     # Selection runs on the fast tool_model; only the answer pays for slow_model.
-    assert cog.openai_client.responses.create_models == [
+    assert _recorded(cog).responses.create_models == [
         cog.runtime_models.tool_model.name,
         cog.runtime_models.slow_model.name,
     ]
 
     # Selection request offers only get_user_memory and lists the author as callable.
-    selection_idx = request_index(responses=cog.openai_client.responses, phase="selection")
-    assert tool_names_for_call(responses=cog.openai_client.responses, n=selection_idx) == [
+    selection_idx = request_index(responses=_recorded(cog).responses, phase="selection")
+    assert tool_names_for_call(responses=_recorded(cog).responses, n=selection_idx) == [
         "get_user_memory"
     ]
     assert extract_callable_user_ids(
-        request=request_input(responses=cog.openai_client.responses, phase="selection")
+        request=request_input(responses=_recorded(cog).responses, phase="selection")
     ) == {1}
-    assert cog.openai_client.responses.create_instructions[selection_idx] == MEMORY_SELECT_PROMPT
+    assert _recorded(cog).responses.create_instructions[selection_idx] == MEMORY_SELECT_PROMPT
 
     # Answer request keeps the built-in tools (no get_user_memory) and the clean persona: the
     # author declined selection, so their stored memory is not injected.
-    answer_idx = request_index(responses=cog.openai_client.responses, phase="answer")
+    answer_idx = request_index(responses=_recorded(cog).responses, phase="answer")
     assert "get_user_memory" not in tool_names_for_call(
-        responses=cog.openai_client.responses, n=answer_idx
+        responses=_recorded(cog).responses, n=answer_idx
     )
     _assert_runtime_time_context(
-        instructions=cog.openai_client.responses.create_instructions[answer_idx],
-        system_prompt="SYS",
+        instructions=_recorded(cog).responses.create_instructions[answer_idx], system_prompt="SYS"
     )
     assert not has_memory_context_block(
-        request=request_input(responses=cog.openai_client.responses, phase="answer")
+        request=request_input(responses=_recorded(cog).responses, phase="answer")
     )
 
     # Extraction still scheduled for the author with a memory-free, tool-free list.
@@ -5422,9 +5503,9 @@ async def test_handle_message_reply_selection_offers_tool_then_answers_with_buil
     assert (
         cog.memory_extractor.extract_model.name == cog.runtime_models.memory_extractor_model.name
     )
-    assert (
-        cog.memory_extractor.evaluate_model.name == cog.runtime_models.memory_evaluator_model.name
-    )
+    evaluate_model = cog.memory_extractor.evaluate_model
+    assert evaluate_model is not None
+    assert evaluate_model.name == cog.runtime_models.memory_evaluator_model.name
     assert (
         cog.memory_extractor.consolidate_model.name
         == cog.runtime_models.memory_consolidator_model.name
@@ -5485,17 +5566,16 @@ async def test_handle_message_reply_without_stored_memory_keeps_instructions(
 
     # The selection phase still offers the tool even when nobody has stored memory; the
     # answer phase keeps the clean persona and the built-in tools.
-    selection_idx = request_index(responses=cog.openai_client.responses, phase="selection")
-    answer_idx = request_index(responses=cog.openai_client.responses, phase="answer")
+    selection_idx = request_index(responses=_recorded(cog).responses, phase="selection")
+    answer_idx = request_index(responses=_recorded(cog).responses, phase="answer")
     assert "get_user_memory" in tool_names_for_call(
-        responses=cog.openai_client.responses, n=selection_idx
+        responses=_recorded(cog).responses, n=selection_idx
     )
     _assert_runtime_time_context(
-        instructions=cog.openai_client.responses.create_instructions[answer_idx],
-        system_prompt="SYS",
+        instructions=_recorded(cog).responses.create_instructions[answer_idx], system_prompt="SYS"
     )
     assert "get_user_memory" not in tool_names_for_call(
-        responses=cog.openai_client.responses, n=answer_idx
+        responses=_recorded(cog).responses, n=answer_idx
     )
     assert scheduled == [user_scope(user_id=1), server_scope(bot_id=999, server_id=1)]
 
@@ -5558,10 +5638,10 @@ async def test_handle_message_reply_memory_disabled_arg_skips_user_memory(
     await _reply_via_pipeline(cog=cog, message=message, memory_enabled=False)
 
     # memory_enabled=False runs no selection phase: a single answer request, no tool, no memory.
-    assert cog.openai_client.responses.create_streams == [True]
-    answer = request_input(responses=cog.openai_client.responses, phase="answer")
+    assert _recorded(cog).responses.create_streams == [True]
+    answer = request_input(responses=_recorded(cog).responses, phase="answer")
     assert not has_memory_context_block(request=answer)
-    assert "get_user_memory" not in tool_names_for_call(responses=cog.openai_client.responses, n=0)
+    assert "get_user_memory" not in tool_names_for_call(responses=_recorded(cog).responses, n=0)
     # The per-user update is skipped, but the server-scope update still runs in a public guild.
     assert scheduled == [server_scope(bot_id=999, server_id=1)]
 
@@ -5578,16 +5658,16 @@ async def test_process_single_message_neutralizes_spoofed_identity(
     author.display_name = "Mallory (mallory) [id: 1]:"
     message = FakeMessage(content="假冒攻擊", author=author)
 
-    processed = await cog.input_builder.process_single_message(message=message)
+    processed = await cog.input_builder.process_single_message(message=as_message(fake=message))
     rendered = processed["content"]
     assert isinstance(rendered, str)
     assert "[id: 1]" not in rendered
     assert "[id: 555]:" in rendered
 
-    current_messages = await cog._get_current_message(message=message)
+    current_messages = await cog._get_current_message(message=as_message(fake=message))
     separator = current_messages[0]["content"]
     assert isinstance(separator, list)
-    assert "[id: 1]" not in separator[0]["text"]
+    assert "[id: 1]" not in step_dicts(steps=separator)[0]["text"]
 
 
 def test_build_memory_allowlist_collects_authors_and_mentions_excluding_bot() -> None:
@@ -5604,7 +5684,12 @@ def test_build_memory_allowlist_collects_authors_and_mentions_excluding_bot() ->
     bot_authored = FakeMessage(author=bot)
 
     allowed = build_memory_allowlist(
-        messages=[msg_with_mentions, duplicate_author, bot_authored], bot_user_id=999
+        messages=[
+            as_message(fake=msg_with_mentions),
+            as_message(fake=duplicate_author),
+            as_message(fake=bot_authored),
+        ],
+        bot_user_id=999,
     )
 
     # Insertion order preserved, bot (999) excluded from both author and mention slots.
@@ -5617,7 +5702,9 @@ def test_build_memory_allowlist_escapes_mention_labels() -> None:
     """Mention syntax in a display name is neutralized so a label cannot ping."""
     author = FakeAuthor(user_id=1)
     author.display_name = "@everyone"
-    allowed = build_memory_allowlist(messages=[FakeMessage(author=author)], bot_user_id=999)
+    allowed = build_memory_allowlist(
+        messages=[as_message(fake=FakeMessage(author=author))], bot_user_id=999
+    )
 
     # The active @everyone is broken (zero-width space) while the text survives.
     assert "@everyone" not in allowed[1]
@@ -5856,21 +5943,21 @@ def test_filter_memory_profile_gate_requires_tagged_file() -> None:
 def test_memory_read_context_by_channel_kind() -> None:
     """Guild sets guild_id; a 1:1 DM sets dm_partner_id; a guildless non-DM channel sets neither."""
     guild_message = FakeMessage(content="hi")
-    guild_context = memory_read_context(message=guild_message)
+    guild_context = memory_read_context(message=as_message(fake=guild_message))
     assert guild_context.guild_id == 1
     assert guild_context.dm_partner_id is None
 
     dm_message = FakeMessage(content="hi", author=FakeAuthor(user_id=7))
     dm_message.guild = None
     dm_message.channel = MagicMock(spec=nextcord.DMChannel)
-    dm_context = memory_read_context(message=dm_message)
+    dm_context = memory_read_context(message=as_message(fake=dm_message))
     assert dm_context.guild_id is None
     assert dm_context.dm_partner_id == 7
 
     # A group DM has no guild but is not a DMChannel, so it fail-closes to neither.
     group_message = FakeMessage(content="hi")
     group_message.guild = None
-    group_context = memory_read_context(message=group_message)
+    group_context = memory_read_context(message=as_message(fake=group_message))
     assert group_context.guild_id is None
     assert group_context.dm_partner_id is None
 
@@ -5993,19 +6080,19 @@ async def test_handle_message_reply_user_memory_injection(  # noqa: PLR0913 -- p
         parent.id = 988
         message.reference = FakeReference(resolved=parent)
 
-    cog.openai_client.responses.select_queue = [
+    _recorded(cog).responses.select_queue = [
         [
             _function_call_item(call_id=f"c{index}", arguments=json.dumps({"user_id_list": ids}))
             for index, ids in enumerate(select_id_lists)
         ]
     ]
-    cog.openai_client.responses.stream_queue = [
+    _recorded(cog).responses.stream_queue = [
         [_text_event(delta="好"), _completed_event(input_tokens=1, output_tokens=1)]
     ]
 
     await _reply_via_pipeline(cog=cog, message=message)
 
-    answer = request_input(responses=cog.openai_client.responses, phase="answer")
+    answer = request_input(responses=_recorded(cog).responses, phase="answer")
     # An allowlisted-but-memoryless user gets a placeholder block, not a leak; the boundary is
     # which ids' real memory reaches the model, so placeholder sections are filtered out.
     injected = {
@@ -6023,7 +6110,7 @@ async def test_handle_message_reply_user_memory_injection(  # noqa: PLR0913 -- p
     )
 
     callable_ids = extract_callable_user_ids(
-        request=request_input(responses=cog.openai_client.responses, phase="selection")
+        request=request_input(responses=_recorded(cog).responses, phase="selection")
     )
     assert callable_includes <= callable_ids
     assert callable_excludes.isdisjoint(callable_ids)
@@ -6121,16 +6208,16 @@ async def test_handle_message_reply_memory_footer(  # noqa: PLR0913 -- parametri
     message.mentions = mention_authors
 
     if select_usage is not None:
-        cog.openai_client.responses.select_usage = SimpleNamespace(
+        _recorded(cog).responses.select_usage = SimpleNamespace(
             input_tokens=select_usage[0], output_tokens=select_usage[1]
         )
-    cog.openai_client.responses.select_queue = [
+    _recorded(cog).responses.select_queue = [
         [
             _function_call_item(call_id=f"c{index}", arguments=json.dumps({"user_id_list": ids}))
             for index, ids in enumerate(select_id_lists)
         ]
     ]
-    cog.openai_client.responses.stream_queue = [
+    _recorded(cog).responses.stream_queue = [
         [
             _text_event(delta="好"),
             _completed_event(input_tokens=stream_usage[0], output_tokens=stream_usage[1]),
@@ -6169,7 +6256,7 @@ async def test_handle_message_reply_falls_back_to_author_memory_when_selection_f
 
     monkeypatch.setattr(cog, "_select_user_memories", boom)
 
-    cog.openai_client.responses.stream_queue = [
+    _recorded(cog).responses.stream_queue = [
         [_text_event(delta="照常回答"), _completed_event(input_tokens=5, output_tokens=6)]
     ]
 
@@ -6178,7 +6265,7 @@ async def test_handle_message_reply_falls_back_to_author_memory_when_selection_f
 
     # The answer request still ran, and the author's own memory was injected as the fallback.
     assert (message.replies[0].content or "").startswith("照常回答")
-    answer = request_input(responses=cog.openai_client.responses, phase="answer")
+    answer = request_input(responses=_recorded(cog).responses, phase="answer")
     assert "甲" in (extract_user_memory_blocks(request=answer).get(1) or "")
 
 
@@ -6248,13 +6335,13 @@ async def test_handle_message_reply_server_memory_gating(  # noqa: PLR0913 -- pa
     )
     if not has_guild:
         message.guild = None
-    cog.openai_client.responses.stream_queue = [
+    _recorded(cog).responses.stream_queue = [
         [_text_event(delta="好"), _completed_event(input_tokens=1, output_tokens=1)]
     ]
 
     await _reply_via_pipeline(cog=cog, message=message, memory_enabled=memory_enabled)
 
-    answer = request_input(responses=cog.openai_client.responses, phase="answer")
+    answer = request_input(responses=_recorded(cog).responses, phase="answer")
     assert (extract_server_memory_block(request=answer) is not None) == expect_server_read
 
     server_scope_value = server_scope(bot_id=999, server_id=1)
@@ -6278,7 +6365,7 @@ async def test_handle_message_reply_server_memory_gating(  # noqa: PLR0913 -- pa
     # On a memory-enabled guild turn the selection request also sees the server memory so it can
     # resolve nicknames; non-guild or SUMMARY turns run no selection phase.
     if memory_enabled and has_guild:
-        selection = request_input(responses=cog.openai_client.responses, phase="selection")
+        selection = request_input(responses=_recorded(cog).responses, phase="selection")
         assert extract_server_memory_block(request=selection) is not None
 
 
@@ -6444,7 +6531,7 @@ async def test_streamer_edits_are_time_throttled(economy_isolated_db: None) -> N
         yield _completed_event(input_tokens=1, output_tokens=1)
 
     streamer = ResponseStreamer(message=message, preview_interval_seconds=0.02)
-    result = await streamer.stream(responses=_events())
+    result = await streamer.stream(responses=cast("AsyncIterator[ResponseStreamEvent]", _events()))
 
     assert len(message.replies) == 1
     reply = message.replies[0]
@@ -6470,18 +6557,18 @@ async def test_streamer_footer_shows_route_effort(economy_isolated_db: None) -> 
 async def test_route_classify_carries_decision_and_defaults_qa() -> None:
     """The route classifies the reply mode; unparsed output falls back to QA."""
     cog = _cog()
-    cog.openai_client.responses.output_parsed = RouteClassification(decision="IMAGE")
+    _recorded(cog).responses.output_parsed = RouteClassification(decision="IMAGE")
     message = FakeMessage(content="draw a cat", author=FakeAuthor(user_id=1))
     assert (await _route(cog=cog, message=message)).decision == "IMAGE"
 
-    cog.openai_client.responses.output_parsed = None
+    _recorded(cog).responses.output_parsed = None
     assert (await _route(cog=cog, message=message)).decision == "QA"
 
 
 async def test_route_url_summary_downgrades_to_qa() -> None:
     """A SUMMARY classification on a message carrying a URL is steered back to QA."""
     cog = _cog()
-    cog.openai_client.responses.output_parsed = RouteClassification(decision="SUMMARY")
+    _recorded(cog).responses.output_parsed = RouteClassification(decision="SUMMARY")
     message = FakeMessage(content="整理 https://example.test/a", author=FakeAuthor(user_id=1))
 
     assert (await _route(cog=cog, message=message)).decision == "QA"
@@ -6490,11 +6577,11 @@ async def test_route_url_summary_downgrades_to_qa() -> None:
 async def test_grade_effort_carries_grade_and_defaults_high() -> None:
     """The effort grader returns the model's grade; unparsed output falls back to high."""
     cog = _cog()
-    cog.openai_client.responses.effort_parsed = EffortGrade(effort="low")
+    _recorded(cog).responses.effort_parsed = EffortGrade(effort="low")
     message = FakeMessage(content="hi", author=FakeAuthor(user_id=1))
     assert (await _grade(cog=cog, message=message)).effort == "low"
 
-    cog.openai_client.responses.effort_parsed = None
+    _recorded(cog).responses.effort_parsed = None
     assert (await _grade(cog=cog, message=message)).effort == "high"
 
 
@@ -6511,7 +6598,7 @@ async def test_resolve_effort_returns_graded_effort_on_success() -> None:
     effort_task = asyncio.create_task(coro=graded())
     assert (
         await cog._resolve_effort(
-            message=FakeMessage(), effort_task=effort_task, route_done=route_done
+            message=as_message(fake=FakeMessage()), effort_task=effort_task, route_done=route_done
         )
         == "low"
     )
@@ -6530,7 +6617,7 @@ async def test_resolve_effort_defaults_high_on_error() -> None:
     effort_task = asyncio.create_task(coro=boom())
     assert (
         await cog._resolve_effort(
-            message=FakeMessage(), effort_task=effort_task, route_done=route_done
+            message=as_message(fake=FakeMessage()), effort_task=effort_task, route_done=route_done
         )
         == "high"
     )
@@ -6553,7 +6640,7 @@ async def test_resolve_effort_defaults_high_on_grace_timeout(
     effort_task = asyncio.create_task(coro=slow())
     assert (
         await cog._resolve_effort(
-            message=FakeMessage(), effort_task=effort_task, route_done=route_done
+            message=as_message(fake=FakeMessage()), effort_task=effort_task, route_done=route_done
         )
         == "high"
     )
@@ -6616,7 +6703,7 @@ async def test_on_message_cancels_effort_task_on_image_route(
     monkeypatch.setattr("discordbot.utils.reactions.update_reaction", fake_reaction)
 
     message = FakeMessage(content="<@!999> draw", author=FakeAuthor(user_id=1))
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
     assert cancelled == [True]
 
 
@@ -6628,7 +6715,7 @@ async def test_handle_message_reply_uses_route_effort(economy_isolated_db: None)
 
     await _reply_via_pipeline(cog=cog, message=message, memory_enabled=False, effort="low")
 
-    assert cog.openai_client.responses.create_reasonings[-1]["effort"] == "low"
+    assert _recorded(cog).responses.create_reasonings[-1]["effort"] == "low"
 
 
 async def test_route_input_excludes_attachment_payloads() -> None:
@@ -6639,7 +6726,7 @@ async def test_route_input_excludes_attachment_payloads() -> None:
 
     await _route(cog=cog, message=message)
 
-    rendered = str(cog.openai_client.responses.parse_inputs[-1])
+    rendered = str(_recorded(cog).responses.parse_inputs[-1])
     assert "input_file" not in rendered
     assert "[attachment: file]" in rendered
 
@@ -6647,7 +6734,7 @@ async def test_route_input_excludes_attachment_payloads() -> None:
 async def test_select_user_memories_uses_text_only_transcript() -> None:
     """The selection request carries the text-only transcript verbatim, no payloads."""
     cog = _cog()
-    cog.openai_client.responses.select_queue = [[]]
+    _recorded(cog).responses.select_queue = [[]]
     message_list = [
         EasyInputMessageParam(
             role="user",
@@ -6660,13 +6747,13 @@ async def test_select_user_memories_uses_text_only_transcript() -> None:
 
     message = FakeMessage()
     await cog._select_user_memories(
-        message=message,
+        message=as_message(fake=message),
         message_list=message_list,
         allowed={1: "u"},
-        read_context=memory_read_context(message=message),
+        read_context=memory_read_context(message=as_message(fake=message)),
     )
 
-    rendered = str(cog.openai_client.responses.create_inputs[-1])
+    rendered = str(_recorded(cog).responses.create_inputs[-1])
     assert "input_image" not in rendered
     assert "input_file" not in rendered
     assert "[attachment: image]" in rendered
@@ -6679,14 +6766,14 @@ async def test_attachment_parts_cached_until_message_changes() -> None:
     attachment = FakeAttachment(filename="note.txt", content_type="text/plain")
     message.attachments = [attachment]
 
-    first = await cog.input_builder.get_attachment_parts(message=message)
-    again = await cog.input_builder.get_attachment_parts(message=message)
+    first = await cog.input_builder.get_attachment_parts(message=as_message(fake=message))
+    again = await cog.input_builder.get_attachment_parts(message=as_message(fake=message))
 
     assert attachment.read_count == 1
     assert again == first
 
     message.edited_at = datetime.now(tz=UTC)
-    await cog.input_builder.get_attachment_parts(message=message)
+    await cog.input_builder.get_attachment_parts(message=as_message(fake=message))
     assert attachment.read_count == 2
 
 
@@ -6698,17 +6785,17 @@ async def test_attachment_cache_reuploads_expired_handle(monkeypatch: pytest.Mon
     attachment = FakeAttachment(filename="note.txt", content_type="text/plain")
     message.attachments = [attachment]
 
-    await builder.get_attachment_parts(message=message)
+    await builder.get_attachment_parts(message=as_message(fake=message))
     assert attachment.read_count == 1
 
     # Within expiry: the cached handle is reused, so no second download.
-    await builder.get_attachment_parts(message=message)
+    await builder.get_attachment_parts(message=as_message(fake=message))
     assert attachment.read_count == 1
 
     # Force the entry past its stored expiry: the next render re-downloads and re-uploads.
     (cache_key, (_expiry, cached_parts)) = next(iter(builder._attachment_cache.items()))
     builder._attachment_cache[cache_key] = (datetime(2000, 1, 1, tzinfo=UTC), cached_parts)
-    await builder.get_attachment_parts(message=message)
+    await builder.get_attachment_parts(message=as_message(fake=message))
     assert attachment.read_count == 2
 
 
@@ -6737,14 +6824,14 @@ async def test_attachment_cache_refreshes_on_embed_url_swap(
         """Builds a fake embed whose image carries a swappable proxy URL."""
         return SimpleNamespace(image=SimpleNamespace(proxy_url=url, url=url), thumbnail=None)
 
-    message.embeds = [_embed("https://media.test/a.png")]
-    await cog.input_builder.get_attachment_parts(message=message)
-    await cog.input_builder.get_attachment_parts(message=message)
+    message.embeds = [cast("Embed", _embed("https://media.test/a.png"))]
+    await cog.input_builder.get_attachment_parts(message=as_message(fake=message))
+    await cog.input_builder.get_attachment_parts(message=as_message(fake=message))
     assert rendered_urls == ["https://media.test/a.png"]
 
     # Same embed count, different image URL: the cache must not serve the stale part.
-    message.embeds = [_embed("https://media.test/b.png")]
-    await cog.input_builder.get_attachment_parts(message=message)
+    message.embeds = [cast("Embed", _embed("https://media.test/b.png"))]
+    await cog.input_builder.get_attachment_parts(message=as_message(fake=message))
     assert rendered_urls == ["https://media.test/a.png", "https://media.test/b.png"]
 
 
@@ -6760,13 +6847,14 @@ async def _prepare_context_with_hanging_selection(
         await asyncio.sleep(1)
 
     monkeypatch.setattr(cog, "_select_user_memories", slow_selection)
-    parts_task = asyncio.create_task(coro=cog._get_reference_and_current(message=message))
-    text_parts = await cog._get_reference_and_current(message=message, text_only=True)
+    msg = as_message(fake=message)
+    parts_task = asyncio.create_task(coro=cog._get_reference_and_current(message=msg))
+    text_parts = await cog._get_reference_and_current(message=msg, text_only=True)
     # The route has already returned, so selection gets only the tiny grace before it times out.
     route_done = asyncio.Event()
     route_done.set()
     return await cog._prepare_reply_context(
-        message=message,
+        message=msg,
         history_limit=2,
         memory_enabled=True,
         parts_task=parts_task,
@@ -6875,11 +6963,11 @@ async def test_memory_selection_timeout_fallback_skips_locked_author_memory(
 
 def test_can_launch_research_requires_guild_text_channel() -> None:
     text = SimpleNamespace(guild=object(), channel=MagicMock(spec=nextcord.TextChannel))
-    assert _can_launch_research(message=text) is True
+    assert _can_launch_research(message=as_message(fake=text)) is True
     thread = SimpleNamespace(guild=object(), channel=MagicMock(spec=nextcord.Thread))
-    assert _can_launch_research(message=thread) is False
+    assert _can_launch_research(message=as_message(fake=thread)) is False
     dm = SimpleNamespace(guild=None, channel=MagicMock(spec=nextcord.TextChannel))
-    assert _can_launch_research(message=dm) is False
+    assert _can_launch_research(message=as_message(fake=dm)) is False
 
 
 async def test_resume_memory_reenqueues_jobs_and_sweeps_other_scopes(

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -147,7 +147,8 @@ async def test_help_response_is_ephemeral_with_a_view() -> None:
     )
 
     await HelpCogs.help.callback(
-        HelpCogs(bot=cast("commands.Bot", SimpleNamespace())), cast("Interaction", interaction)
+        HelpCogs(bot=cast("commands.Bot", SimpleNamespace())),
+        cast("Interaction[commands.Bot]", interaction),
     )
 
     assert interaction.response.sent["ephemeral"] is True

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,6 +1,9 @@
 """Tests for the shared best-effort Responses helpers in utils/llm."""
 
 from types import SimpleNamespace
+from typing import cast
+
+from openai.types.responses import Response
 
 from discordbot.utils.llm import output_text_or_empty
 
@@ -15,10 +18,19 @@ def _text_part(text: str | None) -> SimpleNamespace:
     return SimpleNamespace(type="output_text", text=text)
 
 
+def _as_response(fake: SimpleNamespace) -> Response:
+    """Views a fake output-bearing double as the Response `output_text_or_empty` expects.
+
+    Production discriminates output/content items on `.type` string, not isinstance
+    (see `_gen_reply/streaming.py::_consume`), so a SimpleNamespace stand-in is valid at runtime.
+    """
+    return cast("Response", fake)
+
+
 def test_output_text_or_empty_tolerates_none_text_part() -> None:
     """A lone output_text part with text=None yields "" instead of raising (the reported bug)."""
     responses = SimpleNamespace(output=[_message(_text_part(None))])
-    assert output_text_or_empty(responses=responses) == ""
+    assert output_text_or_empty(responses=_as_response(fake=responses)) == ""
 
 
 def test_output_text_or_empty_joins_valid_parts_and_skips_none() -> None:
@@ -26,7 +38,7 @@ def test_output_text_or_empty_joins_valid_parts_and_skips_none() -> None:
     responses = SimpleNamespace(
         output=[_message(_text_part("hello "), _text_part(None), _text_part("world"))]
     )
-    assert output_text_or_empty(responses=responses) == "hello world"
+    assert output_text_or_empty(responses=_as_response(fake=responses)) == "hello world"
 
 
 def test_output_text_or_empty_ignores_non_text_content_and_items() -> None:
@@ -37,4 +49,4 @@ def test_output_text_or_empty_ignores_non_text_content_and_items() -> None:
             _message(SimpleNamespace(type="refusal", refusal="no"), _text_part("kept")),
         ]
     )
-    assert output_text_or_empty(responses=responses) == "kept"
+    assert output_text_or_empty(responses=_as_response(fake=responses)) == "kept"

--- a/tests/test_maplestory.py
+++ b/tests/test_maplestory.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Unpack, TypedDict
+from typing import TYPE_CHECKING, Any, Unpack, TypedDict, cast
 
 import pytest
 from nextcord import File, Embed, Locale, Attachment, SelectOption
@@ -55,8 +55,12 @@ from discordbot.cogs._maplestory.models import (
 )
 from discordbot.cogs._maplestory.service import MapleStoryService, _load_json, _load_translations
 
+from tests.helpers.casting import as_bot, as_interaction
+
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from nextcord.ui import StringSelect
 
 type JsonValue = str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
 
@@ -206,6 +210,7 @@ def test_maplestory_quest_reward_defaults_are_isolated() -> None:
     """Quest reward and quest list defaults are isolated."""
     first_reward = QuestReward()
     second_reward = QuestReward()
+    assert isinstance(first_reward.items, dict)
     first_reward.items["items"] = [CollectItem(name="Potion", quantity=1)]
     assert second_reward.items == {}
 
@@ -487,13 +492,17 @@ def test_maplestory_service_loads_searches_and_caches(service: MapleStoryService
     assert service.translate(category="missing", name="Slime") == "Slime"
     assert service.search_monsters_by_name(query="slime")[0].display_name == "綠水靈"
     assert service.search_monsters_by_name(query="綠")[0].name == "Slime"
-    assert service.get_monster(name="綠水靈").name == "Slime"
+    monster = service.get_monster(name="綠水靈")
+    assert monster is not None
+    assert monster.name == "Slime"
     assert service.get_monster(name="missing") is None
     assert [
         monster.name for monster in service.get_monsters_by_drop(item_name="Wooden Sword")
     ] == ["Slime"]
     assert service.search_equipment_by_name(query="wooden")
-    assert service.get_equipment(name="木劍").name == "Wooden Sword"
+    equipment = service.get_equipment(name="木劍")
+    assert equipment is not None
+    assert equipment.name == "Wooden Sword"
     assert service.get_equipment(name="missing") is None
     assert service.search_scrolls_by_name(query="gloves")
     assert service.search_npcs_by_name(query="shop")
@@ -577,6 +586,14 @@ def test_maplestory_embeds_include_expected_sections(service: MapleStoryService)
     assert _truncate(text="abcdef", limit=5) == "ab..."
 
 
+def _select_result(view: MapleDropSearchView) -> StringSelect[Any]:
+    """Views the decorated `select_result` callback as the StringSelect item it becomes at runtime.
+
+    `View.__init__` setattr-replaces the decorated class attribute with the real component.
+    """
+    return cast("StringSelect[Any]", view.select_result)
+
+
 async def test_maplestory_view_resolvers_and_selection(service: MapleStoryService) -> None:
     """Verifies resolver dispatch and select option truncation."""
     for search_type, name in [
@@ -596,7 +613,7 @@ async def test_maplestory_view_resolvers_and_selection(service: MapleStoryServic
     drop_view.set_options(
         options=[SelectOption(label=f"Option {i}", value=str(i)) for i in range(30)]
     )
-    assert len(drop_view.select_result.options) == 25
+    assert len(_select_result(view=drop_view).options) == 25
 
 
 async def test_maplestory_view_select_result_handles_loading_and_valid_choice(
@@ -604,15 +621,16 @@ async def test_maplestory_view_select_result_handles_loading_and_valid_choice(
 ) -> None:
     """Verifies that the dropdown handles loading and valid selections."""
     view = MapleDropSearchView(service=service, search_type="monster", query="slime")
+    select_result = _select_result(view=view)
     interaction = _FakeInteraction()
-    view.select_result._selected_values = ["loading"]
-    await view.select_result.callback(interaction)
+    select_result._selected_values = ["loading"]
+    await select_result.callback(as_interaction(fake=interaction))
     assert interaction.response.deferred
     assert interaction.followup.sent[0]["content"] == "請先選擇有效的結果"
 
     valid_interaction = _FakeInteraction()
-    view.select_result._selected_values = ["Slime"]
-    await view.select_result.callback(valid_interaction)
+    select_result._selected_values = ["Slime"]
+    await select_result.callback(as_interaction(fake=valid_interaction))
     assert valid_interaction.followup.edited[0]["message_id"] == 777
     assert isinstance(valid_interaction.followup.edited[0]["embed"], Embed)
     assert valid_interaction.followup.edited[0]["view"] is None
@@ -626,7 +644,7 @@ async def test_maplestory_view_select_result_handles_loading_and_valid_choice(
 @pytest.fixture
 def maple_cog(maple_data_dir: Path) -> MapleStoryCogs:
     """Returns a MapleStory cog backed by the generated fixture data."""
-    return MapleStoryCogs(bot=SimpleNamespace(), data_dir=maple_data_dir)
+    return MapleStoryCogs(bot=as_bot(fake=SimpleNamespace()), data_dir=maple_data_dir)
 
 
 def test_maplestory_commands_are_grouped_under_maplestory() -> None:
@@ -684,6 +702,7 @@ async def test_maplestory_commands_send_multi_result_view(maple_cog: MapleStoryC
     await MapleStoryCogs.maple_monster.callback(maple_cog, interaction, name="Slime")
     payload = interaction.followup.sent[0]
     assert isinstance(payload["embed"], Embed)
+    assert payload["embed"].description is not None
     assert "找到 2 個相關怪物" in payload["embed"].description
     assert isinstance(payload["view"], MapleDropSearchView)
     assert payload["files"][0].filename == DEFAULT_EMBED_SPACER_FILENAME
@@ -696,6 +715,7 @@ async def test_maplestory_commands_send_not_found_and_stats(maple_cog: MapleStor
     await MapleStoryCogs.maple_equip.callback(maple_cog, missing_interaction, name="missing")
     missing_embed = missing_interaction.followup.sent[0]["embed"]
     assert isinstance(missing_embed, Embed)
+    assert missing_embed.description is not None
     assert "找不到名稱包含" in missing_embed.description
 
     stats_interaction = _FakeInteraction()
@@ -707,7 +727,7 @@ async def test_maplestory_commands_send_not_found_and_stats(maple_cog: MapleStor
 
 async def test_maplestory_command_error_path_when_data_missing(tmp_path: Path) -> None:
     """Verifies commands send the generic error embed when data is unavailable."""
-    cog = MapleStoryCogs(bot=SimpleNamespace(), data_dir=tmp_path / "empty")
+    cog = MapleStoryCogs(bot=as_bot(fake=SimpleNamespace()), data_dir=tmp_path / "empty")
     interaction = _FakeInteraction()
     await MapleStoryCogs.maple_stats.callback(cog, interaction)
     embed = interaction.followup.sent[0]["embed"]
@@ -728,7 +748,7 @@ def test_maplestory_setup_registers_cog(monkeypatch: pytest.MonkeyPatch) -> None
 
     bot = SimpleNamespace(add_cog=record_cog)
 
-    maplestory.setup(bot=bot)
+    maplestory.setup(bot=as_bot(fake=bot))
 
     assert isinstance(added[0][0], MapleStoryCogs)
     assert added[0][1] is True

--- a/tests/test_media_cleanup.py
+++ b/tests/test_media_cleanup.py
@@ -11,7 +11,9 @@ import pytest
 
 from discordbot.cogs import media_cleanup
 from discordbot.cogs.media_cleanup import MediaCleanupCogs
-from discordbot.utils.media_delivery import MediaHostingConfig, MediaHostingService
+from discordbot.utils.media_delivery import MediaHostingService
+
+from tests.helpers.casting import as_bot, make_media_hosting_config
 
 
 class _FakeBot:
@@ -27,12 +29,12 @@ def _service(
 ) -> MediaHostingService:
     """A hosting service over an explicit temp serve dir (never the live env-resolved dir)."""
     return MediaHostingService(
-        config=MediaHostingConfig(
-            MEDIA_HOSTING_ENABLED=True,
-            MEDIA_HOSTING_BASE_URL="https://media.test",
-            MEDIA_HOSTING_SERVE_DIR=str(serve_dir),
-            MEDIA_HOSTING_MAX_BYTES=max_bytes,
-            MEDIA_HOSTING_RETENTION_HOURS=retention_hours,
+        config=make_media_hosting_config(
+            enabled=True,
+            base_url="https://media.test",
+            serve_dir=str(serve_dir),
+            max_bytes=max_bytes,
+            retention_hours=retention_hours,
         )
     )
 
@@ -42,7 +44,7 @@ def test_setup_registers_media_cleanup_cog() -> None:
     added: list[tuple[object, object]] = []
     bot = SimpleNamespace(add_cog=lambda cog, override=None: added.append((cog, override)))
 
-    media_cleanup.setup(bot=bot)
+    media_cleanup.setup(bot=as_bot(fake=bot))
 
     assert len(added) == 1
     assert isinstance(added[0][0], MediaCleanupCogs)
@@ -53,7 +55,7 @@ async def test_on_ready_starts_loop_and_sweeps_once_when_enabled(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """With hosting + a cap configured, on_ready spawns one startup sweep and starts the loop."""
-    cog = MediaCleanupCogs(bot=_FakeBot())
+    cog = MediaCleanupCogs(bot=as_bot(fake=_FakeBot()))
     cog.media_hosting = _service(serve_dir=tmp_path)
     swept: list[bool] = []
 
@@ -75,7 +77,7 @@ async def test_on_ready_is_inert_when_cleanup_disabled(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Both caps off -> cleanup disabled -> the loop never starts and no sweep runs."""
-    cog = MediaCleanupCogs(bot=_FakeBot())
+    cog = MediaCleanupCogs(bot=as_bot(fake=_FakeBot()))
     cog.media_hosting = _service(serve_dir=tmp_path, max_bytes=0, retention_hours=0)
     swept: list[bool] = []
 
@@ -95,7 +97,7 @@ async def test_on_ready_starts_once_across_reconnects(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """on_ready fires on every reconnect, but the _started gate starts the loop only once."""
-    cog = MediaCleanupCogs(bot=_FakeBot())
+    cog = MediaCleanupCogs(bot=as_bot(fake=_FakeBot()))
     cog.media_hosting = _service(serve_dir=tmp_path)
     sweeps: list[bool] = []
 

--- a/tests/test_media_delivery.py
+++ b/tests/test_media_delivery.py
@@ -11,10 +11,11 @@ from discordbot.utils.media_delivery import (
     _TEMP_PREFIX,
     MEDIA_ENVELOPE_MARGIN,
     MediaItem,
-    MediaHostingConfig,
     MediaHostingService,
     MediaDeliveryPlanner,
 )
+
+from tests.helpers.casting import make_media_hosting_config
 
 
 def _service(
@@ -27,12 +28,12 @@ def _service(
 ) -> MediaHostingService:
     """Builds a host writer whose config points at a temp serve dir (via the env aliases)."""
     return MediaHostingService(
-        config=MediaHostingConfig(
-            MEDIA_HOSTING_ENABLED=enabled,
-            MEDIA_HOSTING_BASE_URL=base_url,
-            MEDIA_HOSTING_SERVE_DIR=str(serve_dir),
-            MEDIA_HOSTING_MAX_BYTES=max_bytes,
-            MEDIA_HOSTING_RETENTION_HOURS=retention_hours,
+        config=make_media_hosting_config(
+            enabled=enabled,
+            base_url=base_url,
+            serve_dir=str(serve_dir),
+            max_bytes=max_bytes,
+            retention_hours=retention_hours,
         )
     )
 
@@ -233,11 +234,7 @@ def test_empty_base_url_returns_none(tmp_path: Path) -> None:
 def test_empty_serve_dir_returns_none() -> None:
     """An empty serve dir leaves the fallback inert."""
     service = MediaHostingService(
-        config=MediaHostingConfig(
-            MEDIA_HOSTING_ENABLED=True,
-            MEDIA_HOSTING_BASE_URL="https://media.test",
-            MEDIA_HOSTING_SERVE_DIR="",
-        )
+        config=make_media_hosting_config(enabled=True, base_url="https://media.test", serve_dir="")
     )
     assert service.publish_bytes(data=b"x", suffix=".png") is None
 
@@ -415,7 +412,7 @@ def test_cleanup_no_op_on_missing_serve_dir(tmp_path: Path) -> None:
 
 def test_empty_config_is_unavailable() -> None:
     """Empty base_url / serve_dir make the service unavailable (the test-green guard)."""
-    config = MediaHostingConfig(MEDIA_HOSTING_BASE_URL="", MEDIA_HOSTING_SERVE_DIR="")
+    config = make_media_hosting_config(enabled=True, base_url="", serve_dir="")
     assert config.available is False
 
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -3,7 +3,7 @@
 import re
 import time
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 import asyncio
 from pathlib import Path
 import contextlib
@@ -922,7 +922,8 @@ async def test_pipeline_defers_and_replays_newest_update_in_flight(
     async def slow_parse(**kwargs: object) -> SimpleNamespace:
         inputs = kwargs["input"]
         assert isinstance(inputs, list)
-        seen_replies.append(str(inputs[0]["content"]))
+        first = cast("dict[str, object]", inputs[0])
+        seen_replies.append(str(first["content"]))
         started.set()
         if not release.is_set():
             await release.wait()
@@ -1113,7 +1114,8 @@ async def test_pipeline_compaction_triggers_past_main_size(
         seen_instructions.append(str(kwargs["instructions"]))
         inputs = kwargs["input"]
         assert isinstance(inputs, list)
-        seen_inputs.append(str(inputs[0]["content"]))
+        first = cast("dict[str, object]", inputs[0])
+        seen_inputs.append(str(first["content"]))
         return _parsed(output=parsed_outputs.pop(0))
 
     monkeypatch.setattr(fake_client.responses, "parse", staged_parse)
@@ -1248,7 +1250,7 @@ async def test_memory_show_displays_stored_memory(memory_isolated_dir: Path) -> 
     write_main_memory(scope=USER_SCOPE, content="v1\n\n## 使用者輪廓\n愛開玩笑", identity=IDENTITY)
     cog = _memory_cog()
     interaction = _interaction()
-    await MemoryCogs.memory_show.callback(cog, cast("Interaction", interaction))
+    await MemoryCogs.memory_show.callback(cog, cast("Interaction[Any]", interaction))
     assert interaction.response.sent["ephemeral"] is True
     embed = interaction.response.sent["embed"]
     assert isinstance(embed, Embed)
@@ -1264,7 +1266,7 @@ async def test_memory_show_paginates_oversized_memory(memory_isolated_dir: Path)
     )
     cog = _memory_cog()
     interaction = _interaction()
-    await MemoryCogs.memory_show.callback(cog, cast("Interaction", interaction))
+    await MemoryCogs.memory_show.callback(cog, cast("Interaction[Any]", interaction))
     sent = interaction.response.sent
     assert sent["ephemeral"] is True
     view = sent["view"]
@@ -1281,7 +1283,7 @@ async def test_memory_show_paginates_oversized_memory(memory_isolated_dir: Path)
 async def test_memory_show_handles_empty_memory(memory_isolated_dir: Path) -> None:
     cog = _memory_cog()
     interaction = _interaction()
-    await MemoryCogs.memory_show.callback(cog, cast("Interaction", interaction))
+    await MemoryCogs.memory_show.callback(cog, cast("Interaction[Any]", interaction))
     assert interaction.response.sent["ephemeral"] is True
     embed = interaction.response.sent["embed"]
     assert isinstance(embed, Embed)
@@ -1505,7 +1507,7 @@ async def test_memory_regenerate_command_schedules_in_background(
     # Evidence must exist or the command short-circuits before scheduling.
     append_detail(scope=USER_SCOPE, text=DETAIL_EVIDENCE)
     interaction = _regen_interaction()
-    await MemoryCogs.memory_regenerate.callback(cog, cast("Interaction", interaction))
+    await MemoryCogs.memory_regenerate.callback(cog, cast("Interaction[Any]", interaction))
 
     # The command replies immediately and never blocks on the rebuild, so it
     # neither defers nor uses a followup.
@@ -1533,7 +1535,7 @@ async def test_memory_regenerate_command_reports_no_evidence(
     monkeypatch.setattr("discordbot.cogs.memory.schedule_memory_regeneration", fake_schedule)
     # No raw or detail evidence exists for this scope.
     interaction = _regen_interaction()
-    await MemoryCogs.memory_regenerate.callback(cog, cast("Interaction", interaction))
+    await MemoryCogs.memory_regenerate.callback(cog, cast("Interaction[Any]", interaction))
 
     # Without evidence the background task would no-op, so nothing is scheduled
     # and the user is told there is nothing to rebuild yet.
@@ -1559,7 +1561,7 @@ async def test_memory_regenerate_command_blocked_by_cooldown(
 
     monkeypatch.setattr("discordbot.cogs.memory.schedule_memory_regeneration", fake_schedule)
     interaction = _regen_interaction()
-    await MemoryCogs.memory_regenerate.callback(cog, cast("Interaction", interaction))
+    await MemoryCogs.memory_regenerate.callback(cog, cast("Interaction[Any]", interaction))
 
     # Rejected up front: nothing scheduled, no defer, just the ephemeral notice.
     assert scheduled is False
@@ -1584,7 +1586,9 @@ async def test_schedule_memory_regeneration_runs_in_background(memory_isolated_d
 
     assert scheduled is True
     # The actual rebuild runs as a background task; await it to observe the write.
-    await pipeline._regeneration_tasks.get(key=USER_SCOPE)
+    task = pipeline._regeneration_tasks.get(key=USER_SCOPE)
+    assert task is not None
+    await task
     assert read_main_memory(scope=USER_SCOPE) == "v1\n\n## 使用者輪廓\n背景重建後的記憶"
 
 
@@ -1611,7 +1615,9 @@ async def test_schedule_memory_regeneration_dedupes_in_flight(
     # A rebuild already in flight must not double-schedule the whole-file rewrite.
     assert second is False
     release.set()
-    await pipeline._regeneration_tasks.get(key=USER_SCOPE)
+    task = pipeline._regeneration_tasks.get(key=USER_SCOPE)
+    assert task is not None
+    await task
 
 
 def test_paginate_on_lines_single_page_passthrough() -> None:
@@ -1658,13 +1664,13 @@ async def test_memory_pages_view_navigates_and_disables_bounds() -> None:
         footer_text=memory_footer_text(pending_count=1),
         title="🧠 我對你的記憶",
     )
-    prev_button = cast("Button", view.previous_page)
-    next_button = cast("Button", view.next_page)
+    prev_button = cast("Button[Any]", view.previous_page)
+    next_button = cast("Button[Any]", view.next_page)
     assert prev_button.disabled is True
     assert next_button.disabled is False
 
     interaction = SimpleNamespace(response=EditResponseStub())
-    await next_button.callback(cast("Interaction", interaction))
+    await next_button.callback(cast("Interaction[Any]", interaction))
     assert view.page_index == 1
     embed = interaction.response.edited["embed"]
     assert isinstance(embed, Embed)
@@ -1673,11 +1679,11 @@ async def test_memory_pages_view_navigates_and_disables_bounds() -> None:
     assert "1 筆" in (embed.footer.text or "")
     assert prev_button.disabled is False
 
-    await next_button.callback(cast("Interaction", interaction))
+    await next_button.callback(cast("Interaction[Any]", interaction))
     assert view.page_index == 2
     assert next_button.disabled is True
 
-    await prev_button.callback(cast("Interaction", interaction))
+    await prev_button.callback(cast("Interaction[Any]", interaction))
     assert view.page_index == 1
     edited_embed = interaction.response.edited["embed"]
     assert isinstance(edited_embed, Embed)
@@ -1705,7 +1711,7 @@ async def test_memory_pages_view_timeout_disables_buttons() -> None:
             self.edited = kwargs
 
     origin = OriginStub()
-    view.bind_origin(interaction=cast("Interaction", origin))
+    view.bind_origin(interaction=cast("Interaction[Any]", origin))
     await view.on_timeout()
     assert origin.edited["view"] is view
     assert all(child.disabled for child in view.children if isinstance(child, Button))
@@ -1769,7 +1775,7 @@ async def test_memory_show_reports_pending_observations_before_first_consolidati
     append_raw_entry(scope=USER_SCOPE, entry_text="偏好訊號:\n- 第一筆觀察")
     cog = _memory_cog()
     interaction = _interaction()
-    await MemoryCogs.memory_show.callback(cog, cast("Interaction", interaction))
+    await MemoryCogs.memory_show.callback(cog, cast("Interaction[Any]", interaction))
     embed = interaction.response.sent["embed"]
     assert isinstance(embed, Embed)
     assert "1 筆" in (embed.description or "")
@@ -1784,7 +1790,7 @@ async def test_memory_show_strips_version_header_and_counts_pending(
     append_raw_entry(scope=USER_SCOPE, entry_text="偏好訊號:\n- 新觀察")
     cog = _memory_cog()
     interaction = _interaction()
-    await MemoryCogs.memory_show.callback(cog, cast("Interaction", interaction))
+    await MemoryCogs.memory_show.callback(cog, cast("Interaction[Any]", interaction))
     embed = interaction.response.sent["embed"]
     assert isinstance(embed, Embed)
     assert (embed.description or "").startswith("## 使用者輪廓")
@@ -1798,7 +1804,7 @@ async def test_memory_show_does_not_corrupt_malformed_version_token(
     write_main_memory(scope=USER_SCOPE, content="v10 是一段被手動編輯的內容", identity=IDENTITY)
     cog = _memory_cog()
     interaction = _interaction()
-    await MemoryCogs.memory_show.callback(cog, cast("Interaction", interaction))
+    await MemoryCogs.memory_show.callback(cog, cast("Interaction[Any]", interaction))
     embed = interaction.response.sent["embed"]
     assert isinstance(embed, Embed)
     # Only an exact `v1\n` header is stripped; `v10...` must survive intact.
@@ -2292,7 +2298,8 @@ async def test_pipeline_passes_recent_detail_to_consolidation(
     async def staged_parse(**kwargs: object) -> SimpleNamespace:
         inputs = kwargs["input"]
         assert isinstance(inputs, list)
-        seen_inputs.append(str(inputs[0]["content"]))
+        first = cast("dict[str, object]", inputs[0])
+        seen_inputs.append(str(first["content"]))
         return _parsed(output=parsed_outputs.pop(0))
 
     monkeypatch.setattr(fake_client.responses, "parse", staged_parse)
@@ -2573,10 +2580,11 @@ async def test_pipeline_cleared_deferred_turn_marks_job_done(memory_isolated_dir
         token=7,
     )
     captured_at = time.monotonic()
+    extractor, _ = _extractor()
     pipeline._pending_updates[USER_SCOPE] = pipeline._PendingMemoryUpdate(
         subject=f"target_user_id: {USER_ID}",
         transcript="Alice (alice) [id: 123456789]: 哈囉",
-        extractor=object(),
+        extractor=extractor,
         identity=IDENTITY,
         captured_at=captured_at,
         token=7,
@@ -2958,7 +2966,8 @@ async def test_pipeline_consolidation_writes_tone_note(
     async def staged_parse(**kwargs: object) -> SimpleNamespace:
         inputs = kwargs["input"]
         assert isinstance(inputs, list)
-        seen_inputs.append(str(inputs[0]["content"]))
+        first = cast("dict[str, object]", inputs[0])
+        seen_inputs.append(str(first["content"]))
         return _parsed(output=parsed_outputs.pop(0))
 
     monkeypatch.setattr(fake_client.responses, "parse", staged_parse)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1700,7 +1700,7 @@ async def test_memory_pages_view_timeout_disables_buttons() -> None:
             """Initializes the recorded payload."""
             self.edited: dict[str, object] = {}
 
-        async def edit_original_response(self, **kwargs: object) -> None:
+        async def edit_original_message(self, **kwargs: object) -> None:
             """Records the edit payload."""
             self.edited = kwargs
 

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -1,12 +1,17 @@
 """Tests for the shared "is this message addressed to the bot" predicate."""
 
 from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
 
 from discordbot.utils.mentions import has_bot_mention, is_addressed_to_bot
 
+from tests.helpers.casting import as_message
 from tests.helpers.discord_mocks import FakeUser
 
-BOT = SimpleNamespace(id=999)
+if TYPE_CHECKING:
+    from nextcord import ClientUser
+
+BOT = cast("ClientUser", SimpleNamespace(id=999))
 
 
 def test_has_bot_mention_matches_both_mention_forms() -> None:
@@ -28,7 +33,7 @@ def test_has_bot_mention_without_bot_user() -> None:
 def test_is_addressed_to_bot_treats_every_dm_as_addressed() -> None:
     """A DM reaches the reply pipeline without a mention, so it counts as addressed."""
     message = SimpleNamespace(guild=None, content="no mention here", author=FakeUser())
-    assert is_addressed_to_bot(message=message, bot_user=BOT) is True
+    assert is_addressed_to_bot(message=as_message(fake=message), bot_user=BOT) is True
 
 
 def test_is_addressed_to_bot_needs_a_mention_in_a_guild() -> None:
@@ -36,5 +41,5 @@ def test_is_addressed_to_bot_needs_a_mention_in_a_guild() -> None:
     guild = SimpleNamespace(id=1)
     plain = SimpleNamespace(guild=guild, content="just a link", author=FakeUser())
     mentioned = SimpleNamespace(guild=guild, content="<@999> look", author=FakeUser())
-    assert is_addressed_to_bot(message=plain, bot_user=BOT) is False
-    assert is_addressed_to_bot(message=mentioned, bot_user=BOT) is True
+    assert is_addressed_to_bot(message=as_message(fake=plain), bot_user=BOT) is False
+    assert is_addressed_to_bot(message=as_message(fake=mentioned), bot_user=BOT) is True

--- a/tests/test_parse_bilibili.py
+++ b/tests/test_parse_bilibili.py
@@ -2,11 +2,12 @@
 
 import time
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 import asyncio
 from pathlib import Path
 import threading
 
+from google import genai
 import pytest
 
 from discordbot.utils.downloader import VideoMetadata, DownloadResult, VideoDownloader
@@ -21,7 +22,14 @@ from discordbot.cogs._gen_reply.link_sources.bilibili import (
     build_bilibili_context_messages,
 )
 
+from tests.helpers.casting import step_dicts
+
 _URL = "https://www.bilibili.com/video/BV1jpK86hEc8"
+
+
+def _fake_client() -> genai.Client:
+    """Stands in for a Gemini client the builder never actually calls through."""
+    return cast("genai.Client", SimpleNamespace())
 
 
 def _metadata(
@@ -120,14 +128,15 @@ async def _build(gemini: bool = True, ingest: bool = True) -> list[dict[str, Any
     """Runs the builder with the flags most tests share.
 
     The blocks are `EasyInputMessageParam`s, whose `content` is a union the assertions below
-    index into part by part; `Any` is what lets them read as plain JSON.
+    index into part by part; `step_dicts` is what lets them read as plain JSON.
     """
-    return await build_bilibili_context_messages(
+    blocks = await build_bilibili_context_messages(
         url=_URL,
         answer_model_is_gemini=gemini,
-        gemini_client=SimpleNamespace(),
+        gemini_client=_fake_client(),
         allow_media_ingest=ingest,
     )
+    return step_dicts(steps=blocks)
 
 
 async def test_the_clip_is_uploaded_and_referenced_by_files_uri(
@@ -259,8 +268,10 @@ async def test_a_missing_key_reads_the_text_instead_of_raising(
     """No key means no client to upload with, which is a text-only read, not a failure."""
     uploads, _ = _stub_bilibili(monkeypatch)
 
-    blocks = await build_bilibili_context_messages(
-        url=_URL, answer_model_is_gemini=True, gemini_client=None, allow_media_ingest=True
+    blocks = step_dicts(
+        steps=await build_bilibili_context_messages(
+            url=_URL, answer_model_is_gemini=True, gemini_client=None, allow_media_ingest=True
+        )
     )
 
     assert blocks[0]["content"][0]["text"] == BILIBILI_TEXT_ONLY_SEPARATOR
@@ -307,11 +318,13 @@ async def test_a_resolved_short_link_lists_both_urls(monkeypatch: pytest.MonkeyP
     _stub_bilibili(monkeypatch, metadata=_metadata(webpage_url=_URL))
     short_url = "https://b23.tv/abc123X"
 
-    blocks = await build_bilibili_context_messages(
-        url=short_url,
-        answer_model_is_gemini=True,
-        gemini_client=SimpleNamespace(),
-        allow_media_ingest=True,
+    blocks = step_dicts(
+        steps=await build_bilibili_context_messages(
+            url=short_url,
+            answer_model_is_gemini=True,
+            gemini_client=_fake_client(),
+            allow_media_ingest=True,
+        )
     )
 
     text = blocks[1]["content"][0]["text"]
@@ -489,11 +502,25 @@ async def test_the_fetch_bound_is_released_before_the_upload(
     release = asyncio.Event()
 
     class _SlowUploads(_Uploads):
-        async def __call__(self, **kwargs: object) -> dict[str, str] | None:
+        async def __call__(
+            self,
+            *,
+            client: object,
+            source: object,
+            mime_type: str,
+            filename: str,
+            timeout_seconds: float,
+        ) -> dict[str, str] | None:
             """Blocks inside the upload until the test lets it finish."""
             started.set()
             await release.wait()
-            return await super().__call__(**kwargs)  # type: ignore[arg-type]
+            return await super().__call__(
+                client=client,
+                source=source,
+                mime_type=mime_type,
+                filename=filename,
+                timeout_seconds=timeout_seconds,
+            )
 
     monkeypatch.setattr(bilibili_builder, "upload_as_input_file", _SlowUploads())
     slow = asyncio.create_task(_build())
@@ -501,14 +528,16 @@ async def test_the_fetch_bound_is_released_before_the_upload(
         await asyncio.wait_for(started.wait(), timeout=5.0)
 
         # A different link must get through while the first build sits in its upload.
-        other = await asyncio.wait_for(
-            build_bilibili_context_messages(
-                url="https://www.bilibili.com/video/av170001",
-                answer_model_is_gemini=True,
-                gemini_client=SimpleNamespace(),
-                allow_media_ingest=False,
-            ),
-            timeout=5.0,
+        other = step_dicts(
+            steps=await asyncio.wait_for(
+                build_bilibili_context_messages(
+                    url="https://www.bilibili.com/video/av170001",
+                    answer_model_is_gemini=True,
+                    gemini_client=_fake_client(),
+                    allow_media_ingest=False,
+                ),
+                timeout=5.0,
+            )
         )
         assert other[0]["content"][0]["text"] == BILIBILI_TEXT_ONLY_SEPARATOR
     finally:

--- a/tests/test_parse_douyin.py
+++ b/tests/test_parse_douyin.py
@@ -1,7 +1,7 @@
 """Tests for the Douyin-context builder that feeds linked posts to the answer model."""
 
 from types import SimpleNamespace
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 import asyncio
 from pathlib import Path
 
@@ -27,6 +27,11 @@ from discordbot.cogs._gen_reply.link_sources.douyin import (
     DOUYIN_TEXT_ONLY_SEPARATOR,
     build_douyin_context_messages,
 )
+
+from tests.helpers.casting import step_dicts
+
+if TYPE_CHECKING:
+    from google import genai
 
 _URL = "https://v.douyin.com/abc123"
 
@@ -128,14 +133,15 @@ async def _build(gemini: bool = True, ingest: bool = True) -> list[dict[str, Any
     """Runs the builder with the flags most tests share.
 
     The blocks are `EasyInputMessageParam`s, whose `content` is a union the assertions below
-    index into part by part; `Any` is what lets them read as plain JSON.
+    index into part by part; `step_dicts` is what lets them read as plain JSON.
     """
-    return await build_douyin_context_messages(
+    blocks = await build_douyin_context_messages(
         url=_URL,
         answer_model_is_gemini=gemini,
-        gemini_client=SimpleNamespace(),
+        gemini_client=cast("genai.Client", SimpleNamespace()),
         allow_media_ingest=ingest,
     )
+    return step_dicts(steps=blocks)
 
 
 async def test_the_clip_is_uploaded_and_referenced_by_files_uri(
@@ -293,8 +299,10 @@ async def test_a_missing_key_reads_the_caption_instead_of_raising(
     """No key means no client to upload with, which is a text-only read, not a failure."""
     uploads, _ = _stub_douyin(monkeypatch)
 
-    blocks = await build_douyin_context_messages(
-        url=_URL, answer_model_is_gemini=True, gemini_client=None, allow_media_ingest=True
+    blocks = step_dicts(
+        steps=await build_douyin_context_messages(
+            url=_URL, answer_model_is_gemini=True, gemini_client=None, allow_media_ingest=True
+        )
     )
 
     assert blocks[0]["content"][0]["text"] == DOUYIN_TEXT_ONLY_SEPARATOR
@@ -356,11 +364,25 @@ async def test_the_fetch_bound_is_released_before_the_upload(
     release = asyncio.Event()
 
     class _SlowUploads(_Uploads):
-        async def __call__(self, **kwargs: object) -> dict[str, str] | None:
+        async def __call__(
+            self,
+            *,
+            client: object,
+            source: object,
+            mime_type: str,
+            filename: str,
+            timeout_seconds: float,
+        ) -> dict[str, str] | None:
             """Blocks inside the upload until the test lets it finish."""
             started.set()
             await release.wait()
-            return await super().__call__(**kwargs)  # type: ignore[arg-type]
+            return await super().__call__(
+                client=client,
+                source=source,
+                mime_type=mime_type,
+                filename=filename,
+                timeout_seconds=timeout_seconds,
+            )
 
     monkeypatch.setattr(douyin_builder, "upload_as_input_file", _SlowUploads())
     slow = asyncio.create_task(_build())
@@ -368,14 +390,16 @@ async def test_the_fetch_bound_is_released_before_the_upload(
         await asyncio.wait_for(started.wait(), timeout=5.0)
 
         # A different link must get through while the first build sits in its upload.
-        other = await asyncio.wait_for(
-            build_douyin_context_messages(
-                url="https://v.douyin.com/other",
-                answer_model_is_gemini=True,
-                gemini_client=SimpleNamespace(),
-                allow_media_ingest=False,
-            ),
-            timeout=5.0,
+        other = step_dicts(
+            steps=await asyncio.wait_for(
+                build_douyin_context_messages(
+                    url="https://v.douyin.com/other",
+                    answer_model_is_gemini=True,
+                    gemini_client=cast("genai.Client", SimpleNamespace()),
+                    allow_media_ingest=False,
+                ),
+                timeout=5.0,
+            )
         )
         assert other[0]["content"][0]["text"] == DOUYIN_TEXT_ONLY_SEPARATOR
     finally:

--- a/tests/test_parse_douyin_cog.py
+++ b/tests/test_parse_douyin_cog.py
@@ -2,11 +2,12 @@
 
 import time
 from types import SimpleNamespace
-from typing import Unpack, TypedDict
+from typing import TYPE_CHECKING, Unpack, TypedDict, cast
 import asyncio
 from pathlib import Path
 
 import pytest
+from nextcord import Message
 
 from discordbot.cogs import parse_douyin
 from discordbot.utils.douyin import (
@@ -18,13 +19,13 @@ from discordbot.utils.douyin import (
     DouyinUnavailableError,
 )
 from discordbot.cogs.parse_douyin import DouyinCogs
-from discordbot.utils.media_delivery import (
-    MediaHostingConfig,
-    MediaHostingService,
-    MediaDeliveryPlanner,
-)
+from discordbot.utils.media_delivery import MediaHostingService, MediaDeliveryPlanner
 
+from tests.helpers.casting import as_bot, as_message, make_media_hosting_config
 from tests.helpers.discord_mocks import FakeUser, FakeDiscordMessage
+
+if TYPE_CHECKING:
+    from discordbot.typings.douyin import DouyinConfig
 
 _URL = "https://v.douyin.com/abc123"
 _GREEN = "<:greencheck:1517565102424068226>"
@@ -102,15 +103,15 @@ def _cog(
     bot_id: int = 999, **downloader_kwargs: Unpack[_StubOptions]
 ) -> tuple[DouyinCogs, dict[str, _StubDownloader]]:
     """Builds a cog wired to a stub downloader and a hosting-off delivery planner."""
-    cog = DouyinCogs(bot=SimpleNamespace(user=SimpleNamespace(id=bot_id)))
+    cog = DouyinCogs(bot=as_bot(fake=SimpleNamespace(user=SimpleNamespace(id=bot_id))))
     # Pinned explicitly: DouyinConfig reads the real environment (typings/douyin.py loads .env
     # at import), so a dev box with DOUYIN_AUTO_EXPAND_ENABLED=false would silently turn every
     # test below into a no-op that still passes.
-    cog.config = SimpleNamespace(auto_expand_enabled=True)
+    cog.config = cast("DouyinConfig", SimpleNamespace(auto_expand_enabled=True))
     # Explicitly disabled planner — never the no-arg default, whose config is `available` on a
     # dev box where .env enables hosting (it would write into the live serve dir).
     cog.media_delivery = MediaDeliveryPlanner(
-        media_hosting=MediaHostingService(config=MediaHostingConfig(MEDIA_HOSTING_ENABLED=False))
+        media_hosting=MediaHostingService(config=make_media_hosting_config(enabled=False))
     )
     made: dict[str, _StubDownloader] = {}
 
@@ -120,17 +121,28 @@ def _cog(
         made["stub"] = stub
         return stub
 
-    cog.downloader_factory = factory
+    cog.__dict__["downloader_factory"] = factory
     return cog, made
 
 
-def _message(content: str = _URL, filesize_limit: int = 25 * 1024 * 1024) -> FakeDiscordMessage:
+class _DouyinMessage(FakeDiscordMessage):
+    """Adds the author/content/guild fields `DouyinCogs.on_message` reads."""
+
+    def __init__(self, author: FakeUser, content: str, guild: object) -> None:
+        """Builds a message double carrying the fields the cog inspects."""
+        super().__init__()
+        self.author = author
+        self.content = content
+        self.guild = guild
+
+
+def _message(content: str = _URL, filesize_limit: int = 25 * 1024 * 1024) -> _DouyinMessage:
     """Builds a guild message carrying a Douyin link."""
-    message = FakeDiscordMessage()
-    message.author = FakeUser(bot=False)
-    message.content = content
-    message.guild = SimpleNamespace(filesize_limit=filesize_limit)
-    return message
+    return _DouyinMessage(
+        author=FakeUser(bot=False),
+        content=content,
+        guild=SimpleNamespace(filesize_limit=filesize_limit),
+    )
 
 
 def _reply_body(*, message: FakeDiscordMessage) -> str:
@@ -145,7 +157,7 @@ async def test_a_pasted_link_is_expanded_with_its_caption() -> None:
     cog, made = _cog()
     message = _message()
 
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     assert message.suppressed
     reply = message.replies[0]
@@ -162,13 +174,13 @@ async def test_a_message_addressed_to_the_bot_is_left_alone() -> None:
     cog, made = _cog()
 
     mentioned = _message(content=f"<@999> what is this {_URL}")
-    await cog.on_message(message=mentioned)
+    await cog.on_message(message=as_message(fake=mentioned))
     assert mentioned.reactions == []
     assert mentioned.replies == []
 
     direct_message = _message()
     direct_message.guild = None  # a DM always reaches gen_reply, mention or not
-    await cog.on_message(message=direct_message)
+    await cog.on_message(message=as_message(fake=direct_message))
     assert direct_message.reactions == []
     assert direct_message.replies == []
 
@@ -180,7 +192,7 @@ async def test_a_message_without_a_link_is_ignored() -> None:
     cog, made = _cog()
     message = _message(content="just chatting")
 
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     assert message.reactions == []
     assert made == {}
@@ -192,7 +204,7 @@ async def test_a_bot_author_is_ignored() -> None:
     message = _message()
     message.author = FakeUser(bot=True)
 
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     assert made == {}
 
@@ -200,10 +212,10 @@ async def test_a_bot_author_is_ignored() -> None:
 async def test_the_kill_switch_stops_every_request() -> None:
     """Auto-expansion is the one lever that stops the bot talking to Douyin during a WAF ban."""
     cog, made = _cog()
-    cog.config = SimpleNamespace(auto_expand_enabled=False)
+    cog.config = cast("DouyinConfig", SimpleNamespace(auto_expand_enabled=False))
     message = _message()
 
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     assert message.reactions == []
     assert made == {}
@@ -214,7 +226,7 @@ async def test_a_blocked_request_is_never_reported_as_a_missing_post() -> None:
     cog, _ = _cog(download_error=DouyinBlockedError("bot wall"))
     message = _message()
 
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     assert message.reactions[-1] == DouyinCogs.blocked_emoji
     body = _reply_body(message=message)
@@ -227,7 +239,7 @@ async def test_a_deleted_post_says_so() -> None:
     cog, _ = _cog(download_error=DouyinUnavailableError("filtered"))
     message = _message()
 
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     assert message.reactions[-1] == "⚠️"
     assert "刪除" in _reply_body(message=message)
@@ -238,7 +250,7 @@ async def test_an_oversize_post_points_at_the_command() -> None:
     cog, _ = _cog(download_error=DouyinTooLargeError("too big"))
     message = _message()
 
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     assert message.reactions[-1] == "⚠️"
     assert "/download_video" in _reply_body(message=message)
@@ -249,7 +261,7 @@ async def test_a_parse_failure_still_answers() -> None:
     cog, _ = _cog(parse_error=DouyinError("unreadable"))
     message = _message()
 
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     assert message.reactions[-1] == "⚠️"
     assert message.replies[0]["content"] == "-# 檔案無法下載"
@@ -259,14 +271,15 @@ async def test_an_unexpected_failure_marks_the_message() -> None:
     """A failure outside the fetch must not leave the source silently unmarked."""
     cog, _ = _cog()
 
-    async def boom(**_: object) -> None:
+    async def boom(*, message: Message, url: str, current_emoji: str) -> None:
         """Fails the way a Discord API error would."""
+        del message, url, current_emoji
         raise RuntimeError("discord exploded")
 
-    cog._expand = boom
+    cog.__dict__["_expand"] = boom
     message = _message()
 
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     assert message.reactions[-1] == _RED
 
@@ -277,16 +290,14 @@ async def test_an_oversize_clip_is_hosted_as_a_url(tmp_path: Path) -> None:
     (tmp_path / "serve").mkdir()  # pre-existing host mount; the bot never creates the serve dir
     cog.media_delivery = MediaDeliveryPlanner(
         media_hosting=MediaHostingService(
-            config=MediaHostingConfig(
-                MEDIA_HOSTING_ENABLED=True,
-                MEDIA_HOSTING_BASE_URL="https://media.test",
-                MEDIA_HOSTING_SERVE_DIR=str(tmp_path / "serve"),
+            config=make_media_hosting_config(
+                enabled=True, base_url="https://media.test", serve_dir=str(tmp_path / "serve")
             )
         )
     )
     message = _message(filesize_limit=4)  # tiny ceiling -> the clip counts as oversize
 
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     content = _reply_body(message=message)
     assert any(line.startswith("https://media.test/") for line in content.splitlines())
@@ -298,7 +309,7 @@ async def test_an_unhostable_oversize_clip_says_so() -> None:
     cog, _ = _cog()
     message = _message(filesize_limit=4)
 
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     assert message.reactions[-1] == "⚠️"
     assert "檔案大小超過" in _reply_body(message=message)
@@ -314,7 +325,7 @@ async def test_a_capped_gallery_reports_what_it_left_out() -> None:
     )
     message = _message()
 
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     assert "已省略 9 張圖片" in _reply_body(message=message)
     assert message.reactions[-1] == _GREEN
@@ -329,7 +340,7 @@ async def test_the_parsed_post_is_handed_to_the_download() -> None:
     cog, made = _cog()
     message = _message()
 
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     stub = made["stub"]
     assert stub.download_calls == 1
@@ -350,7 +361,7 @@ async def test_a_non_post_link_is_left_alone() -> None:
         cog, made = _cog()
         message = _message(content=content)
 
-        await cog.on_message(message=message)
+        await cog.on_message(message=as_message(fake=message))
 
         assert message.reactions == [], content
         assert message.replies == [], content
@@ -375,12 +386,12 @@ async def test_a_stalled_expansion_gives_up_and_frees_the_slot(
         time.sleep(1.0)
         raise AssertionError("should have been abandoned")
 
-    cog.downloader_factory = lambda output_folder: SimpleNamespace(
+    cog.__dict__["downloader_factory"] = lambda output_folder: SimpleNamespace(
         parse_metadata=never_returns, download=never_returns
     )
     message = _message()
 
-    await cog.on_message(message=message)
+    await cog.on_message(message=as_message(fake=message))
 
     assert message.reactions[-1] == "⚠️"
     body = _reply_body(message=message)

--- a/tests/test_parse_threads.py
+++ b/tests/test_parse_threads.py
@@ -1,8 +1,10 @@
 """Tests for the Threads-context builder that feeds linked posts to the answer model."""
 
 from types import SimpleNamespace
+from typing import cast
 from pathlib import Path
 
+from google import genai
 import pytest
 
 from discordbot.utils.threads import ThreadsOutput, ThreadsDownloader
@@ -15,6 +17,8 @@ from discordbot.cogs._gen_reply.link_sources.threads import (
     THREADS_TEXT_ONLY_SEPARATOR,
     build_threads_context_messages,
 )
+
+from tests.helpers.casting import step_dicts
 
 _URL = "https://www.threads.com/@alice/post/ABC123"
 
@@ -103,9 +107,9 @@ def _stub_media(
     monkeypatch.setattr(target=ThreadsDownloader, name="download_media", value=fake_download_media)
 
 
-def _client() -> SimpleNamespace:
+def _client() -> genai.Client:
     """A stand-in Gemini client; the stubbed upload never reaches through it."""
-    return SimpleNamespace()
+    return cast("genai.Client", SimpleNamespace())
 
 
 async def test_media_is_uploaded_and_referenced_by_files_uri(
@@ -128,9 +132,9 @@ async def test_media_is_uploaded_and_referenced_by_files_uri(
     )
 
     assert len(blocks) == 2
-    assert blocks[0]["content"][0]["text"] == THREADS_CONTEXT_SEPARATOR
+    assert step_dicts(steps=blocks[0]["content"])[0]["text"] == THREADS_CONTEXT_SEPARATOR
 
-    parts = blocks[1]["content"]
+    parts = step_dicts(steps=blocks[1]["content"])
     assert parts[0]["type"] == "input_text"
     assert "@alice" in parts[0]["text"]
     assert "TARGET" in parts[0]["text"]
@@ -189,10 +193,12 @@ async def test_only_the_target_posts_media_is_ingested(monkeypatch: pytest.Monke
         url=_URL, answer_model_is_gemini=True, gemini_client=_client()
     )
 
-    media = [part for part in blocks[1]["content"] if part["type"] == "input_file"]
+    media = [
+        part for part in step_dicts(steps=blocks[1]["content"]) if part["type"] == "input_file"
+    ]
     assert len(media) == 1
     assert len(uploads.calls) == 1
-    text = blocks[1]["content"][0]["text"]
+    text = step_dicts(steps=blocks[1]["content"])[0]["text"]
     assert "ancestor" in text  # the ancestor still supplies context, just no media
 
 
@@ -206,7 +212,9 @@ async def test_build_caps_media_parts(monkeypatch: pytest.MonkeyPatch) -> None:
         url=_URL, answer_model_is_gemini=True, gemini_client=_client()
     )
 
-    media = [part for part in blocks[1]["content"] if part["type"] == "input_file"]
+    media = [
+        part for part in step_dicts(steps=blocks[1]["content"]) if part["type"] == "input_file"
+    ]
     assert len(media) == MAX_THREADS_MEDIA_PARTS
 
 
@@ -226,7 +234,9 @@ async def test_videos_share_the_media_budget_with_images(monkeypatch: pytest.Mon
         url=_URL, answer_model_is_gemini=True, gemini_client=_client()
     )
 
-    media = [part for part in blocks[1]["content"] if part["type"] == "input_file"]
+    media = [
+        part for part in step_dicts(steps=blocks[1]["content"]) if part["type"] == "input_file"
+    ]
     assert len(media) == MAX_THREADS_MEDIA_PARTS
     names = [part["filename"] for part in media]
     assert sum(name.endswith(".mp4") for name in names) == 1  # only the leftover slot
@@ -246,7 +256,9 @@ async def test_a_full_image_budget_leaves_no_room_for_video(
         url=_URL, answer_model_is_gemini=True, gemini_client=_client()
     )
 
-    media = [part for part in blocks[1]["content"] if part["type"] == "input_file"]
+    media = [
+        part for part in step_dicts(steps=blocks[1]["content"]) if part["type"] == "input_file"
+    ]
     assert len(media) == MAX_THREADS_MEDIA_PARTS
     assert all(part["filename"].endswith(".jpg") for part in media)
 
@@ -264,7 +276,7 @@ async def test_build_caps_chain_posts(monkeypatch: pytest.MonkeyPatch) -> None:
         url=_URL, answer_model_is_gemini=True, gemini_client=_client()
     )
 
-    text = blocks[1]["content"][0]["text"]
+    text = step_dicts(steps=blocks[1]["content"])[0]["text"]
     # The target and the nearest ancestors are kept; the oldest posts are dropped.
     assert "TARGET" in text
     assert f"post {MAX_THREADS_POSTS + 3}" in text  # the target (last) survives
@@ -285,7 +297,7 @@ async def test_build_without_a_key_rides_urls_as_text(monkeypatch: pytest.Monkey
         url=_URL, answer_model_is_gemini=True, gemini_client=None
     )
 
-    assert blocks[0]["content"][0]["text"] == THREADS_TEXT_ONLY_SEPARATOR
+    assert step_dicts(steps=blocks[0]["content"])[0]["text"] == THREADS_TEXT_ONLY_SEPARATOR
     assert uploads.calls == []
 
 
@@ -302,8 +314,8 @@ async def test_build_non_gemini_rides_urls_as_text(monkeypatch: pytest.MonkeyPat
     )
 
     # The separator must not claim the media was fetched, since only its URLs are supplied.
-    assert blocks[0]["content"][0]["text"] == THREADS_TEXT_ONLY_SEPARATOR
-    parts = blocks[1]["content"]
+    assert step_dicts(steps=blocks[0]["content"])[0]["text"] == THREADS_TEXT_ONLY_SEPARATOR
+    parts = step_dicts(steps=blocks[1]["content"])
     assert [part["type"] for part in parts] == ["input_text"]
     text = parts[0]["text"]
     assert "https://cdn.test/a.jpg" in text
@@ -322,8 +334,8 @@ async def test_failed_media_degrades_to_an_honest_text_block(
         url=_URL, answer_model_is_gemini=True, gemini_client=_client()
     )
 
-    assert blocks[0]["content"][0]["text"] == THREADS_TEXT_ONLY_SEPARATOR
-    parts = blocks[1]["content"]
+    assert step_dicts(steps=blocks[0]["content"])[0]["text"] == THREADS_TEXT_ONLY_SEPARATOR
+    parts = step_dicts(steps=blocks[1]["content"])
     assert [part["type"] for part in parts] == ["input_text"]
     assert "https://cdn.test/a.jpg" in parts[0]["text"]
 
@@ -339,8 +351,8 @@ async def test_failed_upload_degrades_to_an_honest_text_block(
         url=_URL, answer_model_is_gemini=True, gemini_client=_client()
     )
 
-    assert blocks[0]["content"][0]["text"] == THREADS_TEXT_ONLY_SEPARATOR
-    assert [part["type"] for part in blocks[1]["content"]] == ["input_text"]
+    assert step_dicts(steps=blocks[0]["content"])[0]["text"] == THREADS_TEXT_ONLY_SEPARATOR
+    assert [part["type"] for part in step_dicts(steps=blocks[1]["content"])] == ["input_text"]
 
 
 async def test_one_failed_item_does_not_sink_the_others(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -355,8 +367,10 @@ async def test_one_failed_item_does_not_sink_the_others(monkeypatch: pytest.Monk
         url=_URL, answer_model_is_gemini=True, gemini_client=_client()
     )
 
-    assert blocks[0]["content"][0]["text"] == THREADS_CONTEXT_SEPARATOR
-    media = [part for part in blocks[1]["content"] if part["type"] == "input_file"]
+    assert step_dicts(steps=blocks[0]["content"])[0]["text"] == THREADS_CONTEXT_SEPARATOR
+    media = [
+        part for part in step_dicts(steps=blocks[1]["content"]) if part["type"] == "input_file"
+    ]
     assert [part["filename"] for part in media] == ["threads_video_0.mp4"]
 
 
@@ -369,7 +383,7 @@ async def test_text_only_post_keeps_the_context_separator(monkeypatch: pytest.Mo
         url=_URL, answer_model_is_gemini=True, gemini_client=_client()
     )
 
-    assert blocks[0]["content"][0]["text"] == THREADS_CONTEXT_SEPARATOR
+    assert step_dicts(steps=blocks[0]["content"])[0]["text"] == THREADS_CONTEXT_SEPARATOR
 
 
 async def test_build_empty_post_returns_unavailable_notice(
@@ -384,7 +398,7 @@ async def test_build_empty_post_returns_unavailable_notice(
 
     assert len(blocks) == 1
     assert blocks[0]["role"] == "system"
-    assert blocks[0]["content"][0]["text"] == THREADS_UNAVAILABLE_NOTICE
+    assert step_dicts(steps=blocks[0]["content"])[0]["text"] == THREADS_UNAVAILABLE_NOTICE
 
 
 async def test_build_parse_error_degrades_to_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -401,4 +415,4 @@ async def test_build_parse_error_degrades_to_unavailable(monkeypatch: pytest.Mon
     )
 
     assert len(blocks) == 1
-    assert blocks[0]["content"][0]["text"] == THREADS_UNAVAILABLE_NOTICE
+    assert step_dicts(steps=blocks[0]["content"])[0]["text"] == THREADS_UNAVAILABLE_NOTICE

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -5,17 +5,14 @@ import base64
 from typing import TYPE_CHECKING, cast
 from pathlib import Path
 
+from google import genai
 from nextcord import AllowedMentions
 
 from discordbot.cogs import research as research_cog
 from discordbot.typings.llm import LLMConfig
 from discordbot.cogs._research import agent
 from discordbot.cogs._research import database as rdb
-from discordbot.utils.media_delivery import (
-    MediaHostingConfig,
-    MediaHostingService,
-    MediaDeliveryPlanner,
-)
+from discordbot.utils.media_delivery import MediaHostingService, MediaDeliveryPlanner
 from discordbot.cogs._gen_reply.markers import extract_inline_markers, scrub_markers_for_preview
 from discordbot.cogs._research.delivery import (
     split_report,
@@ -24,8 +21,13 @@ from discordbot.cogs._research.delivery import (
 )
 from discordbot.cogs._research.streaming import ResearchProgressStreamer
 
+from tests.helpers.casting import make_media_hosting_config
+
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
     from nextcord import Thread, Message
+    from google.genai.interactions import InteractionSSEEvent
 
     from discordbot.cogs._research.database import ResearchPhase
 
@@ -33,7 +35,7 @@ if TYPE_CHECKING:
 def _disabled_delivery() -> MediaDeliveryPlanner:
     """A planner whose host is off, so report files attach natively exactly as before hosting."""
     return MediaDeliveryPlanner(
-        media_hosting=MediaHostingService(config=MediaHostingConfig(MEDIA_HOSTING_ENABLED=False))
+        media_hosting=MediaHostingService(config=make_media_hosting_config(enabled=False))
     )
 
 
@@ -196,6 +198,24 @@ def _fake_client(*, streams: list[_FakeStream], terminal: object) -> SimpleNames
     )
 
 
+def _as_client(fake: SimpleNamespace) -> genai.Client:
+    """Views a fake client double as the genai.Client a production signature expects."""
+    return cast("genai.Client", fake)
+
+
+def _as_event(fake: object) -> "InteractionSSEEvent":
+    """Views a fabricated SSE event double as the real SDK union a production signature expects.
+
+    Production discriminates on `.event_type`, not isinstance, so a SimpleNamespace event is safe.
+    """
+    return cast("InteractionSSEEvent", fake)
+
+
+def _as_event_stream(fake: "_FakeStream") -> "AsyncIterator[InteractionSSEEvent]":
+    """Views a fabricated SSE stream double as the real SDK event stream a signature expects."""
+    return cast("AsyncIterator[InteractionSSEEvent]", fake)
+
+
 def _created_event(*, interaction_id: str = "int_9", event_id: str = "e1") -> SimpleNamespace:
     return SimpleNamespace(
         event_type="interaction.created",
@@ -242,7 +262,7 @@ async def test_stream_antigravity_persists_id_streams_and_returns_terminal_resul
         persisted.append(interaction_id)
 
     result = await agent.stream_antigravity(
-        client=client,
+        client=_as_client(client),
         agent="antigravity-preview-05-2026",
         brief="b",
         system_instruction="sys",
@@ -280,7 +300,7 @@ async def test_stream_reconnects_when_stream_ends_without_terminal(monkeypatch) 
         return None
 
     result = await agent.stream_antigravity(
-        client=client,
+        client=_as_client(client),
         agent="a",
         brief="b",
         system_instruction="s",
@@ -310,7 +330,7 @@ async def test_stream_reconnects_after_a_mid_stream_drop(monkeypatch) -> None:  
         return None
 
     result = await agent.stream_antigravity(
-        client=client,
+        client=_as_client(client),
         agent="a",
         brief="b",
         system_instruction="s",
@@ -339,7 +359,7 @@ async def test_stream_falls_back_to_poll_when_streaming_gives_up(monkeypatch) ->
     # Streaming exhausts its reconnects, so the driver degrades to the poll and still returns the
     # authoritative terminal result.
     result = await agent.stream_antigravity(
-        client=client,
+        client=_as_client(client),
         agent="a",
         brief="b",
         system_instruction="s",
@@ -363,7 +383,7 @@ async def test_stream_antigravity_reraises_when_create_never_yields_an_id() -> N
     raised = False
     try:
         await agent.stream_antigravity(
-            client=client,
+            client=_as_client(client),
             agent="a",
             brief="b",
             system_instruction="s",
@@ -381,7 +401,7 @@ async def test_resume_research_stream_drives_from_get_stream() -> None:
     )
     streamer = ResearchProgressStreamer(status=None, label="Deep Research")
     result = await agent.resume_research_stream(
-        client=client, interaction_id="int_9", streamer=streamer
+        client=_as_client(client), interaction_id="int_9", streamer=streamer
     )
     # Resume re-attaches via get(stream=True) and never calls create.
     assert client.aio.interactions.create_kwargs == {}
@@ -401,7 +421,7 @@ async def test_stream_plan_passes_research_tools_and_returns_plan() -> None:
     )
     streamer = ResearchProgressStreamer(status=None, label="Deep Research", action="Planning")
     plan = await agent.stream_plan(
-        client=client,
+        client=_as_client(client),
         agent="deep-research-preview-04-2026",
         brief="b",
         system_instruction="sys",
@@ -429,7 +449,7 @@ async def test_stream_refine_passes_research_tools_and_returns_plan() -> None:
     )
     streamer = ResearchProgressStreamer(status=None, label="Deep Research", action="Re-planning")
     plan = await agent.stream_refine(
-        client=client,
+        client=_as_client(client),
         agent="deep-research-preview-04-2026",
         previous_interaction_id="plan_v1",
         feedback="tighten the scope",
@@ -442,18 +462,20 @@ async def test_stream_refine_passes_research_tools_and_returns_plan() -> None:
 
 
 def test_is_terminal_event_classifies_statuses() -> None:
-    assert agent._is_terminal_event(event=_completed_event()) is True
+    assert agent._is_terminal_event(event=_as_event(_completed_event())) is True
     assert (
         agent._is_terminal_event(
-            event=SimpleNamespace(event_type="error", error=SimpleNamespace(message="boom"))
+            event=_as_event(
+                SimpleNamespace(event_type="error", error=SimpleNamespace(message="boom"))
+            )
         )
         is True
     )
     running = SimpleNamespace(event_type="interaction.status_update", status="in_progress")
-    assert agent._is_terminal_event(event=running) is False
+    assert agent._is_terminal_event(event=_as_event(running)) is False
     failed = SimpleNamespace(event_type="interaction.status_update", status="budget_exceeded")
-    assert agent._is_terminal_event(event=failed) is True
-    assert agent._is_terminal_event(event=_thought_event("x")) is False
+    assert agent._is_terminal_event(event=_as_event(failed)) is True
+    assert agent._is_terminal_event(event=_as_event(_thought_event("x"))) is False
 
 
 def test_to_result_extracts_text_image_and_usage() -> None:
@@ -515,12 +537,14 @@ def test_latest_thought_reads_thought_step_summary() -> None:
 
 def test_streamer_feed_accumulates_only_thought_summaries() -> None:
     streamer = ResearchProgressStreamer(status=None, label="Antigravity")
-    streamer._feed(event=_thought_event("searching..."))
+    streamer._feed(event=_as_event(_thought_event("searching...")))
     text_delta = SimpleNamespace(
         event_type="step.delta", event_id="x", delta=SimpleNamespace(type="text", text="body")
     )
-    streamer._feed(event=text_delta)  # report text is delivered separately, not shown as reasoning
-    streamer._feed(event=_created_event())  # non-delta events are ignored
+    streamer._feed(
+        event=_as_event(text_delta)
+    )  # report text is delivered separately, not reasoning
+    streamer._feed(event=_as_event(_created_event()))  # non-delta events are ignored
     assert streamer.reasoning == "searching..."
 
 
@@ -538,7 +562,7 @@ async def test_streamer_write_snapshot_edits_and_skips_unchanged() -> None:
     streamer = ResearchProgressStreamer(status=status, label="Antigravity", reasoning="thinking")
     await streamer._write_preview_snapshot()
     assert len(status.edits) == 1
-    assert status.edits[0]["allowed_mentions"].everyone is False
+    assert cast("AllowedMentions", status.edits[0]["allowed_mentions"]).everyone is False
     # A second write of the same rendered snapshot is a no-op, so the editor never spams edits.
     streamer._displayed = streamer._render_preview()
     await streamer._write_preview_snapshot()
@@ -550,7 +574,9 @@ async def test_streamer_stream_accumulates_and_stops_editor_cleanly() -> None:
     streamer = ResearchProgressStreamer(
         status=status, label="Antigravity", preview_interval_seconds=0.01
     )
-    await streamer.stream(events=_FakeStream([_thought_event("aaa"), _thought_event("bbb")]))
+    await streamer.stream(
+        events=_as_event_stream(_FakeStream([_thought_event("aaa"), _thought_event("bbb")]))
+    )
     assert streamer.reasoning == "aaabbb"
     assert streamer._editor_task is None  # the cadence editor is always stopped in finally
 
@@ -601,7 +627,9 @@ def test_owner_allowed_mentions_blocks_everyone_and_roles() -> None:
     mentions = research_cog._owner_allowed_mentions(owner_id=42)
     assert mentions.everyone is False
     assert mentions.roles is False
-    assert [obj.id for obj in mentions.users] == [42]
+    users = mentions.users
+    assert isinstance(users, list)
+    assert [obj.id for obj in users] == [42]
 
 
 def test_failure_text_distinguishes_budget() -> None:
@@ -924,10 +952,8 @@ async def test_delivery_hosts_oversized_report_file(tmp_path: Path) -> None:
     thread.guild = SimpleNamespace(filesize_limit=4)  # tiny ceiling so research.md is oversize
     planner = MediaDeliveryPlanner(
         media_hosting=MediaHostingService(
-            config=MediaHostingConfig(
-                MEDIA_HOSTING_ENABLED=True,
-                MEDIA_HOSTING_BASE_URL="https://media.test",
-                MEDIA_HOSTING_SERVE_DIR=str(tmp_path),
+            config=make_media_hosting_config(
+                enabled=True, base_url="https://media.test", serve_dir=str(tmp_path)
             )
         )
     )

--- a/tests/test_server_memory.py
+++ b/tests/test_server_memory.py
@@ -1,7 +1,7 @@
 """Tests for the bot's per-server (community) long-term memory flavor."""
 
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 from pathlib import Path
 
 from nextcord import Embed
@@ -193,7 +193,7 @@ async def test_memory_server_show_displays_stored_memory(memory_isolated_dir: Pa
     )
     cog = _server_cog()
     interaction = _guild_interaction()
-    await MemoryCogs.memory_server_show.callback(cog, cast("Interaction", interaction))
+    await MemoryCogs.memory_server_show.callback(cog, cast("Interaction[Any]", interaction))
     assert interaction.response.sent["ephemeral"] is True
     embed = interaction.response.sent["embed"]
     assert isinstance(embed, Embed)
@@ -203,7 +203,7 @@ async def test_memory_server_show_displays_stored_memory(memory_isolated_dir: Pa
 async def test_memory_server_show_handles_empty_memory(memory_isolated_dir: Path) -> None:
     cog = _server_cog()
     interaction = _guild_interaction()
-    await MemoryCogs.memory_server_show.callback(cog, cast("Interaction", interaction))
+    await MemoryCogs.memory_server_show.callback(cog, cast("Interaction[Any]", interaction))
     embed = interaction.response.sent["embed"]
     assert isinstance(embed, Embed)
     assert "還沒有對這個伺服器的記憶" in (embed.description or "")
@@ -212,7 +212,7 @@ async def test_memory_server_show_handles_empty_memory(memory_isolated_dir: Path
 async def test_memory_server_show_blocks_dms(memory_isolated_dir: Path) -> None:
     cog = _server_cog()
     interaction = _guild_interaction(guild_id=None)
-    await MemoryCogs.memory_server_show.callback(cog, cast("Interaction", interaction))
+    await MemoryCogs.memory_server_show.callback(cog, cast("Interaction[Any]", interaction))
     embed = interaction.response.sent["embed"]
     assert isinstance(embed, Embed)
     assert "只能在伺服器" in (embed.description or "")

--- a/tests/test_stock_views.py
+++ b/tests/test_stock_views.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 from io import BytesIO
 from types import SimpleNamespace
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 import asyncio
 from datetime import datetime
 
 from PIL import Image
 import pytest
 from nextcord import File, Embed, Locale
+from nextcord.ui import StringSelect
 
 from discordbot.cogs import stock
 from discordbot.utils import owned_message_views
@@ -18,6 +19,7 @@ from discordbot.cogs.stock import StockCogs
 from discordbot.cogs._stock import views as stock_views
 from discordbot.typings.stock import (
     StockAction,
+    StockNewsView,
     StockMarketQuote,
     StockProfileView,
     StockPositionView,
@@ -46,6 +48,11 @@ from discordbot.cogs._stock.presentation import (
     build_stock_detail_embed,
     _build_market_board_image_cached,
 )
+
+from tests.helpers.casting import as_bot, as_message, as_interaction, make_not_found
+
+if TYPE_CHECKING:
+    from discordbot.cogs._stock.news import StockNewsAI
 
 BCAT_SYMBOL = "BCAT"
 BCAT_NAME = "破貓科技股份有限公司"
@@ -120,8 +127,7 @@ class DeletedMessageStub(MessageStub):
 
     async def edit(self, **kwargs: Any) -> None:  # noqa: ANN401 -- test double
         """Raises the same exception nextcord emits for deleted messages."""
-        response = SimpleNamespace(status=404, reason="Not Found", headers={})
-        raise stock_views.nextcord.NotFound(response=response, message="missing")
+        raise make_not_found(message="missing")
 
 
 class UserStub:
@@ -240,7 +246,7 @@ def test_stock_setup_is_sync_and_adds_cog_with_override() -> None:
             """Records add_cog arguments."""
             calls.append({"cog": cog, "override": override})
 
-    stock.setup(BotStub())
+    stock.setup(bot=as_bot(fake=BotStub()))
 
     assert isinstance(calls[0]["cog"], StockCogs)
     assert calls[0]["override"] is True
@@ -271,7 +277,7 @@ async def test_stock_command_sends_public_market_and_schedules_cleanup(
     monkeypatch.setattr(stock, "list_market_quotes", fake_list_market_quotes)
     monkeypatch.setattr(stock, "_schedule_stock_news_refresh", fake_schedule_stock_news_refresh)
     monkeypatch.setattr(stock, "track_public_message", fake_track)
-    cog = StockCogs(bot=SimpleNamespace())
+    cog = StockCogs(bot=as_bot(fake=SimpleNamespace()))
     cog.__dict__["news_ai"] = SimpleNamespace(generate=lambda _profile: None)
     interaction = InteractionStub()
 
@@ -305,7 +311,7 @@ async def test_stock_news_background_refresh_is_deduped(monkeypatch: pytest.Monk
     monkeypatch.setattr(stock, "ensure_due_stock_news", fake_ensure_due_stock_news)
     monkeypatch.setattr(stock, "_stock_news_refresh_task", None)
     monkeypatch.setattr(stock, "_stock_news_refresh_task_loop", None)
-    news_ai = SimpleNamespace(generate=lambda _context: None)
+    news_ai = cast("StockNewsAI", SimpleNamespace(generate=lambda _context: None))
 
     stock._schedule_stock_news_refresh(news_ai=news_ai)
     await started.wait()
@@ -336,7 +342,7 @@ async def test_stock_command_raises_when_interaction_has_no_user(
         return (_quote(),)
 
     monkeypatch.setattr(stock, "list_market_quotes", fake_list_market_quotes)
-    cog = StockCogs(bot=SimpleNamespace())
+    cog = StockCogs(bot=as_bot(fake=SimpleNamespace()))
     interaction = InteractionStub(user_id=None)
 
     with pytest.raises(RuntimeError, match="missing Discord user identity"):
@@ -352,8 +358,11 @@ async def test_stock_public_view_rejects_non_owner_interaction() -> None:
     view = StockMarketView(quotes=(_quote(),), owner_id=1)
     intruder = InteractionStub(user_id=2, name="bob")
 
-    assert await view.interaction_check(interaction=InteractionStub(user_id=1)) is True
-    assert await view.interaction_check(interaction=intruder) is False
+    assert (
+        await view.interaction_check(interaction=as_interaction(fake=InteractionStub(user_id=1)))
+        is True
+    )
+    assert await view.interaction_check(interaction=as_interaction(fake=intruder)) is False
     assert intruder.response.sent[0]["ephemeral"] is True
     assert "只有發起者" in intruder.response.sent[0]["content"]
 
@@ -374,9 +383,10 @@ async def test_stock_market_select_edits_public_detail(monkeypatch: pytest.Monke
     monkeypatch.setattr(stock_views, "edit_stock_detail", fake_edit_stock_detail)
     view = StockMarketView(quotes=(_quote(),), owner_id=1)
     interaction = InteractionStub()
-    view.stock_select._selected_values = [BCAT_SYMBOL]
+    stock_select = cast("StringSelect[StockMarketView]", view.stock_select)
+    stock_select._selected_values = [BCAT_SYMBOL]
 
-    await view.stock_select.callback(interaction)
+    await stock_select.callback(interaction=as_interaction(fake=interaction))
 
     assert selected == [BCAT_SYMBOL]
     assert interaction.user is not None
@@ -388,7 +398,8 @@ async def test_stock_market_select_edits_public_detail(monkeypatch: pytest.Monke
 async def test_stock_market_select_truncates_long_company_names() -> None:
     """The market dropdown keeps option labels inside Discord's limit."""
     view = StockMarketView(quotes=(_quote(name="長" * 128),), owner_id=1)
-    option = view.stock_select.options[0]
+    stock_select = cast("StringSelect[StockMarketView]", view.stock_select)
+    option = stock_select.options[0]
 
     assert len(option.label) == stock_views.SELECT_OPTION_LABEL_LIMIT
     assert option.label.startswith(f"{BCAT_SYMBOL} · 長")
@@ -401,6 +412,7 @@ def test_stock_market_embed_uses_board_attachment_for_rows() -> None:
     embed = build_market_embed(quotes=(_quote(),), board_filename=filename)
 
     assert embed.image.url == f"attachment://{filename}"
+    assert embed.description is not None
     assert "市值" not in embed.description
     assert "100,000,000" not in embed.description
 
@@ -471,7 +483,7 @@ async def test_stock_detail_buttons_edit_same_public_message(
 ) -> None:
     """Detail buttons edit the original public message instead of sending followups."""
 
-    async def fake_news(symbol: str) -> tuple:
+    async def fake_news(symbol: str) -> tuple[StockNewsView, ...]:
         """Returns no fake news."""
         return ()
 
@@ -502,7 +514,7 @@ async def test_stock_detail_buttons_edit_same_public_message(
     )
 
     operate_interaction = InteractionStub()
-    await operate.callback(operate_interaction)
+    await operate.callback(as_interaction(fake=operate_interaction))
     assert operate_interaction.response.deferred
     embed = operate_interaction.message.edits[0]["embed"]
     assert isinstance(embed, Embed)
@@ -513,12 +525,12 @@ async def test_stock_detail_buttons_edit_same_public_message(
     assert isinstance(operate_interaction.message.edits[0]["view"], StockActionView)
 
     news_interaction = InteractionStub()
-    await news.callback(news_interaction)
+    await news.callback(as_interaction(fake=news_interaction))
     assert "近期新聞" in news_interaction.response.sent[0]["embed"].title
     assert news_interaction.response.sent[0]["view"].owner_id == view.owner_id
 
     back_interaction = InteractionStub()
-    await back.callback(back_interaction)
+    await back.callback(as_interaction(fake=back_interaction))
     assert isinstance(back_interaction.response.sent[0]["view"], StockMarketView)
     assert back_interaction.response.sent[0]["view"].owner_id == view.owner_id
 
@@ -532,6 +544,7 @@ def test_stock_detail_embed_uses_localized_user_labels() -> None:
     assert "可用資金" in field_names
     assert "目前操作 user" not in field_names
     assert "操作 user 資金" not in field_names
+    assert embed.description is not None
     assert "市值 `1億`" in embed.description
 
 
@@ -601,13 +614,14 @@ def test_stock_detail_embed_compacts_recent_trades() -> None:
 async def test_stock_action_dropdown_launches_quantity_modal() -> None:
     """Action dropdown launches one modal with only the quantity input."""
     view = StockActionView(symbol=BCAT_SYMBOL, owner_id=1)
-    action_select = next(
+    child = next(
         child for child in view.children if getattr(child, "custom_id", "") == "stock:action"
     )
-    action_select._selected_values = [StockAction.SHORT.value]
+    assert isinstance(child, StringSelect)
+    child._selected_values = [StockAction.SHORT.value]
 
     interaction = InteractionStub()
-    await action_select.callback(interaction)
+    await child.callback(interaction=as_interaction(fake=interaction))
 
     assert interaction.response.modals[0].action == StockAction.SHORT
     assert interaction.response.modals[0].owner_id == view.owner_id
@@ -644,7 +658,7 @@ async def test_stock_modal_rejects_non_owner_before_settlement(
     modal = StockQuantityModal(symbol=BCAT_SYMBOL, action=StockAction.BUY, owner_id=1)
     intruder = InteractionStub(user_id=2, name="bob")
 
-    await modal.submit_quantity(interaction=intruder, raw_quantity="1")
+    await modal.submit_quantity(interaction=as_interaction(fake=intruder), raw_quantity="1")
 
     assert calls == []
     assert intruder.response.sent[0]["ephemeral"] is True
@@ -676,7 +690,7 @@ async def test_stock_modal_reports_invalid_input_root_cause_in_public_message(
     modal = StockQuantityModal(symbol=BCAT_SYMBOL, action=StockAction.BUY, owner_id=1)
     interaction = InteractionStub()
 
-    await modal.submit_quantity(interaction=interaction, raw_quantity="abc")
+    await modal.submit_quantity(interaction=as_interaction(fake=interaction), raw_quantity="abc")
 
     assert interaction.response.deferred
     assert not interaction.response.deferred_ephemeral
@@ -730,7 +744,7 @@ async def test_successful_stock_modal_edits_result_and_refresh_view(
     modal = StockQuantityModal(symbol=BCAT_SYMBOL, action=StockAction.BUY, owner_id=1)
     interaction = InteractionStub()
 
-    await modal.submit_quantity(interaction=interaction, raw_quantity="1")
+    await modal.submit_quantity(interaction=as_interaction(fake=interaction), raw_quantity="1")
 
     assert not interaction.response.deferred_ephemeral
     assert "交易完成" in interaction.message.edits[0]["embed"].title
@@ -789,11 +803,11 @@ async def test_edit_owned_public_message_recovers_when_target_was_deleted(
     chart_file = File(fp=BytesIO(b"chart-bytes"), filename="chart.png")
 
     await owned_message_views.edit_owned_public_message(
-        interaction=interaction,
+        interaction=as_interaction(fake=interaction),
         embed=Embed(title="股票交易完成"),
         view=view,
         file=chart_file,
-        message=interaction.message,
+        message=as_message(fake=interaction.message),
     )
 
     assert interaction.followup.sent[0].get("ephemeral") is not True
@@ -819,7 +833,7 @@ async def test_stock_public_view_timeout_deletes_bound_message(
     monkeypatch.setattr(owned_message_views, "delete_public_message", fake_delete)
     message = MessageStub()
     view = StockPublicView(owner_id=1)
-    view.bind_message(message=message)
+    view.bind_message(message=as_message(fake=message))
 
     await view.on_timeout()
 

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -1,6 +1,7 @@
 """Tests for YouTube URL detection and the Gemini Interactions answer-path adapters."""
 
 from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
 from collections.abc import AsyncIterator
 
 import pytest
@@ -10,6 +11,12 @@ from discordbot.cogs._gen_reply.interactions import (
     to_interactions_input,
     adapt_interactions_stream,
 )
+
+from tests.helpers.casting import step_dicts
+
+if TYPE_CHECKING:
+    from google.genai.interactions import InteractionSSEEvent
+    from openai.types.responses.response_input_param import ResponseInputParam
 
 
 @pytest.mark.parametrize(
@@ -69,8 +76,11 @@ def test_to_interactions_input_maps_roles_and_appends_video() -> None:
         {"role": "user", "content": [{"type": "input_text", "text": "what happens here"}]},
     ]
 
-    steps = to_interactions_input(
-        answer_input=answer_input, youtube_url="https://youtu.be/abcdefghijk"
+    steps = step_dicts(
+        steps=to_interactions_input(
+            answer_input=cast("ResponseInputParam", answer_input),
+            youtube_url="https://youtu.be/abcdefghijk",
+        )
     )
 
     # system + user coalesce into one user_input step; assistant is its own model_output step.
@@ -99,8 +109,11 @@ def test_to_interactions_input_maps_media_parts_by_kind() -> None:
         }
     ]
 
-    steps = to_interactions_input(
-        answer_input=answer_input, youtube_url="https://youtu.be/abcdefghijk"
+    steps = step_dicts(
+        steps=to_interactions_input(
+            answer_input=cast("ResponseInputParam", answer_input),
+            youtube_url="https://youtu.be/abcdefghijk",
+        )
     )
 
     parts = steps[-1]["content"]
@@ -114,7 +127,9 @@ def test_to_interactions_input_maps_media_parts_by_kind() -> None:
 
 def test_to_interactions_input_skips_empty_and_handles_no_user_step() -> None:
     """Empty content is dropped, and a video with no prior user step still gets one."""
-    steps = to_interactions_input(answer_input=[], youtube_url="https://youtu.be/abcdefghijk")
+    steps = step_dicts(
+        steps=to_interactions_input(answer_input=[], youtube_url="https://youtu.be/abcdefghijk")
+    )
     assert len(steps) == 1
     assert steps[0]["type"] == "user_input"
     assert steps[0]["content"] == [{"type": "video", "uri": "https://youtu.be/abcdefghijk"}]
@@ -152,11 +167,24 @@ async def _aiter(events: list[SimpleNamespace]) -> AsyncIterator[SimpleNamespace
         yield event
 
 
+def _as_stream(events: list[SimpleNamespace]) -> "AsyncIterator[InteractionSSEEvent]":
+    """Views the fabricated events as the real SDK stream the adapter consumes.
+
+    Production discriminates on `.event_type`, not isinstance, so SimpleNamespace events are safe.
+    """
+    return cast("AsyncIterator[InteractionSSEEvent]", _aiter(events=events))
+
+
+def _ns(event: object) -> SimpleNamespace:
+    """Narrows an adapted event to the namespace shape the adapter fabricates."""
+    assert isinstance(event, SimpleNamespace)
+    return event
+
+
 async def test_adapt_interactions_stream_remaps_to_responses_events() -> None:
     """Interactions events become Responses-shaped events the streamer consumes."""
-    out = [
-        event async for event in adapt_interactions_stream(stream=_aiter(_interaction_events()))
-    ]
+    stream = adapt_interactions_stream(stream=_as_stream(events=_interaction_events()))
+    out = [event async for event in stream]
 
     types = [event.type for event in out]
     assert types == [
@@ -166,12 +194,12 @@ async def test_adapt_interactions_stream_remaps_to_responses_events() -> None:
         "response.output_text.delta",
         "response.completed",
     ]
-    assert out[0].response.model == "gemini-3.1-pro-preview"
-    assert out[1].delta == "hmm"
-    assert out[2].delta == "Hello"
+    assert _ns(event=out[0]).response.model == "gemini-3.1-pro-preview"
+    assert _ns(event=out[1]).delta == "hmm"
+    assert _ns(event=out[2]).delta == "Hello"
     # Usage is emitted once, on completion, with the Responses field names.
-    assert out[-1].response.usage.input_tokens == 12
-    assert out[-1].response.usage.output_tokens == 34
+    assert _ns(event=out[-1]).response.usage.input_tokens == 12
+    assert _ns(event=out[-1]).response.usage.output_tokens == 34
 
 
 async def test_adapt_interactions_stream_raises_on_error_event() -> None:
@@ -179,5 +207,5 @@ async def test_adapt_interactions_stream_raises_on_error_event() -> None:
     events = [SimpleNamespace(event_type="error", error="boom")]
 
     with pytest.raises(RuntimeError):
-        async for _ in adapt_interactions_stream(stream=_aiter(events)):
+        async for _ in adapt_interactions_stream(stream=_as_stream(events=events)):
             pass


### PR DESCRIPTION
## Summary

Adopts Astral's ty ahead of mypy in pre-commit (the configuration ported from the template, see #366) and fixes all 1369 diagnostics it surfaced at the root cause — no rule downgrades, no excludes, and the ported `[tool.ty.rules]` config is byte-identical to the first commit.

Closes #366.

## Status

- [x] Commit 1: ty adoption (pre-commit hook `v0.0.63` + `--all-groups`, `[tool.ty.rules]` stricter config, Ruff `PGH003`, README badges, CONTRIBUTING)
- [x] src fixes (362 diagnostics → 0)
- [x] tests fixes (982 → 0)
- [x] scripts fixes (25 → 0)
- [x] `uv run pre-commit run -a` green (ruff, ty, mypy, all hooks)
- [x] `uv run pytest` green: 1325 passed, coverage 85.96% (gate 80%)

## Real bugs the migration surfaced

- `_gen_reply/interactions.py`: the usage fallback read `event.metadata.usage`, but the genai `StreamMetadata` model only has `total_usage` — the fallback path would have raised `AttributeError` at runtime.
- `_memory/views.py`: the pages-view timeout called `edit_original_response`, which does not exist on nextcord's `Interaction` (discord.py naming); the call always raised under `contextlib.suppress`, so timeout never actually disabled the buttons.
- `scripts/test_fallback.py`: `model_name` was bound only inside the stream loop and read after it — a latent `NameError` on an empty stream.

## Conventions established

- nextcord generics are parametrized repo-wide: `Interaction[commands.Bot]`, `Button["OwningView"]` (`Button[View]` in shared helpers), `Context[commands.Bot]`; src never adds `from __future__ import annotations` to cog modules (slash registration evaluates annotations).
- Test doubles stay plain classes; `tests/helpers/casting.py` centralizes the cast adapters (`as_message` / `as_interaction` / `as_bot` / `step_dicts` / `make_media_hosting_config` / `make_not_found`) applied at production-call boundaries.
- Optional narrowing is explicit guards (`x = ...; if x is None: return`), and `str | None` membership assertions gained `assert ... is not None` (strictly stronger tests).

## ty: ignore ledger

Every `# ty: ignore` in the diff:

| Site | Rule | Reason |
|---|---|---|
| `scripts/trading.py` (2 imports) | `unresolved-import` | `tradingagents` is an intentionally-external dependency for a kept-for-later standalone script; not in any dependency group by design |

Three pre-existing mypy `# type: ignore[...]` comments in tests became unnecessary and were removed (their sites are now typed for real).

## Behavior-adjacent fix shapes for review focus

All covered by the existing suite (1325 tests, assertions unchanged or strengthened):

- `_stock/database.py`: the settlement guard now also discriminates the planning union by `isinstance` (fail-closed; `.success` still short-circuits first).
- `_research/views.py`: the disabled Max button is removed via a `self.children` lookup by `custom_id` instead of the decorated-method attribute.
- `utils/message_cleanup.py`: channel capability check moved from `hasattr(..., "fetch_message")` to `isinstance(..., Messageable)` (equivalent for nextcord channel types).
- `utils/avatars.py`: `AvatarUser` protocol members became read-only properties (call sites unchanged).
- Optional guards add early returns in event handlers where the value is impossible-in-practice `None`.
