### PR TITLE
ci: run opencode from a mention and on every ready pull request

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -12,9 +12,9 @@ permissions: write-all
 env:
   OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
 
-concurrency:
-  group: opencode-review-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+# concurrency:
+#   group: opencode-review-${{ github.event.pull_request.number }}
+#   cancel-in-progress: true
 
 jobs:
   review:
@@ -28,19 +28,13 @@ jobs:
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
 
     steps:
-      # Full history, so the skill can resolve a merge base against the base branch.
+      # Full history, so a base-branch diff resolves.
       - name: Checkout
         if: env.OPENCODE_API_KEY != ''
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
-
-      # Lands in .agents/skills/, which opencode scans on its own.
-      - name: Install skills
-        if: env.OPENCODE_API_KEY != ''
-        run: |
-          npx -y skills add Mai0313/skills --agent opencode --skill code-review -y
 
       - name: Run opencode
         if: env.OPENCODE_API_KEY != ''
@@ -53,16 +47,10 @@ jobs:
           share: false
           variant: high
           prompt: |
-            Review this pull request with the `code-review` skill, against the
-            base branch `origin/${{ github.event.pull_request.base.ref }}`.
+            Use the review skill to do a code review of this pull request.
 
-            Shape the report for a GitHub comment: the verdict as a bold opening
-            line, then one block per finding in severity order, each starting
-            with a bold `P<n> — <title>` line, then its location as a markdown
-            link to `https://github.com/${{ github.repository }}/blob/${{ github.event.pull_request.head.sha }}/<path>#L<line>`,
-            then the finding itself. Reformatting is the only liberty you may
-            take: never drop, merge, or soften one. A single line is enough when
-            there is nothing to report.
+            Follow whichever of CLAUDE.md, AGENTS.md, README.md and
+            .github/copilot-instructions.md this repository actually has, and
+            treat a breach of them as a finding.
 
-            Your reply is posted as a comment for you, so do not post one
-            yourself, and do not commit or push anything.
+            Do not modify, commit, or push anything.

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -21,7 +21,7 @@ jobs:
     name: Review
     runs-on: ubuntu-latest
     # The action asserts the author has write access and posts an error comment
-    # when they do not, so keep non-collaborator PRs out. This also covers
+    # when they do not, so keep non-collaborator PRs out. This also excludes
     # dependabot, whose PRs come in as CONTRIBUTOR.
     if: |
       github.event.pull_request.draft == false &&
@@ -31,7 +31,7 @@ jobs:
       # Full history, so the skill can resolve a merge base against the base branch.
       - name: Checkout
         if: env.OPENCODE_API_KEY != ''
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install skills
         if: env.OPENCODE_API_KEY != ''
         run: |
-          npx -y skills add Mai0313/skills --agent opencode -y
+          npx -y skills add Mai0313/skills --agent opencode --skill code-review -y
 
       - name: Run opencode
         if: env.OPENCODE_API_KEY != ''
@@ -48,8 +48,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          model: opencode/gemini-3.1-pro
+          model: opencode/gemini-3.6-flash
           agent: build
+          share: false
           variant: high
           prompt: |
             Review this pull request with the `code-review` skill, against the

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -36,11 +36,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      # Lands in .agents/skills/, which opencode scans on its own.
-      - name: Install skills
-        if: env.OPENCODE_API_KEY != ''
-        run: |
-          npx -y skills add Mai0313/skills --agent opencode --skill code-review -y
+      # Lands in .agents/skills/, which opencode scans on its own. Left off: a
+      # review skill narrowed what got looked at without improving the findings.
+      # - name: Install skills
+      #   if: env.OPENCODE_API_KEY != ''
+      #   run: |
+      #     npx -y skills add Mai0313/skills --agent opencode --skill code-review -y
 
       - name: Run opencode
         if: env.OPENCODE_API_KEY != ''

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install skills
         if: env.OPENCODE_API_KEY != ''
         run: |
-          npx -y skills add https://github.com/anthropics/knowledge-work-plugins --agent opencode --skill code-review -y
+          npx -y skills add Mai0313/skills --agent opencode --skill code-review -y
 
       - name: Run opencode
         if: env.OPENCODE_API_KEY != ''

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -1,0 +1,59 @@
+name: opencode Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions: write-all
+
+# `secrets` is unavailable in any `if`, so bridge the key through env and gate
+# each step, letting a repo without it finish green. The composite action merges
+# this same env, so its own step needs no OPENCODE_API_KEY.
+env:
+  OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+
+concurrency:
+  group: opencode-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Review
+    runs-on: ubuntu-latest
+    # The action asserts the author has write access and posts an error comment
+    # when they do not, so keep non-collaborator PRs out. This also covers
+    # dependabot, whose PRs come in as CONTRIBUTOR.
+    if: |
+      github.event.pull_request.draft == false &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+
+    steps:
+      # Full history, so the skill can resolve a merge base against the base branch.
+      - name: Checkout
+        if: env.OPENCODE_API_KEY != ''
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Lands in .agents/skills/, which opencode scans on its own.
+      - name: Install skills
+        if: env.OPENCODE_API_KEY != ''
+        run: |
+          npx -y skills add Mai0313/skills --agent opencode -y
+
+      - name: Run opencode
+        if: env.OPENCODE_API_KEY != ''
+        uses: anomalyco/opencode/github@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: opencode/gemini-3.1-pro
+          agent: build
+          variant: high
+          prompt: |
+            Review this pull request with the `code-review` skill, against the
+            base branch `origin/${{ github.event.pull_request.base.ref }}`.
+
+            Your reply is posted as a comment for you, so do not post one
+            yourself, and do not commit or push anything.

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -57,6 +57,7 @@ jobs:
 
             Follow whichever of CLAUDE.md, AGENTS.md, README.md and
             .github/copilot-instructions.md this repository actually has, and
-            treat a breach of them as a finding.
+            treat a breach of them as a finding. Where a comment already records
+            why something is the way it is, that is a decision, not a finding.
 
             Do not modify, commit, or push anything.

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -56,5 +56,13 @@ jobs:
             Review this pull request with the `code-review` skill, against the
             base branch `origin/${{ github.event.pull_request.base.ref }}`.
 
+            Shape the report for a GitHub comment: the verdict as a bold opening
+            line, then one block per finding in severity order, each starting
+            with a bold `P<n> — <title>` line, then its location as a markdown
+            link to `https://github.com/${{ github.repository }}/blob/${{ github.event.pull_request.head.sha }}/<path>#L<line>`,
+            then the finding itself. Reformatting is the only liberty you may
+            take: never drop, merge, or soften one. A single line is enough when
+            there is nothing to report.
+
             Your reply is posted as a comment for you, so do not post one
             yourself, and do not commit or push anything.

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -36,6 +36,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # Lands in .agents/skills/, which opencode scans on its own.
+      - name: Install skills
+        if: env.OPENCODE_API_KEY != ''
+        run: |
+          npx -y skills add https://github.com/anthropics/knowledge-work-plugins --agent opencode --skill code-review -y
+
       - name: Run opencode
         if: env.OPENCODE_API_KEY != ''
         uses: anomalyco/opencode/github@latest

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Checkout
         if: env.OPENCODE_API_KEY != ''
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,52 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions: write-all
+
+# `secrets` is unavailable in any `if`, so bridge the key through env and gate
+# each step, letting a repo without it finish green. The composite action merges
+# this same env, so its own step needs no OPENCODE_API_KEY.
+env:
+  OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+
+jobs:
+  mention:
+    name: Mention
+    runs-on: ubuntu-latest
+    # The action asserts the commenter has write access and answers with an
+    # error comment when they do not, so keep drive-by mentions out.
+    if: |
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+      (contains(github.event.comment.body, ' /oc') ||
+       startsWith(github.event.comment.body, '/oc') ||
+       contains(github.event.comment.body, ' /opencode') ||
+       startsWith(github.event.comment.body, '/opencode'))
+
+    steps:
+      - name: Checkout
+        if: env.OPENCODE_API_KEY != ''
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      # Lands in .agents/skills/, which opencode scans on its own.
+      - name: Install skills
+        if: env.OPENCODE_API_KEY != ''
+        run: |
+          npx -y skills add Mai0313/skills --agent opencode -y
+
+      - name: Run opencode
+        if: env.OPENCODE_API_KEY != ''
+        uses: anomalyco/opencode/github@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: opencode/gemini-3.1-pro
+          agent: build
+          variant: high
+          mentions: /opencode,/oc

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -46,7 +46,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          model: opencode/gemini-3.1-pro
+          model: opencode/gemini-3.6-flash
           agent: build
+          share: false
           variant: high
           mentions: /opencode,/oc

--- a/.gitignore
+++ b/.gitignore
@@ -223,3 +223,7 @@ TODO.md
 
 # Host-local compose override (machine-specific bind mounts, e.g. media hosting)
 /docker-compose.override.yaml
+
+# Agent skills, pulled on demand by `npx skills add`
+/.agents/skills/
+/skills-lock.json


### PR DESCRIPTION
Adds two opencode workflows, split by trigger.

**`opencode.yml`** answers `/oc` or `/opencode` on an issue comment or a PR review comment. The comment body is the prompt, so the workflow sets no `prompt` of its own: the action skips the mention parser entirely once one is given.

**`opencode-review.yml`** reviews a pull request through the `code-review` skill. The prompt pins the skill's target to the base branch, because the action denies the session's `question` permission and the skill would otherwise stop to offer its four targets. `fetch-depth: 0` is what lets it resolve a merge base.

Both jobs:

- gate on `author_association`, since the action asserts the actor has write access and answers with an error comment when they do not
- gate every step on `env.OPENCODE_API_KEY != ''`, so a clone without the secret finishes green instead of red. `secrets` is unavailable in any `if`, hence the env bridge; the composite action merges the same env, so its step needs no key of its own
- pull skills with `npx skills add`, which land in `.agents/skills/` where opencode already looks. Those are gitignored rather than committed

`opencode.yml` cannot be exercised from this PR: `issue_comment` is a repository-level event, so GitHub only ever runs it from the default branch. `opencode-review.yml` runs here and reviews this diff.