### PR TITLE
ci: unify the pull request label set

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,186 +1,41 @@
-# 🏷️ Auto Labeler Configuration
-# 這個檔案會自動為 PR 添加標籤，基於分支名稱和檔案變更路徑
-# 設計來支援 Python 和 TypeScript 專案，與 release-drafter.yml 完全對應
+# 依分支名稱自動為 PR 掛上一個 type label。
+#
+# 只看 head-branch,不看檔案路徑,因為路徑說不出「這是修 bug」還是「這是新功能」。
+# 唯一的例外是 chore:一個只動到工具鏈的 PR 就真的是雜務,而 any-glob-to-all-files
+# 要求「所有」改動檔案都符合,不會像 any-glob-to-any-file 那樣碰到一個就中。
+#
+# 顏色和描述沒辦法寫在這裡,由 .github/workflows/sync_labels.yml 維護。
+# 這份設定與語言無關,所有 template 和下游 repo 共用同一份。
 
-# 主要標籤會被 release-drafter.yml 用於：
-# 1. 自動分類到對應的 changelog 區段
-# 2. 決定版本號 (Major/Minor/Patch)
-# 3. 生成 release notes
-
-# ===============================
-# 🎯 Main Labels (對應 release-drafter categories)
-# ===============================
-
-# 💥 Breaking Changes
 breaking:
-  - head-branch:
-      - "^breaking/.*"
-      - "^major/.*"
-      - "^BREAKING/.*"
+  - head-branch: ["^breaking/"]
 
-# ✨ Features
 feature:
-  - head-branch:
-      - "^feat/.*"
-      - "^feature/.*"
-      - "^add/.*"
-  - changed-files:
-      - any-glob-to-any-file:
-          - "src/**/*.py"
-          - "src/**/*.ts"
-          - "src/**/*.js"
-          - "lib/**/*.py"
-          - "lib/**/*.ts"
-          - "lib/**/*.js"
+  - head-branch: ["^feat/"]
 
-# 🐛 Bug Fixes
-bugfix:
-  - head-branch:
-      - "^fix/.*"
-      - "^bug/.*"
-      - "^bugfix/.*"
-      - "^hotfix/.*"
+bug:
+  - head-branch: ["^fix/"]
 
-# 🧰 Maintenance
-chore:
-  - head-branch:
-      - "^chore/.*"
-      - "^maintenance/.*"
-      - "^config/.*"
-      - "^update/.*"
-  - changed-files:
-      - any-glob-to-any-file:
-          - ".github/**"
-          - ".pre-commit-config.yaml"
-          - "pyproject.toml"
-          - "setup.py"
-          - "Makefile"
-
-# 📦 Dependencies
-dependencies:
-  - head-branch:
-      - "^dep/.*"
-      - "^deps/.*"
-      - "^dependencies/.*"
-      - "^dependabot/.*"
-  - changed-files:
-      - any-glob-to-any-file:
-          - "requirements*.txt"
-          - "pyproject.toml"
-          - "setup.py"
-          - "setup.cfg"
-          - "Pipfile*"
-          - "poetry.lock"
-          - "uv.lock"
-          - "package.json"
-          - "package-lock.json"
-          - "yarn.lock"
-          - "pnpm-lock.yaml"
-
-# 📝 Documentation
-documentation:
-  - head-branch:
-      - "^docs/.*"
-      - "^doc/.*"
-      - "^documentation/.*"
-  - changed-files:
-      - any-glob-to-any-file:
-          - "docs/**/*"
-          - "**/*.md"
-          - "**/*.rst"
-          - "**/*.ipynb"
-          - "notebooks/**/*"
-          - "notebook/**/*"
-          - "mkdocs.yml"
-          - "README*"
-          - "CHANGELOG*"
-
-# 🧪 Tests
-unit-test:
-  - head-branch:
-      - "^test/.*"
-      - "^tests/.*"
-  - changed-files:
-      - any-glob-to-any-file:
-          - "tests/**/*.py"
-          - "test/**/*.py"
-          - "**/test_*.py"
-          - "**/*_test.py"
-          - "**/*test*.py"
-          - "**/*spec*.py"
-          - "tests/**/*.ts"
-          - "test/**/*.ts"
-          - "**/*.test.ts"
-          - "**/*.spec.ts"
-          - "**/*.test.js"
-          - "**/*.spec.js"
-          - "jest.config.*"
-          - "vitest.config.*"
-          - "pytest.ini"
-          - "conftest.py"
-
-# ⚡️ Performance Improvements
-perf:
-  - head-branch:
-      - "^perf/.*"
-      - "^performance/.*"
-      - "^optimize/.*"
-  - changed-files:
-      - any-glob-to-any-file:
-          - "**/*perf*.py"
-          - "**/*benchmark*.py"
-          - "**/*performance*.py"
-          - "**/*perf*.ts"
-          - "**/*benchmark*.ts"
-          - "**/*performance*.ts"
-
-# 🔒️ Security Fixes
-security:
-  - head-branch:
-      - "^security/.*"
-      - "^sec/.*"
-  - changed-files:
-      - any-glob-to-any-file:
-          - "**/*security*.py"
-          - "**/*auth*.py"
-          - "**/*credential*.py"
-          - "**/*security*.ts"
-          - "**/*auth*.ts"
-          - "**/*credential*.ts"
-
-# ♻️ Code Refactoring
 refactor:
-  - head-branch:
-      - "^refactor/.*"
-      - "^cleanup/.*"
-      - "^restructure/.*"
+  - head-branch: ["^refactor/"]
 
-# 🎨 Code Style & Formatting
-style:
-  - head-branch:
-      - "^style/.*"
-      - "^format/.*"
-      - "^lint/.*"
+documentation:
+  - head-branch: ["^docs?/"]
+
+test:
+  - head-branch: ["^tests?/"]
+
+perf:
+  - head-branch: ["^perf/"]
+
+chore:
+  - head-branch: ["^chore/", "^ci/", "^build/", "^style/", "^config/"]
   - changed-files:
-      - any-glob-to-any-file:
+      - any-glob-to-all-files:
+          - ".github/**"
+          - ".devcontainer/**"
+          - "docker/**"
+          - "Dockerfile*"
+          - "Makefile"
           - ".pre-commit-config.yaml"
-          - ".ruff.toml"
-          - "ruff.toml"
-          - ".black"
-          - ".flake8"
-          - ".isort.cfg"
-          - ".mypy.ini"
-          - "mypy.ini"
-          - ".pylintrc"
-          - ".eslintrc*"
-          - ".prettier*"
-          - "stylelint*"
-          - "**/*.css"
-          - "**/*.scss"
-          - "**/*.sass"
-
-# 🔙 Reverts
-revert:
-  - head-branch:
-      - "^revert/.*"
-      - "^rollback/.*"
+          - ".gitignore"

--- a/.github/workflows/sync_labels.yml
+++ b/.github/workflows/sync_labels.yml
@@ -1,0 +1,41 @@
+name: Sync Labels
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - .github/workflows/sync_labels.yml
+  workflow_dispatch:
+
+permissions: write-all
+
+jobs:
+  sync_labels:
+    name: Sync Labels
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Sync
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # --force 讓已存在的 label 更新顏色和描述,不存在的就建出來。
+          # 沒有這一步,actions/labeler 會自己補建,但它只能給名字,顏色一律是灰的。
+          sync() { gh label create "$1" --color "$2" --description "$3" --force; }
+
+          sync breaking      B60205 "Breaks compatibility and bumps the major version"
+          sync bug           D73A4A "Something isn't working"
+          sync feature       0E8A16 "New functionality"
+          sync perf          FBCA04 "Performance improvement"
+          sync refactor      5319E7 "Code restructuring without a behavior change"
+          sync test          006B75 "Tests and test infrastructure"
+          sync documentation 0075CA "Improvements or additions to documentation"
+          sync chore         CFD3D7 "Maintenance, CI, build and tooling"
+
+          # Dependabot 自己會建這個,labeler.yml 不管它,這裡只統一顏色。
+          sync dependencies  0366D6 "Pull requests that update a dependency file"


### PR DESCRIPTION
Labels now come from the branch name instead of changed-file globs, and a new workflow keeps label colors in sync.

Opened-by: Claude Opus 5 (1M context)