### PR TITLE
refactor: tighten followup typing and dedupe test cast adapters

### DIFF
--- a/src/discordbot/cogs/_economy/interactions.py
+++ b/src/discordbot/cogs/_economy/interactions.py
@@ -1,6 +1,6 @@
 """Shared send/edit helpers for economy interaction responses."""
 
-from typing import Any, Protocol, cast
+from typing import Protocol, cast
 
 from nextcord import File, Embed, Message, Interaction
 from nextcord.ui import View
@@ -24,16 +24,13 @@ async def send_expiring_followup(
 ) -> None:
     """Sends a game-related economy embed and schedules its cleanup."""
     extra_files = [file] if file is not None else None
-    kwargs: dict[str, Any] = {
-        "embed": embed,
-        "wait": True,
-        **embed_spacer_payload(
-            embeds=[embed], is_edit=False, target=interaction, extra_files=extra_files
-        ),
-    }
+    spacer = embed_spacer_payload(
+        embeds=[embed], is_edit=False, target=interaction, extra_files=extra_files
+    )
     if view is not None:
-        kwargs["view"] = view
-    message = await interaction.followup.send(**kwargs)
+        message = await interaction.followup.send(embed=embed, view=view, wait=True, **spacer)
+    else:
+        message = await interaction.followup.send(embed=embed, wait=True, **spacer)
     user_name = interaction.user.name if interaction.user is not None else None
     schedule_public_message_delete(message=message, user_name=user_name)
 

--- a/tests/helpers/casting.py
+++ b/tests/helpers/casting.py
@@ -17,7 +17,15 @@ from nextcord.ext import commands
 from discordbot.utils.media_delivery import MediaHostingConfig
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from google import genai
     from aiohttp import ClientResponse
+    from nextcord import Guild
+    from google.genai.interactions import InteractionSSEEvent
+
+    from discordbot import cli
+    from discordbot.utils.avatars import AvatarUser
 
 
 def as_message(fake: object) -> Message:
@@ -35,6 +43,26 @@ def as_bot(fake: object) -> commands.Bot:
     return cast("commands.Bot", fake)
 
 
+def as_discord_bot(fake: object) -> "cli.DiscordBot":
+    """Views a bot double as cli.DiscordBot for its own unbound method calls."""
+    return cast("cli.DiscordBot", fake)
+
+
+def as_command_context(fake: object) -> "commands.Context[commands.Bot]":
+    """Views a context double as the commands.Context a command handler expects."""
+    return cast("commands.Context[commands.Bot]", fake)
+
+
+def as_avatar_user(fake: object) -> "AvatarUser":
+    """Views a fake user double as the AvatarUser protocol ``guild_avatar_url`` expects."""
+    return cast("AvatarUser", fake)
+
+
+def as_guild(fake: object) -> "Guild | None":
+    """Views a fake guild double as the nextcord Guild ``guild_avatar_url`` expects."""
+    return cast("Guild | None", fake)
+
+
 def step_dicts(steps: object) -> list[dict[str, Any]]:
     """Views a typed input/step list as plain dicts for key-level assertions.
 
@@ -44,6 +72,25 @@ def step_dicts(steps: object) -> list[dict[str, Any]]:
     is safe.
     """
     return cast("list[dict[str, Any]]", steps)
+
+
+def as_client(fake: object) -> "genai.Client":
+    """Views a fake Gemini client double as the genai.Client a production signature expects."""
+    return cast("genai.Client", fake)
+
+
+def make_stub_gemini_client() -> "genai.Client":
+    """Builds an empty Gemini client stub for paths that never call through it."""
+    return as_client(fake=SimpleNamespace())
+
+
+def as_interaction_event_stream(fake: object) -> "AsyncIterator[InteractionSSEEvent]":
+    """Views a fabricated SSE stream double as the SDK event stream a signature expects.
+
+    Production discriminates on ``.event_type``, not isinstance, so ``SimpleNamespace``
+    events are safe.
+    """
+    return cast("AsyncIterator[InteractionSSEEvent]", fake)
 
 
 def make_not_found(message: str = "missing") -> NotFound:

--- a/tests/test_avatar_utils.py
+++ b/tests/test_avatar_utils.py
@@ -1,26 +1,21 @@
 """Tests for guild-aware Discord avatar selection."""
 
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from discordbot import cli
-from discordbot.utils.avatars import AvatarUser, guild_avatar_url
+from discordbot.utils.avatars import guild_avatar_url
 
-from tests.helpers.casting import as_message, make_not_found
+from tests.helpers.casting import (
+    as_guild,
+    as_message,
+    as_avatar_user,
+    as_discord_bot,
+    make_not_found,
+)
 
 if TYPE_CHECKING:
     import pytest
-    from nextcord import Guild
-
-
-def _as_avatar_user(fake: object) -> AvatarUser:
-    """Views a fake user as the AvatarUser protocol `guild_avatar_url` expects."""
-    return cast("AvatarUser", fake)
-
-
-def _as_guild(fake: object) -> "Guild | None":
-    """Views a fake guild as the nextcord Guild `guild_avatar_url` expects."""
-    return cast("Guild | None", fake)
 
 
 class FakeUser:
@@ -83,7 +78,7 @@ async def test_guild_avatar_url_prefers_cached_guild_avatar() -> None:
     )
 
     avatar_url = await guild_avatar_url(
-        user=_as_avatar_user(fake=FakeUser()), guild=_as_guild(fake=guild)
+        user=as_avatar_user(fake=FakeUser()), guild=as_guild(fake=guild)
     )
 
     assert avatar_url == "https://cdn.test/cached.png"
@@ -98,7 +93,7 @@ async def test_guild_avatar_url_fetches_member_when_cache_misses() -> None:
     )
 
     avatar_url = await guild_avatar_url(
-        user=_as_avatar_user(fake=FakeUser()), guild=_as_guild(fake=guild)
+        user=as_avatar_user(fake=FakeUser()), guild=as_guild(fake=guild)
     )
 
     assert avatar_url == "https://cdn.test/fetched.png"
@@ -110,8 +105,8 @@ async def test_guild_avatar_url_falls_back_to_global_avatar() -> None:
     guild = FakeGuild(cached_member=None, fetched_member=None)
 
     avatar_url = await guild_avatar_url(
-        user=_as_avatar_user(fake=FakeUser(avatar_url="https://cdn.test/global.png")),
-        guild=_as_guild(fake=guild),
+        user=as_avatar_user(fake=FakeUser(avatar_url="https://cdn.test/global.png")),
+        guild=as_guild(fake=guild),
     )
 
     assert avatar_url == "https://cdn.test/global.png"
@@ -153,6 +148,6 @@ async def test_message_reward_stores_guild_avatar(monkeypatch: "pytest.MonkeyPat
         user=object(), process_commands=noop_process_commands, _message_reward_at={}
     )
 
-    await cli.DiscordBot.on_message(cast("cli.DiscordBot", bot), message=as_message(fake=message))
+    await cli.DiscordBot.on_message(as_discord_bot(fake=bot), message=as_message(fake=message))
 
     assert captured_avatar_url == "https://cdn.test/server.png"

--- a/tests/test_cogs_smoke.py
+++ b/tests/test_cogs_smoke.py
@@ -67,7 +67,14 @@ from discordbot.cogs._games.blackjack_views import BlackjackLobbyView
 from discordbot.cogs._games.dragon_gate_views import DragonGateLobbyView
 
 from tests.helpers.embeds import assert_embed_has_field, assert_embed_title_prefix
-from tests.helpers.casting import as_bot, as_message, as_interaction, make_media_hosting_config
+from tests.helpers.casting import (
+    as_bot,
+    as_message,
+    as_discord_bot,
+    as_interaction,
+    as_command_context,
+    make_media_hosting_config,
+)
 from tests.helpers.discord_mocks import (
     FakeUser,
     DiscordPayload,
@@ -2090,16 +2097,6 @@ async def test_games_on_ready_cleans_stale_messages_once(monkeypatch: pytest.Mon
     assert calls == [bot]
 
 
-def _as_discord_bot(fake: object) -> cli.DiscordBot:
-    """Views a bot double as cli.DiscordBot for its own unbound method calls."""
-    return cast("cli.DiscordBot", fake)
-
-
-def _as_command_context(fake: object) -> commands.Context[commands.Bot]:
-    """Views a context double as commands.Context for on_command_error."""
-    return cast("commands.Context[commands.Bot]", fake)
-
-
 def test_setup_functions_register_cogs(monkeypatch: pytest.MonkeyPatch) -> None:
     """Verifies every cog setup function registers the expected cog type."""
     added: list[
@@ -2153,7 +2150,7 @@ def test_cli_loads_cogs_and_handles_command_errors(tmp_path: Path) -> None:
         loaded.append((modules, stop_at_error))
 
     bot = SimpleNamespace(load_extensions=record_load_extensions)
-    cli.DiscordBot._load_cogs_sync(_as_discord_bot(fake=bot))
+    cli.DiscordBot._load_cogs_sync(as_discord_bot(fake=bot))
     assert loaded[0][1] is True
     assert "discordbot.cogs.template" in loaded[0][0]
 
@@ -2182,12 +2179,12 @@ async def test_cli_message_and_command_error_branches(monkeypatch: pytest.Monkey
     )
     user_message = SimpleNamespace(author=FakeUser(user_id=1, bot=False))
     await cli.DiscordBot.on_message(
-        _as_discord_bot(fake=bot), message=as_message(fake=user_message)
+        as_discord_bot(fake=bot), message=as_message(fake=user_message)
     )
     assert processed == [user_message]
     assert rewards[0]["amount"] == cli.BASE_MESSAGE_REWARD_AMOUNT
     await cli.DiscordBot.on_message(
-        _as_discord_bot(fake=bot), message=as_message(fake=SimpleNamespace(author=bot.user))
+        as_discord_bot(fake=bot), message=as_message(fake=SimpleNamespace(author=bot.user))
     )
     assert len(processed) == 1
     assert len(rewards) == 1
@@ -2205,21 +2202,21 @@ async def test_cli_message_and_command_error_branches(monkeypatch: pytest.Monkey
         command=SimpleNamespace(qualified_name="demo"),
     )
     await cli.DiscordBot.on_command_error(
-        _as_discord_bot(fake=bot), _as_command_context(fake=context), commands.NotOwner()
+        as_discord_bot(fake=bot), as_command_context(fake=context), commands.NotOwner()
     )
     await cli.DiscordBot.on_command_error(
-        _as_discord_bot(fake=bot),
-        _as_command_context(fake=context),
+        as_discord_bot(fake=bot),
+        as_command_context(fake=context),
         commands.MissingPermissions(missing_permissions=["kick_members"]),
     )
     await cli.DiscordBot.on_command_error(
-        _as_discord_bot(fake=bot),
-        _as_command_context(fake=context),
+        as_discord_bot(fake=bot),
+        as_command_context(fake=context),
         commands.BotMissingPermissions(missing_permissions=["send_messages"]),
     )
     await cli.DiscordBot.on_command_error(
-        _as_discord_bot(fake=bot),
-        _as_command_context(fake=context),
+        as_discord_bot(fake=bot),
+        as_command_context(fake=context),
         commands.CommandNotFound("nope"),
     )
     assert len(sent) == 4
@@ -2234,8 +2231,8 @@ async def test_cli_message_and_command_error_branches(monkeypatch: pytest.Monkey
 
     monkeypatch.setattr(cli.logfire, "error", record_error)
     await cli.DiscordBot.on_command_error(
-        _as_discord_bot(fake=bot),
-        _as_command_context(fake=context),
+        as_discord_bot(fake=bot),
+        as_command_context(fake=context),
         commands.CommandInvokeError(ValueError("boom")),
     )
     assert len(sent) == 4
@@ -2270,13 +2267,13 @@ async def test_cli_message_reward_cooldown_suppresses_rapid_repeat(
     )
     message = SimpleNamespace(author=FakeUser(user_id=1, bot=False))
 
-    await cli.DiscordBot.on_message(_as_discord_bot(fake=bot), message=as_message(fake=message))
-    await cli.DiscordBot.on_message(_as_discord_bot(fake=bot), message=as_message(fake=message))
+    await cli.DiscordBot.on_message(as_discord_bot(fake=bot), message=as_message(fake=message))
+    await cli.DiscordBot.on_message(as_discord_bot(fake=bot), message=as_message(fake=message))
     assert len(rewards) == 1
 
     # Backdate the last-reward stamp so the cooldown window has elapsed.
     bot._message_reward_at[1] -= cli.MESSAGE_REWARD_COOLDOWN_SECONDS + 1
-    await cli.DiscordBot.on_message(_as_discord_bot(fake=bot), message=as_message(fake=message))
+    await cli.DiscordBot.on_message(as_discord_bot(fake=bot), message=as_message(fake=message))
     assert len(rewards) == 2
 
 
@@ -2305,7 +2302,7 @@ async def test_cli_message_reward_cooldown_prunes_expired_users(
     )
 
     await cli.DiscordBot.on_message(
-        _as_discord_bot(fake=bot),
+        as_discord_bot(fake=bot),
         message=as_message(fake=SimpleNamespace(author=FakeUser(user_id=3, bot=False))),
     )
 
@@ -2339,9 +2336,9 @@ async def test_cli_message_reward_cooldown_rolls_back_on_credit_failure(
     )
     message = SimpleNamespace(author=FakeUser(user_id=1, bot=False))
 
-    await cli.DiscordBot.on_message(_as_discord_bot(fake=bot), message=as_message(fake=message))
+    await cli.DiscordBot.on_message(as_discord_bot(fake=bot), message=as_message(fake=message))
     # The first credit failed, so the slot is rolled back and the next message retries.
     assert 1 not in bot._message_reward_at
-    await cli.DiscordBot.on_message(_as_discord_bot(fake=bot), message=as_message(fake=message))
+    await cli.DiscordBot.on_message(as_discord_bot(fake=bot), message=as_message(fake=message))
     assert attempts == 2
     assert bot._message_reward_at.get(1) is not None

--- a/tests/test_files_api.py
+++ b/tests/test_files_api.py
@@ -2,7 +2,6 @@
 
 import io
 from types import SimpleNamespace
-from typing import cast
 import asyncio
 from pathlib import Path
 
@@ -14,6 +13,8 @@ from discordbot.cogs._gen_reply.files_api import (
     upload_to_files_api,
     upload_as_input_file,
 )
+
+from tests.helpers.casting import as_client
 
 
 class _Files:
@@ -49,7 +50,7 @@ class _Files:
 
 def _client(files: _Files) -> genai.Client:
     """Wraps a fake Files resource in the client shape the helper reaches through."""
-    return cast("genai.Client", SimpleNamespace(aio=SimpleNamespace(files=files)))
+    return as_client(fake=SimpleNamespace(aio=SimpleNamespace(files=files)))
 
 
 async def test_upload_returns_the_active_uri() -> None:

--- a/tests/test_game_cleanup.py
+++ b/tests/test_game_cleanup.py
@@ -1,6 +1,5 @@
 """Tests for public response cleanup helpers."""
 
-from typing import TYPE_CHECKING, cast
 import asyncio
 from pathlib import Path
 
@@ -20,10 +19,7 @@ from discordbot.utils.message_cleanup import (
     schedule_public_message_delete,
 )
 
-from tests.helpers.casting import as_message, as_interaction, make_not_found
-
-if TYPE_CHECKING:
-    from nextcord.ext import commands
+from tests.helpers.casting import as_bot, as_message, as_interaction, make_not_found
 
 
 class _DeletableMessageStub:
@@ -222,7 +218,7 @@ async def test_delete_public_message_after_waits_then_deletes() -> None:
     """Public response cleanup deletes the message after the configured delay."""
     message = _DeletableMessageStub()
 
-    await delete_public_message_after(message=cast("Message", message), delay=0)
+    await delete_public_message_after(message=as_message(fake=message), delay=0)
 
     assert message.delete_calls == 1
 
@@ -240,20 +236,20 @@ async def test_track_public_message_persists_message_identity() -> None:
         user_name="alice",
     )
 
-    record = await track_public_message(message=cast("Message", message), user_name="alice")
+    record = await track_public_message(message=as_message(fake=message), user_name="alice")
 
     assert record == expected
     assert await list_pending_public_messages() == [expected]
-    await track_public_message(message=cast("Message", message))
+    await track_public_message(message=as_message(fake=message))
     assert await list_pending_public_messages() == [expected]
 
 
 async def test_delete_public_message_after_forgets_successful_cleanup() -> None:
     """Successful TTL cleanup removes the persisted restart record."""
     message = _DeletableMessageStub(message_id=10, channel_id=20)
-    await track_public_message(message=cast("Message", message))
+    await track_public_message(message=as_message(fake=message))
 
-    await delete_public_message_after(message=cast("Message", message), delay=0)
+    await delete_public_message_after(message=as_message(fake=message), delay=0)
 
     assert message.delete_calls == 1
     assert await list_pending_public_messages() == []
@@ -262,10 +258,10 @@ async def test_delete_public_message_after_forgets_successful_cleanup() -> None:
 async def test_delete_tracked_public_messages_deletes_stale_restart_records() -> None:
     """Startup cleanup deletes persisted Discord messages and clears the records."""
     message = _DeletableMessageStub(message_id=10, channel_id=20)
-    await track_public_message(message=cast("Message", message))
+    await track_public_message(message=as_message(fake=message))
     bot = _BotStub()
 
-    await delete_tracked_public_messages(bot=cast("commands.Bot", bot))
+    await delete_tracked_public_messages(bot=as_bot(fake=bot))
 
     assert bot.deleted == [(20, 10)]
     assert bot.fetch_calls == [20]
@@ -275,10 +271,10 @@ async def test_delete_tracked_public_messages_deletes_stale_restart_records() ->
 async def test_delete_tracked_public_messages_skips_non_messageable_cached_channel() -> None:
     """Cached PartialMessageable-like channels should be resolved via fetch_channel first."""
     message = _DeletableMessageStub(message_id=10, channel_id=20)
-    await track_public_message(message=cast("Message", message))
+    await track_public_message(message=as_message(fake=message))
     bot = _BotStub(cached_channel=_NonMessageableChannelStub())
 
-    await delete_tracked_public_messages(bot=cast("commands.Bot", bot))
+    await delete_tracked_public_messages(bot=as_bot(fake=bot))
 
     assert bot.deleted == [(20, 10)]
     assert bot.fetch_calls == [20]
@@ -288,9 +284,9 @@ async def test_delete_tracked_public_messages_skips_non_messageable_cached_chann
 async def test_delete_tracked_public_messages_keeps_unresolved_channel_records() -> None:
     """Startup cleanup keeps records when it cannot resolve a message-fetchable channel."""
     message = _DeletableMessageStub(message_id=10, channel_id=20)
-    await track_public_message(message=cast("Message", message))
+    await track_public_message(message=as_message(fake=message))
 
-    await delete_tracked_public_messages(bot=cast("commands.Bot", _UnfetchableBotStub()))
+    await delete_tracked_public_messages(bot=as_bot(fake=_UnfetchableBotStub()))
 
     assert await list_pending_public_messages() == [
         PendingPublicMessage(channel_id=20, message_id=10)
@@ -362,7 +358,7 @@ async def test_send_private_followup_is_ephemeral_and_not_scheduled(
 async def test_delete_public_message_after_ignores_already_deleted_message() -> None:
     """Manual deletion before cleanup should not surface as a task failure."""
     await delete_public_message_after(
-        message=cast("Message", _AlreadyDeletedMessageStub()), delay=0
+        message=as_message(fake=_AlreadyDeletedMessageStub()), delay=0
     )
 
 
@@ -384,7 +380,7 @@ async def test_schedule_public_message_delete_uses_default_ttl(
         fake_delete_public_message_after,
     )
 
-    schedule_public_message_delete(message=cast("Message", _DeletableMessageStub()))
+    schedule_public_message_delete(message=as_message(fake=_DeletableMessageStub()))
     await asyncio.sleep(delay=0)
 
     assert scheduled_delay == PUBLIC_MESSAGE_TTL_SECONDS

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -2,18 +2,16 @@
 
 import ast
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, cast
 from pathlib import Path
 
-from nextcord import Embed, Locale, Interaction
+from nextcord import Embed, Locale
 from nextcord.ui import View
 
 from discordbot.cogs.help import HelpCogs
 from discordbot.cogs._help.views import HelpView
 from discordbot.cogs._help.content import HELP_CONTENT, CATEGORY_ORDER, OVERVIEW_VALUE
 
-if TYPE_CHECKING:
-    from nextcord.ext import commands
+from tests.helpers.casting import as_bot, as_interaction
 
 _LOCALES = ("default", Locale.zh_TW, Locale.ja)
 
@@ -147,8 +145,7 @@ async def test_help_response_is_ephemeral_with_a_view() -> None:
     )
 
     await HelpCogs.help.callback(
-        HelpCogs(bot=cast("commands.Bot", SimpleNamespace())),
-        cast("Interaction[commands.Bot]", interaction),
+        HelpCogs(bot=as_bot(fake=SimpleNamespace())), as_interaction(fake=interaction)
     )
 
     assert interaction.response.sent["ephemeral"] is True

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -78,10 +78,10 @@ from discordbot.cogs._memory.extraction import (
     observation_key_sources_from_text,
 )
 
+from tests.helpers.casting import as_bot, as_interaction
+
 if TYPE_CHECKING:
     from openai import AsyncOpenAI
-    from nextcord import Interaction
-    from nextcord.ext import commands
 
 USER_ID = 123456789
 
@@ -1243,14 +1243,14 @@ def _interaction(user_id: int = USER_ID) -> SimpleNamespace:
 
 def _memory_cog() -> MemoryCogs:
     """Builds a MemoryCogs instance with a stub bot."""
-    return MemoryCogs(bot=cast("commands.Bot", SimpleNamespace()))
+    return MemoryCogs(bot=as_bot(fake=SimpleNamespace()))
 
 
 async def test_memory_show_displays_stored_memory(memory_isolated_dir: Path) -> None:
     write_main_memory(scope=USER_SCOPE, content="v1\n\n## 使用者輪廓\n愛開玩笑", identity=IDENTITY)
     cog = _memory_cog()
     interaction = _interaction()
-    await MemoryCogs.memory_show.callback(cog, cast("Interaction[Any]", interaction))
+    await MemoryCogs.memory_show.callback(cog, as_interaction(fake=interaction))
     assert interaction.response.sent["ephemeral"] is True
     embed = interaction.response.sent["embed"]
     assert isinstance(embed, Embed)
@@ -1266,7 +1266,7 @@ async def test_memory_show_paginates_oversized_memory(memory_isolated_dir: Path)
     )
     cog = _memory_cog()
     interaction = _interaction()
-    await MemoryCogs.memory_show.callback(cog, cast("Interaction[Any]", interaction))
+    await MemoryCogs.memory_show.callback(cog, as_interaction(fake=interaction))
     sent = interaction.response.sent
     assert sent["ephemeral"] is True
     view = sent["view"]
@@ -1283,7 +1283,7 @@ async def test_memory_show_paginates_oversized_memory(memory_isolated_dir: Path)
 async def test_memory_show_handles_empty_memory(memory_isolated_dir: Path) -> None:
     cog = _memory_cog()
     interaction = _interaction()
-    await MemoryCogs.memory_show.callback(cog, cast("Interaction[Any]", interaction))
+    await MemoryCogs.memory_show.callback(cog, as_interaction(fake=interaction))
     assert interaction.response.sent["ephemeral"] is True
     embed = interaction.response.sent["embed"]
     assert isinstance(embed, Embed)
@@ -1507,7 +1507,7 @@ async def test_memory_regenerate_command_schedules_in_background(
     # Evidence must exist or the command short-circuits before scheduling.
     append_detail(scope=USER_SCOPE, text=DETAIL_EVIDENCE)
     interaction = _regen_interaction()
-    await MemoryCogs.memory_regenerate.callback(cog, cast("Interaction[Any]", interaction))
+    await MemoryCogs.memory_regenerate.callback(cog, as_interaction(fake=interaction))
 
     # The command replies immediately and never blocks on the rebuild, so it
     # neither defers nor uses a followup.
@@ -1535,7 +1535,7 @@ async def test_memory_regenerate_command_reports_no_evidence(
     monkeypatch.setattr("discordbot.cogs.memory.schedule_memory_regeneration", fake_schedule)
     # No raw or detail evidence exists for this scope.
     interaction = _regen_interaction()
-    await MemoryCogs.memory_regenerate.callback(cog, cast("Interaction[Any]", interaction))
+    await MemoryCogs.memory_regenerate.callback(cog, as_interaction(fake=interaction))
 
     # Without evidence the background task would no-op, so nothing is scheduled
     # and the user is told there is nothing to rebuild yet.
@@ -1561,7 +1561,7 @@ async def test_memory_regenerate_command_blocked_by_cooldown(
 
     monkeypatch.setattr("discordbot.cogs.memory.schedule_memory_regeneration", fake_schedule)
     interaction = _regen_interaction()
-    await MemoryCogs.memory_regenerate.callback(cog, cast("Interaction[Any]", interaction))
+    await MemoryCogs.memory_regenerate.callback(cog, as_interaction(fake=interaction))
 
     # Rejected up front: nothing scheduled, no defer, just the ephemeral notice.
     assert scheduled is False
@@ -1670,7 +1670,7 @@ async def test_memory_pages_view_navigates_and_disables_bounds() -> None:
     assert next_button.disabled is False
 
     interaction = SimpleNamespace(response=EditResponseStub())
-    await next_button.callback(cast("Interaction[Any]", interaction))
+    await next_button.callback(as_interaction(fake=interaction))
     assert view.page_index == 1
     embed = interaction.response.edited["embed"]
     assert isinstance(embed, Embed)
@@ -1679,11 +1679,11 @@ async def test_memory_pages_view_navigates_and_disables_bounds() -> None:
     assert "1 筆" in (embed.footer.text or "")
     assert prev_button.disabled is False
 
-    await next_button.callback(cast("Interaction[Any]", interaction))
+    await next_button.callback(as_interaction(fake=interaction))
     assert view.page_index == 2
     assert next_button.disabled is True
 
-    await prev_button.callback(cast("Interaction[Any]", interaction))
+    await prev_button.callback(as_interaction(fake=interaction))
     assert view.page_index == 1
     edited_embed = interaction.response.edited["embed"]
     assert isinstance(edited_embed, Embed)
@@ -1711,7 +1711,7 @@ async def test_memory_pages_view_timeout_disables_buttons() -> None:
             self.edited = kwargs
 
     origin = OriginStub()
-    view.bind_origin(interaction=cast("Interaction[Any]", origin))
+    view.bind_origin(interaction=as_interaction(fake=origin))
     await view.on_timeout()
     assert origin.edited["view"] is view
     assert all(child.disabled for child in view.children if isinstance(child, Button))
@@ -1775,7 +1775,7 @@ async def test_memory_show_reports_pending_observations_before_first_consolidati
     append_raw_entry(scope=USER_SCOPE, entry_text="偏好訊號:\n- 第一筆觀察")
     cog = _memory_cog()
     interaction = _interaction()
-    await MemoryCogs.memory_show.callback(cog, cast("Interaction[Any]", interaction))
+    await MemoryCogs.memory_show.callback(cog, as_interaction(fake=interaction))
     embed = interaction.response.sent["embed"]
     assert isinstance(embed, Embed)
     assert "1 筆" in (embed.description or "")
@@ -1790,7 +1790,7 @@ async def test_memory_show_strips_version_header_and_counts_pending(
     append_raw_entry(scope=USER_SCOPE, entry_text="偏好訊號:\n- 新觀察")
     cog = _memory_cog()
     interaction = _interaction()
-    await MemoryCogs.memory_show.callback(cog, cast("Interaction[Any]", interaction))
+    await MemoryCogs.memory_show.callback(cog, as_interaction(fake=interaction))
     embed = interaction.response.sent["embed"]
     assert isinstance(embed, Embed)
     assert (embed.description or "").startswith("## 使用者輪廓")
@@ -1804,7 +1804,7 @@ async def test_memory_show_does_not_corrupt_malformed_version_token(
     write_main_memory(scope=USER_SCOPE, content="v10 是一段被手動編輯的內容", identity=IDENTITY)
     cog = _memory_cog()
     interaction = _interaction()
-    await MemoryCogs.memory_show.callback(cog, cast("Interaction[Any]", interaction))
+    await MemoryCogs.memory_show.callback(cog, as_interaction(fake=interaction))
     embed = interaction.response.sent["embed"]
     assert isinstance(embed, Embed)
     # Only an exact `v1\n` header is stripped; `v10...` must survive intact.

--- a/tests/test_parse_bilibili.py
+++ b/tests/test_parse_bilibili.py
@@ -1,13 +1,11 @@
 """Tests for the Bilibili-context builder that feeds linked videos to the answer model."""
 
 import time
-from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 import asyncio
 from pathlib import Path
 import threading
 
-from google import genai
 import pytest
 
 from discordbot.utils.downloader import VideoMetadata, DownloadResult, VideoDownloader
@@ -22,14 +20,9 @@ from discordbot.cogs._gen_reply.link_sources.bilibili import (
     build_bilibili_context_messages,
 )
 
-from tests.helpers.casting import step_dicts
+from tests.helpers.casting import step_dicts, make_stub_gemini_client
 
 _URL = "https://www.bilibili.com/video/BV1jpK86hEc8"
-
-
-def _fake_client() -> genai.Client:
-    """Stands in for a Gemini client the builder never actually calls through."""
-    return cast("genai.Client", SimpleNamespace())
 
 
 def _metadata(
@@ -133,7 +126,7 @@ async def _build(gemini: bool = True, ingest: bool = True) -> list[dict[str, Any
     blocks = await build_bilibili_context_messages(
         url=_URL,
         answer_model_is_gemini=gemini,
-        gemini_client=_fake_client(),
+        gemini_client=make_stub_gemini_client(),
         allow_media_ingest=ingest,
     )
     return step_dicts(steps=blocks)
@@ -322,7 +315,7 @@ async def test_a_resolved_short_link_lists_both_urls(monkeypatch: pytest.MonkeyP
         steps=await build_bilibili_context_messages(
             url=short_url,
             answer_model_is_gemini=True,
-            gemini_client=_fake_client(),
+            gemini_client=make_stub_gemini_client(),
             allow_media_ingest=True,
         )
     )
@@ -533,7 +526,7 @@ async def test_the_fetch_bound_is_released_before_the_upload(
                 build_bilibili_context_messages(
                     url="https://www.bilibili.com/video/av170001",
                     answer_model_is_gemini=True,
-                    gemini_client=_fake_client(),
+                    gemini_client=make_stub_gemini_client(),
                     allow_media_ingest=False,
                 ),
                 timeout=5.0,

--- a/tests/test_parse_douyin.py
+++ b/tests/test_parse_douyin.py
@@ -1,7 +1,6 @@
 """Tests for the Douyin-context builder that feeds linked posts to the answer model."""
 
-from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any
 import asyncio
 from pathlib import Path
 
@@ -28,10 +27,7 @@ from discordbot.cogs._gen_reply.link_sources.douyin import (
     build_douyin_context_messages,
 )
 
-from tests.helpers.casting import step_dicts
-
-if TYPE_CHECKING:
-    from google import genai
+from tests.helpers.casting import step_dicts, make_stub_gemini_client
 
 _URL = "https://v.douyin.com/abc123"
 
@@ -138,7 +134,7 @@ async def _build(gemini: bool = True, ingest: bool = True) -> list[dict[str, Any
     blocks = await build_douyin_context_messages(
         url=_URL,
         answer_model_is_gemini=gemini,
-        gemini_client=cast("genai.Client", SimpleNamespace()),
+        gemini_client=make_stub_gemini_client(),
         allow_media_ingest=ingest,
     )
     return step_dicts(steps=blocks)
@@ -395,7 +391,7 @@ async def test_the_fetch_bound_is_released_before_the_upload(
                 build_douyin_context_messages(
                     url="https://v.douyin.com/other",
                     answer_model_is_gemini=True,
-                    gemini_client=cast("genai.Client", SimpleNamespace()),
+                    gemini_client=make_stub_gemini_client(),
                     allow_media_ingest=False,
                 ),
                 timeout=5.0,

--- a/tests/test_parse_threads.py
+++ b/tests/test_parse_threads.py
@@ -1,10 +1,7 @@
 """Tests for the Threads-context builder that feeds linked posts to the answer model."""
 
-from types import SimpleNamespace
-from typing import cast
 from pathlib import Path
 
-from google import genai
 import pytest
 
 from discordbot.utils.threads import ThreadsOutput, ThreadsDownloader
@@ -18,7 +15,7 @@ from discordbot.cogs._gen_reply.link_sources.threads import (
     build_threads_context_messages,
 )
 
-from tests.helpers.casting import step_dicts
+from tests.helpers.casting import step_dicts, make_stub_gemini_client
 
 _URL = "https://www.threads.com/@alice/post/ABC123"
 
@@ -107,11 +104,6 @@ def _stub_media(
     monkeypatch.setattr(target=ThreadsDownloader, name="download_media", value=fake_download_media)
 
 
-def _client() -> genai.Client:
-    """A stand-in Gemini client; the stubbed upload never reaches through it."""
-    return cast("genai.Client", SimpleNamespace())
-
-
 async def test_media_is_uploaded_and_referenced_by_files_uri(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -128,7 +120,7 @@ async def test_media_is_uploaded_and_referenced_by_files_uri(
     _stub_media(monkeypatch, uploads=uploads)
 
     blocks = await build_threads_context_messages(
-        url=_URL, answer_model_is_gemini=True, gemini_client=_client()
+        url=_URL, answer_model_is_gemini=True, gemini_client=make_stub_gemini_client()
     )
 
     assert len(blocks) == 2
@@ -157,7 +149,7 @@ async def test_images_are_downscaled_before_upload(monkeypatch: pytest.MonkeyPat
     _stub_media(monkeypatch, uploads=uploads)
 
     await build_threads_context_messages(
-        url=_URL, answer_model_is_gemini=True, gemini_client=_client()
+        url=_URL, answer_model_is_gemini=True, gemini_client=make_stub_gemini_client()
     )
 
     source, mime_type, _ = uploads.calls[0]
@@ -172,7 +164,7 @@ async def test_video_is_uploaded_from_disk_and_cleaned_up(monkeypatch: pytest.Mo
     _stub_media(monkeypatch, uploads=uploads)
 
     await build_threads_context_messages(
-        url=_URL, answer_model_is_gemini=True, gemini_client=_client()
+        url=_URL, answer_model_is_gemini=True, gemini_client=make_stub_gemini_client()
     )
 
     source, mime_type, _ = uploads.calls[0]
@@ -190,7 +182,7 @@ async def test_only_the_target_posts_media_is_ingested(monkeypatch: pytest.Monke
     _stub_media(monkeypatch, uploads=uploads)
 
     blocks = await build_threads_context_messages(
-        url=_URL, answer_model_is_gemini=True, gemini_client=_client()
+        url=_URL, answer_model_is_gemini=True, gemini_client=make_stub_gemini_client()
     )
 
     media = [
@@ -209,7 +201,7 @@ async def test_build_caps_media_parts(monkeypatch: pytest.MonkeyPatch) -> None:
     _stub_media(monkeypatch, uploads=_Uploads())
 
     blocks = await build_threads_context_messages(
-        url=_URL, answer_model_is_gemini=True, gemini_client=_client()
+        url=_URL, answer_model_is_gemini=True, gemini_client=make_stub_gemini_client()
     )
 
     media = [
@@ -231,7 +223,7 @@ async def test_videos_share_the_media_budget_with_images(monkeypatch: pytest.Mon
     _stub_media(monkeypatch, uploads=uploads)
 
     blocks = await build_threads_context_messages(
-        url=_URL, answer_model_is_gemini=True, gemini_client=_client()
+        url=_URL, answer_model_is_gemini=True, gemini_client=make_stub_gemini_client()
     )
 
     media = [
@@ -253,7 +245,7 @@ async def test_a_full_image_budget_leaves_no_room_for_video(
     _stub_media(monkeypatch, uploads=uploads)
 
     blocks = await build_threads_context_messages(
-        url=_URL, answer_model_is_gemini=True, gemini_client=_client()
+        url=_URL, answer_model_is_gemini=True, gemini_client=make_stub_gemini_client()
     )
 
     media = [
@@ -273,7 +265,7 @@ async def test_build_caps_chain_posts(monkeypatch: pytest.MonkeyPatch) -> None:
     _stub_media(monkeypatch, uploads=_Uploads())
 
     blocks = await build_threads_context_messages(
-        url=_URL, answer_model_is_gemini=True, gemini_client=_client()
+        url=_URL, answer_model_is_gemini=True, gemini_client=make_stub_gemini_client()
     )
 
     text = step_dicts(steps=blocks[1]["content"])[0]["text"]
@@ -310,7 +302,7 @@ async def test_build_non_gemini_rides_urls_as_text(monkeypatch: pytest.MonkeyPat
     _stub_media(monkeypatch, uploads=uploads)
 
     blocks = await build_threads_context_messages(
-        url=_URL, answer_model_is_gemini=False, gemini_client=_client()
+        url=_URL, answer_model_is_gemini=False, gemini_client=make_stub_gemini_client()
     )
 
     # The separator must not claim the media was fetched, since only its URLs are supplied.
@@ -331,7 +323,7 @@ async def test_failed_media_degrades_to_an_honest_text_block(
     _stub_media(monkeypatch, uploads=_Uploads(), image_fetch_fails=True)
 
     blocks = await build_threads_context_messages(
-        url=_URL, answer_model_is_gemini=True, gemini_client=_client()
+        url=_URL, answer_model_is_gemini=True, gemini_client=make_stub_gemini_client()
     )
 
     assert step_dicts(steps=blocks[0]["content"])[0]["text"] == THREADS_TEXT_ONLY_SEPARATOR
@@ -348,7 +340,7 @@ async def test_failed_upload_degrades_to_an_honest_text_block(
     _stub_media(monkeypatch, uploads=_Uploads(fail=True))
 
     blocks = await build_threads_context_messages(
-        url=_URL, answer_model_is_gemini=True, gemini_client=_client()
+        url=_URL, answer_model_is_gemini=True, gemini_client=make_stub_gemini_client()
     )
 
     assert step_dicts(steps=blocks[0]["content"])[0]["text"] == THREADS_TEXT_ONLY_SEPARATOR
@@ -364,7 +356,7 @@ async def test_one_failed_item_does_not_sink_the_others(monkeypatch: pytest.Monk
     _stub_media(monkeypatch, uploads=uploads, image_fetch_fails=True)
 
     blocks = await build_threads_context_messages(
-        url=_URL, answer_model_is_gemini=True, gemini_client=_client()
+        url=_URL, answer_model_is_gemini=True, gemini_client=make_stub_gemini_client()
     )
 
     assert step_dicts(steps=blocks[0]["content"])[0]["text"] == THREADS_CONTEXT_SEPARATOR
@@ -380,7 +372,7 @@ async def test_text_only_post_keeps_the_context_separator(monkeypatch: pytest.Mo
     _stub_media(monkeypatch, uploads=_Uploads())
 
     blocks = await build_threads_context_messages(
-        url=_URL, answer_model_is_gemini=True, gemini_client=_client()
+        url=_URL, answer_model_is_gemini=True, gemini_client=make_stub_gemini_client()
     )
 
     assert step_dicts(steps=blocks[0]["content"])[0]["text"] == THREADS_CONTEXT_SEPARATOR
@@ -393,7 +385,7 @@ async def test_build_empty_post_returns_unavailable_notice(
     _stub_parse(monkeypatch, [])
 
     blocks = await build_threads_context_messages(
-        url=_URL, answer_model_is_gemini=True, gemini_client=_client()
+        url=_URL, answer_model_is_gemini=True, gemini_client=make_stub_gemini_client()
     )
 
     assert len(blocks) == 1
@@ -411,7 +403,7 @@ async def test_build_parse_error_degrades_to_unavailable(monkeypatch: pytest.Mon
     monkeypatch.setattr(target=ThreadsDownloader, name="parse_metadata", value=boom)
 
     blocks = await build_threads_context_messages(
-        url=_URL, answer_model_is_gemini=True, gemini_client=_client()
+        url=_URL, answer_model_is_gemini=True, gemini_client=make_stub_gemini_client()
     )
 
     assert len(blocks) == 1

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -5,7 +5,6 @@ import base64
 from typing import TYPE_CHECKING, cast
 from pathlib import Path
 
-from google import genai
 from nextcord import AllowedMentions
 
 from discordbot.cogs import research as research_cog
@@ -21,12 +20,15 @@ from discordbot.cogs._research.delivery import (
 )
 from discordbot.cogs._research.streaming import ResearchProgressStreamer
 
-from tests.helpers.casting import make_media_hosting_config
+from tests.helpers.casting import (
+    as_client,
+    as_message,
+    make_media_hosting_config,
+    as_interaction_event_stream,
+)
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
-
-    from nextcord import Thread, Message
+    from nextcord import Thread
     from google.genai.interactions import InteractionSSEEvent
 
     from discordbot.cogs._research.database import ResearchPhase
@@ -198,22 +200,12 @@ def _fake_client(*, streams: list[_FakeStream], terminal: object) -> SimpleNames
     )
 
 
-def _as_client(fake: SimpleNamespace) -> genai.Client:
-    """Views a fake client double as the genai.Client a production signature expects."""
-    return cast("genai.Client", fake)
-
-
 def _as_event(fake: object) -> "InteractionSSEEvent":
     """Views a fabricated SSE event double as the real SDK union a production signature expects.
 
     Production discriminates on `.event_type`, not isinstance, so a SimpleNamespace event is safe.
     """
     return cast("InteractionSSEEvent", fake)
-
-
-def _as_event_stream(fake: "_FakeStream") -> "AsyncIterator[InteractionSSEEvent]":
-    """Views a fabricated SSE stream double as the real SDK event stream a signature expects."""
-    return cast("AsyncIterator[InteractionSSEEvent]", fake)
 
 
 def _created_event(*, interaction_id: str = "int_9", event_id: str = "e1") -> SimpleNamespace:
@@ -262,7 +254,7 @@ async def test_stream_antigravity_persists_id_streams_and_returns_terminal_resul
         persisted.append(interaction_id)
 
     result = await agent.stream_antigravity(
-        client=_as_client(client),
+        client=as_client(fake=client),
         agent="antigravity-preview-05-2026",
         brief="b",
         system_instruction="sys",
@@ -300,7 +292,7 @@ async def test_stream_reconnects_when_stream_ends_without_terminal(monkeypatch) 
         return None
 
     result = await agent.stream_antigravity(
-        client=_as_client(client),
+        client=as_client(fake=client),
         agent="a",
         brief="b",
         system_instruction="s",
@@ -330,7 +322,7 @@ async def test_stream_reconnects_after_a_mid_stream_drop(monkeypatch) -> None:  
         return None
 
     result = await agent.stream_antigravity(
-        client=_as_client(client),
+        client=as_client(fake=client),
         agent="a",
         brief="b",
         system_instruction="s",
@@ -359,7 +351,7 @@ async def test_stream_falls_back_to_poll_when_streaming_gives_up(monkeypatch) ->
     # Streaming exhausts its reconnects, so the driver degrades to the poll and still returns the
     # authoritative terminal result.
     result = await agent.stream_antigravity(
-        client=_as_client(client),
+        client=as_client(fake=client),
         agent="a",
         brief="b",
         system_instruction="s",
@@ -383,7 +375,7 @@ async def test_stream_antigravity_reraises_when_create_never_yields_an_id() -> N
     raised = False
     try:
         await agent.stream_antigravity(
-            client=_as_client(client),
+            client=as_client(fake=client),
             agent="a",
             brief="b",
             system_instruction="s",
@@ -401,7 +393,7 @@ async def test_resume_research_stream_drives_from_get_stream() -> None:
     )
     streamer = ResearchProgressStreamer(status=None, label="Deep Research")
     result = await agent.resume_research_stream(
-        client=_as_client(client), interaction_id="int_9", streamer=streamer
+        client=as_client(fake=client), interaction_id="int_9", streamer=streamer
     )
     # Resume re-attaches via get(stream=True) and never calls create.
     assert client.aio.interactions.create_kwargs == {}
@@ -421,7 +413,7 @@ async def test_stream_plan_passes_research_tools_and_returns_plan() -> None:
     )
     streamer = ResearchProgressStreamer(status=None, label="Deep Research", action="Planning")
     plan = await agent.stream_plan(
-        client=_as_client(client),
+        client=as_client(fake=client),
         agent="deep-research-preview-04-2026",
         brief="b",
         system_instruction="sys",
@@ -449,7 +441,7 @@ async def test_stream_refine_passes_research_tools_and_returns_plan() -> None:
     )
     streamer = ResearchProgressStreamer(status=None, label="Deep Research", action="Re-planning")
     plan = await agent.stream_refine(
-        client=_as_client(client),
+        client=as_client(fake=client),
         agent="deep-research-preview-04-2026",
         previous_interaction_id="plan_v1",
         feedback="tighten the scope",
@@ -575,7 +567,9 @@ async def test_streamer_stream_accumulates_and_stops_editor_cleanly() -> None:
         status=status, label="Antigravity", preview_interval_seconds=0.01
     )
     await streamer.stream(
-        events=_as_event_stream(_FakeStream([_thought_event("aaa"), _thought_event("bbb")]))
+        events=as_interaction_event_stream(
+            fake=_FakeStream([_thought_event("aaa"), _thought_event("bbb")])
+        )
     )
     assert streamer.reasoning == "aaabbb"
     assert streamer._editor_task is None  # the cadence editor is always stopped in finally
@@ -904,7 +898,7 @@ async def test_delivery_keeps_footer_message_under_the_limit() -> None:
     # would overflow, so it must ride its own trailing message.
     await deliver_report(
         thread=cast("Thread", thread),  # minimal Thread double for the delivery path
-        status=cast("Message", status),  # minimal status-message double
+        status=as_message(fake=status),  # minimal status-message double
         owner_mention="<@1>",
         result=_completed_result(report_text="X" * 1990),
         footer=footer,
@@ -930,7 +924,7 @@ async def test_delivery_inlines_footer_for_short_reports() -> None:
     thread = _FakeThread()
     await deliver_report(
         thread=cast("Thread", thread),  # minimal Thread double for the delivery path
-        status=cast("Message", status),  # minimal status-message double
+        status=as_message(fake=status),  # minimal status-message double
         owner_mention="<@1>",
         result=_completed_result(report_text="# Report\nbody"),
         footer="-# footer",
@@ -959,7 +953,7 @@ async def test_delivery_hosts_oversized_report_file(tmp_path: Path) -> None:
     )
     await deliver_report(
         thread=cast("Thread", thread),  # minimal Thread double for the delivery path
-        status=cast("Message", status),  # minimal status-message double
+        status=as_message(fake=status),  # minimal status-message double
         owner_mention="<@1>",
         result=_completed_result(report_text="# Report\nbody"),
         footer="-# footer",
@@ -986,7 +980,7 @@ async def test_delivery_attaches_both_files_when_each_fits_but_combined_over() -
     thread.guild = SimpleNamespace(filesize_limit=100)  # each file fits, md + png together do not
     await deliver_report(
         thread=cast("Thread", thread),  # minimal Thread double for the delivery path
-        status=cast("Message", status),  # minimal status-message double
+        status=as_message(fake=status),  # minimal status-message double
         owner_mention="<@1>",
         result=_completed_result(report_text="R" * 60, image_bytes=b"x" * 60),
         footer="-# footer",

--- a/tests/test_server_memory.py
+++ b/tests/test_server_memory.py
@@ -1,7 +1,6 @@
 """Tests for the bot's per-server (community) long-term memory flavor."""
 
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, cast
 from pathlib import Path
 
 from nextcord import Embed
@@ -22,9 +21,7 @@ from discordbot.cogs._memory.server_prompts import (
     SERVER_PHASE1_EVALUATOR_PROMPT,
 )
 
-if TYPE_CHECKING:
-    from nextcord import Interaction
-    from nextcord.ext import commands
+from tests.helpers.casting import as_bot, as_interaction
 
 BOT_ID = 555
 GUILD_ID = 777
@@ -176,7 +173,7 @@ class ResponseStub:
 def _server_cog() -> MemoryCogs:
     """Builds a MemoryCogs whose bot exposes a stable user id."""
     bot = SimpleNamespace(user=SimpleNamespace(id=BOT_ID))
-    return MemoryCogs(bot=cast("commands.Bot", bot))
+    return MemoryCogs(bot=as_bot(fake=bot))
 
 
 def _guild_interaction(guild_id: int | None = GUILD_ID) -> SimpleNamespace:
@@ -193,7 +190,7 @@ async def test_memory_server_show_displays_stored_memory(memory_isolated_dir: Pa
     )
     cog = _server_cog()
     interaction = _guild_interaction()
-    await MemoryCogs.memory_server_show.callback(cog, cast("Interaction[Any]", interaction))
+    await MemoryCogs.memory_server_show.callback(cog, as_interaction(fake=interaction))
     assert interaction.response.sent["ephemeral"] is True
     embed = interaction.response.sent["embed"]
     assert isinstance(embed, Embed)
@@ -203,7 +200,7 @@ async def test_memory_server_show_displays_stored_memory(memory_isolated_dir: Pa
 async def test_memory_server_show_handles_empty_memory(memory_isolated_dir: Path) -> None:
     cog = _server_cog()
     interaction = _guild_interaction()
-    await MemoryCogs.memory_server_show.callback(cog, cast("Interaction[Any]", interaction))
+    await MemoryCogs.memory_server_show.callback(cog, as_interaction(fake=interaction))
     embed = interaction.response.sent["embed"]
     assert isinstance(embed, Embed)
     assert "還沒有對這個伺服器的記憶" in (embed.description or "")
@@ -212,7 +209,7 @@ async def test_memory_server_show_handles_empty_memory(memory_isolated_dir: Path
 async def test_memory_server_show_blocks_dms(memory_isolated_dir: Path) -> None:
     cog = _server_cog()
     interaction = _guild_interaction(guild_id=None)
-    await MemoryCogs.memory_server_show.callback(cog, cast("Interaction[Any]", interaction))
+    await MemoryCogs.memory_server_show.callback(cog, as_interaction(fake=interaction))
     embed = interaction.response.sent["embed"]
     assert isinstance(embed, Embed)
     assert "只能在伺服器" in (embed.description or "")

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -12,10 +12,9 @@ from discordbot.cogs._gen_reply.interactions import (
     adapt_interactions_stream,
 )
 
-from tests.helpers.casting import step_dicts
+from tests.helpers.casting import step_dicts, as_interaction_event_stream
 
 if TYPE_CHECKING:
-    from google.genai.interactions import InteractionSSEEvent
     from openai.types.responses.response_input_param import ResponseInputParam
 
 
@@ -167,14 +166,6 @@ async def _aiter(events: list[SimpleNamespace]) -> AsyncIterator[SimpleNamespace
         yield event
 
 
-def _as_stream(events: list[SimpleNamespace]) -> "AsyncIterator[InteractionSSEEvent]":
-    """Views the fabricated events as the real SDK stream the adapter consumes.
-
-    Production discriminates on `.event_type`, not isinstance, so SimpleNamespace events are safe.
-    """
-    return cast("AsyncIterator[InteractionSSEEvent]", _aiter(events=events))
-
-
 def _ns(event: object) -> SimpleNamespace:
     """Narrows an adapted event to the namespace shape the adapter fabricates."""
     assert isinstance(event, SimpleNamespace)
@@ -183,7 +174,9 @@ def _ns(event: object) -> SimpleNamespace:
 
 async def test_adapt_interactions_stream_remaps_to_responses_events() -> None:
     """Interactions events become Responses-shaped events the streamer consumes."""
-    stream = adapt_interactions_stream(stream=_as_stream(events=_interaction_events()))
+    stream = adapt_interactions_stream(
+        stream=as_interaction_event_stream(fake=_aiter(events=_interaction_events()))
+    )
     out = [event async for event in stream]
 
     types = [event.type for event in out]
@@ -207,5 +200,7 @@ async def test_adapt_interactions_stream_raises_on_error_event() -> None:
     events = [SimpleNamespace(event_type="error", error="boom")]
 
     with pytest.raises(RuntimeError):
-        async for _ in adapt_interactions_stream(stream=_as_stream(events=events)):
+        async for _ in adapt_interactions_stream(
+            stream=as_interaction_event_stream(fake=_aiter(events=events))
+        ):
             pass


### PR DESCRIPTION
## Summary

Two follow-ups from the ty adoption (#366 / #368), each a self-contained commit.

### #369 - Replace the untyped kwargs bag in the economy followup helper

`send_expiring_followup` assembled its send arguments into a loose `dict[str, Any]` and `**`-splatted it, so no value was checked at the call boundary. It now passes explicit keyword arguments and splats only `embed_spacer_payload(...)`, matching every other send site in the module.

The optional `view` keeps its conditional-omission semantics through a two-branch send: nextcord's `Webhook.send` rejects `view=None` (it dereferences `view.is_finished()`), so the `None` case simply omits the argument rather than passing a sentinel. Behavior and the existing test assertions are unchanged; the explicit `wait=True` also lets the checker resolve the non-optional `WebhookMessage` return.

### #370 - Deduplicate module-local test cast adapters into `tests/helpers`

The sweep left the same cast-adapter shape duplicated across modules with slightly different spellings. Genuinely shared ones now live once in `tests/helpers/casting.py`:

- `as_client` / `make_stub_gemini_client` - consolidates the `genai.Client` stand-ins that had grown as `_as_client` / `_client` / `_fake_client` / inline casts across 5 files.
- `as_discord_bot` - consolidates `_as_discord_bot` plus an inline `cli.DiscordBot` cast.
- `as_interaction_event_stream` - consolidates the `AsyncIterator[InteractionSSEEvent]` casts (`_as_stream` / `_as_event_stream`).
- `as_avatar_user` / `as_guild` / `as_command_context` - the remaining named boundary casts.

Inline `commands.Bot` / `Message` / `Interaction` casts that duplicated the existing `as_bot` / `as_message` / `as_interaction` helpers now route through them. File-specific builders that only construct a fake (e.g. `test_files_api.py::_client`, `test_research.py::_fake_client`) stay local but route their one cast through `as_client`.

#### Scope note

`as_avatar_user` / `as_guild` / `as_command_context` each had a single consuming file at the time of the sweep, so under a strict reading of "per-file ones with a single caller may stay local" they could have stayed put. They are hoisted deliberately: they are the same pure production-boundary cast shape as `as_bot` / `as_message`, and keeping the whole named-boundary family in one place stops the next test from copying whichever local spelling it sees first. The genuinely file-specific builders above are the ones kept local.

## Verification

- `uv run pre-commit run -a` (ruff, ruff format, ty, mypy, ...) all pass
- `uv run pytest` - full suite green, coverage gate met
- Independent adversarial review pass: #369 behavior equivalence, per-call-site correctness, and type/import safety all clean; no genuine cross-file duplicate missed.

## Closes

Closes #369
Closes #370