### PR TITLE
chore(models): point the peak slow model at gemini-3.7-flash

### DIFF
--- a/src/discordbot/typings/models.py
+++ b/src/discordbot/typings/models.py
@@ -248,7 +248,7 @@ class RuntimeModelCatalog(BaseModel):
         # The peak/off-peak split is load-bearing again rather than dormant: Gemini Pro has
         # historically slowed down during peak hours, so peak takes the flash snapshot.
         if self.is_peak:
-            return ModelSettings(name="gemini-3.6-flash", effort="high")
+            return ModelSettings(name="gemini-3.7-flash", effort="high")
         return ModelSettings(name="gemini-3.1-pro-preview", effort="high")
 
     @property

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -6592,7 +6592,7 @@ def test_runtime_model_catalog_dispatches_slow_model_by_peak_hour(
     assert before_peak[1:] == (False, False)
     assert after_peak[1:] == (False, False)
     assert weekend[1:] == (False, False)
-    assert peak_start[0] == ModelSettings(name="gemini-3.6-flash", effort="high")
+    assert peak_start[0] == ModelSettings(name="gemini-3.7-flash", effort="high")
     assert peak_start[0] == peak_end[0]
     assert before_peak[0] == ModelSettings(name="gemini-3.1-pro-preview", effort="high")
     assert before_peak[0] == after_peak[0] == weekend[0]


### PR DESCRIPTION
## What

`RuntimeModelCatalog.slow_model` now dispatches `gemini-3.7-flash` on its peak branch, replacing `gemini-3.6-flash`. The off-peak branch (`gemini-3.1-pro-preview`) is untouched.

`gemini-3.7-flash` is already routed by the proxy, so the id is live rather than assumed.

## What is deliberately left alone

CLAUDE.md mentions `gemini-3.6-flash` twice, and both are **measurement records** rather than configuration:

- the 2026-08-08 effort-legality table for `interactions.create`
- the 2026-07 built-in-plus-function-tool combination list

Rewriting either to name 3.7 would claim a measurement that was never run on 3.7. They should be updated by re-measuring, not by find-and-replace.

## Risk

Per CLAUDE.md, an effort's legality is decided by the pair (model string, surface), and 3.7 has not been measured on `interactions.create` — the one surface the peak branch reaches directly, via the YouTube answer turn. The exposure is small: `EffortGrade` has emitted only `{low, high}` since #490, which is the one set every model and surface measured so far accepts.

## Testing

CI skips pytest on `chore/` branches (#486), so the suite was run locally instead:

- `uvx pre-commit run -a` — all hooks pass
- `uv run pytest` — 1754 passed, coverage gate met

Opened-by: Claude Opus 5 (1M context)
