### PR TITLE
docs(capabilities): state the real gate on the two /admin commands

### DIFF
--- a/src/discordbot/cogs/gen_reply/capabilities.md
+++ b/src/discordbot/cogs/gen_reply/capabilities.md
@@ -72,10 +72,13 @@ Central bank:
 - `/central_bank call` — central bankers only: forced collection
 - `/central_bank status` — how much the central bank can still lend
 
-Server admins:
+Balance maintenance:
 
-- `/admin refund_tax` — add to someone's balance
-- `/admin collect_tax` — take from someone's balance
+- `/admin refund_tax` — economy admins only: add to someone's balance
+- `/admin collect_tax` — economy admins only: take from someone's balance
+
+Economy admin and central banker are flags on an account, set by whoever runs me. Neither is a
+Discord role: being a server admin grants neither, and no command hands one out.
 
 ## Simulated stock market
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -14,6 +14,16 @@ _CODE_SPAN_RE = re.compile(pattern=r"`([^`]+)`")
 # `and/or` or `24/7`; anything else in front of one (a space, a `*`, a bracket) means the text
 # names a command where `_documented_commands` cannot read it.
 _BARE_COMMAND_RE = re.compile(pattern=r"(?<![\w:/.\-])(/[a-z][\w-]*)")
+_PICKER_GATE_KEYWORD = "default_member_permissions"
+# Every boolean column on `UserAccount`, mapped to the wording it owes and the command lines
+# that owe it, or `None` when the flag gates no command. `is_admin`'s wording carries the term
+# its own refusal embed shows the user, so a refused member reads one name for the flag.
+_ACCOUNT_FLAG_GATES: dict[str, tuple[str, tuple[str, ...]] | None] = {
+    "is_vip": None,
+    "is_admin": ("economy admins only", ("/admin refund_tax", "/admin collect_tax")),
+    "is_central_banker": ("central bankers only", ("/central_bank call",)),
+    "hide_from_leaderboard": None,
+}
 
 
 def _declared_parent(decorator: ast.Call) -> str | None:
@@ -150,6 +160,63 @@ def _mentions_command(body: str, command: str) -> bool:
     return re.search(pattern=rf"/{re.escape(pattern=command)}(?![\w-])", string=body) is not None
 
 
+def _account_flag_columns() -> set[str]:
+    """Returns the boolean flag columns `UserAccount` declares.
+
+    Read by AST rather than imported: that module owns the process-wide economy engine, and a
+    test asking which columns exist has no business building one. A column counts on any
+    `Mapped[...]` naming `bool`, never on that annotation spelled one exact way — the optional
+    form is house style two columns above `is_admin`, and a pin a new flag can be added past
+    is worse than none.
+    """
+    module = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "discordbot"
+        / "services"
+        / "economy"
+        / "database.py"
+    )
+    parsed = ast.parse(source=module.read_text(encoding="utf-8"), filename=str(module))
+    accounts = [
+        node
+        for node in ast.walk(node=parsed)
+        if isinstance(node, ast.ClassDef) and node.name == "UserAccount"
+    ]
+    # Loud rather than the bare StopIteration a `next()` would raise: a renamed or moved model
+    # has to say what it broke, the same way the command scan refuses to shrink in silence.
+    assert len(accounts) == 1, f"expected one UserAccount model, found {len(accounts)}"
+    columns: set[str] = set()
+    for node in accounts[0].body:
+        if not isinstance(node, ast.AnnAssign) or not isinstance(node.target, ast.Name):
+            continue
+        annotation = ast.unparse(ast_obj=node.annotation)
+        if annotation.startswith("Mapped[") and "bool" in annotation:
+            columns.add(node.target.id)
+    return columns
+
+
+def _command_line(body: str, command: str) -> str | None:
+    """Returns the line naming this command, or `None` when the document has no such line."""
+    return next((line for line in body.splitlines() if f"`{command}`" in line), None)
+
+
+def _modules_declaring_a_picker_gate() -> list[str]:
+    """Returns the cog modules handing Discord a permission to filter its command picker."""
+    cogs_dir = Path(__file__).resolve().parents[1] / "src" / "discordbot" / "cogs"
+    declaring: list[str] = []
+    for module in cogs_dir.rglob(pattern="*.py"):
+        parsed = ast.parse(source=module.read_text(encoding="utf-8"), filename=str(module))
+        if any(
+            keyword.arg == _PICKER_GATE_KEYWORD
+            for node in ast.walk(node=parsed)
+            if isinstance(node, ast.Call)
+            for keyword in node.keywords
+        ):
+            declaring.append(module.relative_to(cogs_dir).as_posix())
+    return sorted(declaring)
+
+
 def test_slash_command_scan_resolves_subcommands() -> None:
     """The scan must reach group subcommands, since a silent shrink is what it guards against."""
     paths = _slash_command_paths()
@@ -258,6 +325,59 @@ def test_capabilities_doc_accounts_for_every_inline_marker() -> None:
         "<generate-video>",
         "<deep-research>",
     }, "the inline markers changed: say so in capabilities.md, then pin the new set here"
+
+
+def test_capabilities_doc_states_every_gate_on_the_gated_command_line() -> None:
+    """A permission claim carries no command, so neither command guard can see it.
+
+    That is how a `Server admins:` heading sat over two commands gated on an account flag
+    Discord knows nothing about, telling a server admin they could move other people's
+    balances and whoever actually held the flag that they could not. This document is the
+    answer model's only description of the bot, so a wrong gate is the bot saying it.
+
+    Same shape as the marker guard, for the same reason: with nothing to match on, the set is
+    read out of the code and pinned instead. What the marker guard does not have to decide is
+    WHERE the document says it — and here that is the whole defect. The gate has to sit on the
+    command's own line, because the heading it used to sit under is one the model drops the
+    moment it quotes a single line back, which is how a wrong gate outlives a reader who
+    checked the line and not the heading above it.
+
+    The pin covers `UserAccount`, which is where both of today's gates live; a flag added to
+    another model, and a gate on a button rather than a command, are outside it.
+    """
+    assert _account_flag_columns() == set(_ACCOUNT_FLAG_GATES), (
+        "UserAccount's flag columns changed: if a new one gates a command, say so on that "
+        "command's own line in capabilities.md, then pin the new set here"
+    )
+    unstated: list[str] = []
+    for gate in _ACCOUNT_FLAG_GATES.values():
+        if gate is None:
+            continue
+        wording, commands = gate
+        for command in commands:
+            line = _command_line(body=CAPABILITIES_DOC, command=command)
+            if line is None or wording not in line.lower():
+                unstated.append(f"{command} ({wording})")
+    assert not unstated, f"these command lines state no gate: {sorted(unstated)}"
+
+
+def test_no_command_hides_behind_a_discord_permission() -> None:
+    """The premise behind "neither is a Discord role": Discord filters nothing away here.
+
+    No command declares `default_member_permissions`, so Discord offers every one of them to
+    every member and each gate refuses inside its own callback instead. The day one is
+    declared, the picker starts hiding commands from the very people a flag may have been
+    granted to, and that sentence needs rewriting — which a guard that only reads the document
+    would never say.
+
+    Scoped to the declaration deliberately. Whether an in-callback permission read gates a
+    command or merely asks what the bot itself may do is not decidable by scanning, and
+    `permissions_for` already appears twice for the latter.
+    """
+    declared = _modules_declaring_a_picker_gate()
+    assert not declared, (
+        f"a command now hides behind a Discord permission: revisit capabilities.md {declared}"
+    )
 
 
 def test_capabilities_block_is_a_low_authority_assistant_note() -> None:


### PR DESCRIPTION
Closes #437

`capabilities.md` headed the two `/admin` commands with `Server admins:`. The gate is not a Discord permission — both run through `_run_admin_adjustment`, which checks `get_admin`, a read of the `user_account.is_admin` flag in `economy.db`. That document is injected into every QA reply as the answer model's only description of the bot, so the line was the bot actively telling a server admin they could move other people's balances, and whoever actually held the flag that they could not.

## The wording

The gate moves onto each command's own line, in the form `/central_bank call` already used:

```
Balance maintenance:

- `/admin refund_tax` — economy admins only: add to someone's balance
- `/admin collect_tax` — economy admins only: take from someone's balance
```

Stating it on the line rather than over a heading is the substance of the fix, not formatting. The answer model quotes a single line back; a gate one line away is a gate that quote drops, which is how the wrong claim survived a reader who checked the command and not the heading above it. The heading is now a neutral grouping label, so no heading carries a permission claim at all. "economy admins" is the term the refusal embed already shows the user, so a refused member reads one name for the flag rather than two.

One sentence closes the section, since `/central_bank call`'s "central bankers only" was accurate but equally unexplained:

> Economy admin and central banker are flags on an account, set by whoever runs me. Neither is a Discord role: being a server admin grants neither, and no command hands one out.

The negation is what does the work — without it a reader lands back on the same inference — and the second half answers the follow-up ("how do I get it?") the model would otherwise invent a reply to.

## The guard

Neither existing scan could see this: both match command paths, and a permission claim carries no command. That is the problem `test_capabilities_doc_accounts_for_every_inline_marker` already solves for markers, so the guard takes the same shape — read the set out of the code, pin it, require the document to describe each member. The set is `UserAccount`'s boolean columns, read by AST (no import, so no module-level engine is built), matching any `Mapped[...]` naming `bool` so the optional spelling used elsewhere in that class cannot add a flag past the pin. The check is anchored to the gated command's own line, which is what makes it fail on the exact wording this PR replaces.

A second test pins the premise behind "neither is a Discord role": no command declares `default_member_permissions`, so Discord filters nothing and each gate refuses inside its own callback. It is scoped to that declaration deliberately — whether an in-callback permission read gates a command or just asks what the bot itself may do is not decidable by scanning, and `permissions_for` already appears twice for the latter.

Every failure mode was verified by temporarily introducing it: the old heading-only wording fails, a `Mapped[bool | None]` flag fails the pin, a renamed `UserAccount` fails with a message instead of a bare `StopIteration`, a declared `default_member_permissions` fails the premise check, and a comment merely mentioning a Discord permission does not.

## Not changing: the picker

#437 left open whether to declare `default_member_permissions` so Discord stops offering both commands to every member. Deliberately not done. That declaration can only be expressed in Discord permissions, and the real gate is an account flag orthogonal to them, so no declaration matches it. `administrator=True` would hide the commands from an economy admin who is not also a Discord admin — trading a clear ephemeral refusal for a command that cannot be found. The in-callback refusal stays.

## Left for follow-ups

Adversarial review turned up three things in the same family, all out of scope here:

- The `/admin` group's own Discord description strings still read `管理員限定` / `管理者専用` / "Admin-only", which reads as *server* admin in the command picker — the same misreading, on a surface users meet earlier. The three READMEs say "Admin-only" too.
- `/central_bank borrow` does not mention that a central banker has to approve it, within 180s.
- `/admin collect_tax` clamps at the target's balance and no-ops against a user with no wallet row; the result embed says so, the document does not.
