### PR TITLE
feat(threads): react on every Threads post the bot reads

### DIFF
--- a/src/discordbot/cogs/gen_reply/cog.py
+++ b/src/discordbot/cogs/gen_reply/cog.py
@@ -2346,6 +2346,16 @@ class ReplyGeneratorCogs(commands.Cog):
                                 deadline=link_context_deadline,
                             )
                         )
+                    if "threads" in link_tasks:
+                        # Persistent marker (added directly, not via the status chain) saying a
+                        # Threads post was read, the same one `parse_threads` adds when it expands
+                        # a link instead. Added once every builder is started so the REST call
+                        # never sits between two of them.
+                        await update_reaction(
+                            message=message,
+                            bot_user=self.bot.user,
+                            emoji="<:threads:1535657820668559380>",
+                        )
                 if route.decision in ("IMAGE", "VIDEO"):
                     # IMAGE and VIDEO share identical speculative-task teardown; they differ only
                     # in the status emoji and which media handler runs. Effort is answer-only,

--- a/src/discordbot/cogs/parse_threads/cog.py
+++ b/src/discordbot/cogs/parse_threads/cog.py
@@ -594,6 +594,12 @@ class ThreadsCogs(commands.Cog):
             return
 
         url = match.group(0)
+        # Persistent marker (added directly, not through the status chain, which replaces its own
+        # reaction) saying a Threads post was read. `gen_reply` adds the same one on the path it
+        # takes instead of this one, so every read is marked the same way whichever cog did it.
+        await update_reaction(
+            message=message, bot_user=self.bot.user, emoji="<:threads:1535657820668559380>"
+        )
         current_emoji = await update_reaction(message=message, bot_user=self.bot.user, emoji="🔗")
 
         try:

--- a/tests/test_cogs_smoke.py
+++ b/tests/test_cogs_smoke.py
@@ -419,6 +419,9 @@ async def test_threads_cog_builds_embeds_and_handles_messages(tmp_path: Path) ->
     assert success_message.suppressed
     assert success_message.replies[0]["files"]
     assert success_message.reactions[-1] == "<:greencheck:1517565102424068226>"
+    # The read marker rides beside the status chain, which only ever removes its own reaction.
+    assert success_message.reactions[0] == "<:threads:1535657820668559380>"
+    assert all(emoji != "<:threads:1535657820668559380>" for emoji, _ in success_message.removed)
     # The parse now carries the comments too, but the expansion shows the chain only: the
     # 10-embed cap belongs to the linked post, and a comment would push its own images out.
     assert all(

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -5634,6 +5634,8 @@ async def test_on_message_injects_threads_context_before_current(
     answer = request_input(responses=_recorded(cog).responses, phase="answer")
     assert has_threads_context_block(request=answer)
     assert extract_threads_context_block(request=answer) == "MOCK THREADS POST BODY"
+    # A persistent marker says the post was read, the same one the expansion cog adds.
+    assert "<:threads:1535657820668559380>" in message.added_reactions
 
     # The block lands after memory but before the current message (which stays last).
     headers = [text.split("\n", 1)[0] for _role, text in iter_text_blocks(request=answer)]


### PR DESCRIPTION
Adds a persistent `<:threads:1535657820668559380>` reaction to the message carrying a Threads link, on both paths that read one.

- `parse_threads/cog.py`: added right after the URL match, ahead of the 🔗 progress reaction. It is added directly rather than through `ReactionStatusChain`, which only ever removes its own previous reaction, so the marker survives the ✅ / ⚠️ / ❌ that follows and is present whether the expansion succeeded or not.
- `gen_reply/cog.py`: added once the router has selected the `threads` link source AND `_link_url_for_source` resolved a URL, so an incidental link that starts no builder gets no marker. Placed after the builder loop so the REST call never sits between two builders.

The emoji literal is inlined at both sites, matching how every other reaction in the codebase is written (`<:greencheck:...>`, `<:youtube:...>`).

`capabilities.md` is untouched: it documents commands and features, not reaction markers — the equivalent `<:youtube:>` watch marker is not described there either.

## Testing

- `uv run pytest tests/test_gen_reply.py tests/test_cogs_smoke.py` — 333 passed. Two assertions added: `test_threads_cog_builds_embeds_and_handles_messages` pins the marker's position and that the status chain never removes it; `test_on_message_injects_threads_context_before_current` pins the gen_reply path.
- `uvx pre-commit run -a` — all green.

Opened-by: Claude Opus 5