### PR TITLE
ci: drop the staged windows binary after zipping

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -88,6 +88,10 @@ jobs:
           $bin = "${{ github.event.repository.name }}.exe"
           $zip = "${{ github.event.repository.name }}-v$version-${{ matrix.friendly_id }}.zip"
           Compress-Archive -Path "$dest\$bin" -DestinationPath "$dest\$zip" -Force
+          # Anything left in $dest gets uploaded and lands on the release, so
+          # the staged binary would ship as a second copy of what the .zip
+          # already holds.
+          Remove-Item "$dest\$bin" -Force
 
       - name: Create .tar.gz (all platforms)
         if: ${{ !startsWith(matrix.runner, 'windows') }}


### PR DESCRIPTION
## Problem

`build_release.yml` stages the built binary under `dist/<target>/` and then uploads everything in that directory. The `.tar.gz` branch removes the raw binary after archiving it; the Windows branch never did. The staged `.exe` therefore travels through the artifact and lands on the GitHub Release next to the `.zip` that already contains it.

On [v0.42.0](https://github.com/Mai0313/discordbot/releases/tag/v0.42.0) that is a redundant 93 MB `discordbot.exe`.

## Fix

`Remove-Item` after `Compress-Archive`, mirroring the `rm` the `.tar.gz` branch already does.

## Verification

The same fix was verified end to end on `Mai0313/amfs`: v0.0.1 shipped the stray binary, v0.0.2 with this change did not, and both Windows `.zip` assets came out identical in size. It has also been applied to `rust_template`, `repo_template`, and `VibeCodingTracker`, which all carry the same defect.

This branch was prepared in a separate worktree so it would not disturb the uncommitted work in the main checkout.