### PR TITLE
docs(tests): sweep comments and docstrings against the tests they sit on

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,10 @@
 """Shared pytest fixtures.
 
-`economy_isolated_db` lives here instead of being copy-pasted into every
-test module that exercises the economy DB.
+Each `*_isolated_db` fixture points the owning module's module-level engine at a fresh
+`tmp_path` SQLite file for one test and disposes it afterwards; `memory_isolated_dir` does
+the same for the file-backed memory store. The autouse fixtures are the other half of that
+isolation, keeping a real deployment's `.env` and `data/` out of every test whether or not
+it asked for them.
 """
 
 from pathlib import Path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,11 @@
 """Shared pytest fixtures.
 
 Each `*_isolated_db` fixture points the owning module's module-level engine at a fresh
-`tmp_path` SQLite file for one test and disposes it afterwards; `memory_isolated_dir` does
-the same for the file-backed memory store. The autouse fixtures are the other half of that
-isolation, keeping a real deployment's `.env` and `data/` out of every test whether or not
-it asked for them.
+`tmp_path` SQLite file for one test and disposes it afterwards. `memory_isolated_dir` covers
+more than a directory: the store dir, the `memory_job` engine, the process-local caches,
+counters and task registries the store and pipeline hold, and the git committer. The autouse
+fixtures are the other half of that isolation, keeping a real deployment's `.env` and `data/`
+out of every test whether or not it asked for them.
 """
 
 from pathlib import Path

--- a/tests/helpers/discord_mocks.py
+++ b/tests/helpers/discord_mocks.py
@@ -66,8 +66,9 @@ class FakeUser:
         self.bot = bot
         self.mention = f"<@{user_id}>"
         self.display_avatar = SimpleNamespace(url=avatar_url)
-        # Commands that surface snowflake-derived account age read created_at; pin
-        # it well into the past so the value is never surprising under freezegun.
+        # Commands that surface snowflake-derived account age read created_at (`/balance`
+        # renders `now - created_at`); pinning it years back keeps that a plausible number
+        # instead of the zero a stub created "now" would show.
         self.created_at = datetime.now(tz=UTC) - timedelta(days=365 * 5)
 
 

--- a/tests/helpers/llm_input.py
+++ b/tests/helpers/llm_input.py
@@ -8,9 +8,10 @@ helpers walk the role/content structure instead, keyed on the production block
 headers and the ``[id: N]`` markers the memory blocks emit, so a test asserts on
 *which user's memory reached which role* rather than on an arbitrary literal.
 
-The block-header anchors are derived from the production renderers at import
-time, so a wording change in ``memory_tool.py`` is tracked automatically rather
-than silently breaking these extractors.
+The block-header anchors are derived from the production renderers and the
+link-source separators at import time, so a wording change in ``memory_tool.py``
+or in a ``link_sources`` module is tracked automatically rather than silently
+breaking these extractors.
 """
 
 import re

--- a/tests/test_blackjack.py
+++ b/tests/test_blackjack.py
@@ -175,7 +175,7 @@ def test_settle_player_blackjack_pays_three_to_two() -> None:
 
 
 def test_settlement_metadata_shows_vip_bonus_numbers() -> None:
-    """VIP winning settlements surface the base and boosted deltas."""
+    """A VIP-boosted win shows the total delta and the VIP bonus inside it."""
     metadata = settlement_metadata(
         delta=150, new_balance=1_150, is_allin=False, base_delta=100, vip_bonus=50
     )

--- a/tests/test_blackjack_view_buttons.py
+++ b/tests/test_blackjack_view_buttons.py
@@ -183,7 +183,7 @@ async def test_player_actions_is_split_hand_disables_double_split_surrender() ->
 
 
 async def test_split_aces_subhand_disables_hit_and_stand() -> None:
-    """Split Aces alone removes every control, without relying on the finished flag."""
+    """Split Aces removes Hit and Stand with `finished` still False; Split removed the rest."""
     round_state = BlackjackRound.from_participants(
         rng=Random(x=0),
         participants=[_participant(user_id=1, display_name="Alice")],

--- a/tests/test_blackjack_view_buttons.py
+++ b/tests/test_blackjack_view_buttons.py
@@ -1,9 +1,8 @@
-"""Button-state matrix and dealer / bot turn tests for `BlackjackView`.
+"""Button-state matrix, dealer play, and bot-turn tests for `BlackjackView`.
 
-Each test instantiates the view with a deterministic `BlackjackRound`, then
-asserts which action / insurance buttons are attached across the round
-lifecycle. Dealer play is deterministic (H17), so dealer tests cover the rule
-path; bot-turn tests cover the deterministic bot player decisions.
+Controls are presence-based, so the button tests assert which custom_ids are
+attached rather than which are disabled. Dealer play is deterministic (H17) and
+the bot's decisions come from the EV engine, so both are asserted exactly.
 """
 
 # ruff: noqa: S311 -- seeded Random() in tests is for determinism, not cryptography
@@ -155,7 +154,7 @@ async def test_player_actions_ace_ten_hides_split() -> None:
 
 
 async def test_player_actions_after_hit_disables_double_split_surrender() -> None:
-    """After a Hit, `actions_taken` > 0 locks the first-action-only buttons."""
+    """After a Hit the first-action-only controls leave the view instead of being disabled."""
     round_state = _round_with_two_cards(
         player_cards=[Card(rank="5", suit="♠"), Card(rank="6", suit="♥")],
         dealer_cards=[Card(rank="5", suit="♣"), Card(rank="6", suit="♦")],
@@ -184,7 +183,7 @@ async def test_player_actions_is_split_hand_disables_double_split_surrender() ->
 
 
 async def test_split_aces_subhand_disables_hit_and_stand() -> None:
-    """Split Aces forces finished + is_split_aces, blocking Hit and Stand."""
+    """Split Aces alone removes every control, without relying on the finished flag."""
     round_state = BlackjackRound.from_participants(
         rng=Random(x=0),
         participants=[_participant(user_id=1, display_name="Alice")],
@@ -565,7 +564,7 @@ async def test_bot_action_plays_ev_action(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 async def test_apply_bot_action_routes_known_actions() -> None:
-    """`_apply_bot_action` calls the matching BlackjackRound API for each known action."""
+    """An allowed action is routed to its `BlackjackRound` method and reported applied."""
     round_state = _round_with_two_cards(
         player_cards=[Card(rank="10", suit="♠"), Card(rank="7", suit="♥")],
         dealer_cards=[Card(rank="5", suit="♣"), Card(rank="6", suit="♦")],

--- a/tests/test_cogs_smoke.py
+++ b/tests/test_cogs_smoke.py
@@ -808,7 +808,7 @@ async def test_threads_cog_reserves_the_quoted_posts_slot_against_an_ancestors_g
     descriptions = [embed.description or "" for embed in embeds]
     assert any(text.startswith("🔗 **被引用的貼文**") for text in descriptions)
     assert "commentary" in descriptions
-    # The ancestor gives up its tenth image, not the target or the quoted post.
+    # The ancestor gives up two of its ten images, not the target or the quoted post.
     assert sum(1 for embed in embeds if embed.image) == 8
 
 
@@ -905,7 +905,8 @@ async def test_threads_cog_hosts_oversized_video(tmp_path: Path) -> None:
     message = FakeDiscordMessage()
     message.__dict__["author"] = FakeUser(bot=False)
     message.__dict__["content"] = "https://www.threads.net/@alice/post/abc"
-    # A tiny ceiling drives max_size negative, so the 3-byte video counts as oversized.
+    # The 1 MiB envelope margin alone overshoots this ceiling, so no combined body ever fits
+    # and even a 3-byte video is peeled out to a hosted URL.
     message.__dict__["guild"] = SimpleNamespace(filesize_limit=4)
     cog.downloader = cast(
         "ThreadsDownloader",
@@ -2166,7 +2167,11 @@ def ignore_scheduled_public_message(
 
 
 async def fake_game_balance(user_id: int) -> int:
-    """Returns a small fake game balance (bot stays at 0 so it does not auto-join)."""
+    """Returns a small fake game balance, and zero for the bot's own id.
+
+    Zero is not what keeps the bot out of the lobby: `_bot_blackjack_participant` reads
+    `get_account`, so the empty isolated economy DB is what makes it skip its seat.
+    """
     if user_id == 999:
         return 0
     return 100
@@ -2576,7 +2581,7 @@ async def test_games_on_ready_cleans_stale_messages_once(monkeypatch: pytest.Mon
 
 
 def test_setup_functions_register_cogs(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Verifies every cog setup function registers the expected cog type."""
+    """Verifies each cog setup function listed here registers the expected cog type."""
     added: list[
         tuple[
             VideoCogs

--- a/tests/test_discord_embed_utils.py
+++ b/tests/test_discord_embed_utils.py
@@ -41,7 +41,7 @@ def test_apply_embed_spacer_image_sets_attachment_url() -> None:
 
 
 def test_build_embed_spacer_file_returns_fresh_png_upload() -> None:
-    """Each send or edit gets its own Discord File object."""
+    """Every call builds its own Discord File, since one File's buffer serves one request."""
     first = build_embed_spacer_file()
     second = build_embed_spacer_file()
 

--- a/tests/test_douyin.py
+++ b/tests/test_douyin.py
@@ -759,7 +759,7 @@ def test_local_write_failure_leaves_no_partial_file(
             raise OSError(28, "No space left on device")
 
         # Simulate a mid-write disk failure; the instance-dict write shadows the
-        # bound method without tripping either checker's method-assign rule.
+        # bound method without tripping the type checker's method-assign rule.
         handle.__dict__["write"] = write
         return handle
 

--- a/tests/test_douyin.py
+++ b/tests/test_douyin.py
@@ -759,7 +759,7 @@ def test_local_write_failure_leaves_no_partial_file(
             raise OSError(28, "No space left on device")
 
         # Simulate a mid-write disk failure; the instance-dict write shadows the
-        # bound method without tripping the type checker's method-assign rule.
+        # bound method without the direct attribute assignment a type checker rejects.
         handle.__dict__["write"] = write
         return handle
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -124,7 +124,7 @@ def test_facebook_share_resolution_never_downloads_the_page(
     """Only where the request landed is wanted, so the body is left on the wire.
 
     Every other test stubs the resolver out, so without this one a request that downloads a
-    full Facebook page to read a single header stays green forever.
+    full Facebook page just to learn where it landed stays green forever.
     """
     requests_made: list[dict[str, object]] = []
 

--- a/tests/test_dragon_gate.py
+++ b/tests/test_dragon_gate.py
@@ -911,8 +911,8 @@ async def test_dragon_gate_view_pool_emptied_replenishes_and_finalises_without_c
     assert len(state.calls) == 1
     assert state.calls[0]["player_delta"] == 10_000
     assert view._settled is True
-    # The pool state above is the invariant; the dealer embed is rendered and well-formed but its
-    # exact replenishment copy is not pinned.
+    # The pool state above is the invariant; the final embed's replenishment copy is not pinned,
+    # only that the closing render still carries a well-formed history embed.
     embeds = message.edits[-1]["embeds"]
     assert isinstance(embeds, list)
     assert isinstance(embeds[1], Embed)
@@ -1022,8 +1022,8 @@ async def test_dragon_gate_view_single_player_zero_balance_finalizes(
     assert round_state.is_active(user_id=1) is False
     assert round_state.finished is True
     assert view._settled is True
-    # The end-state above is the invariant; the dealer embed is rendered and well-formed but its
-    # exact "all players out" copy is not pinned.
+    # The end-state above is the invariant; the final embed's "all players out" copy is not
+    # pinned, only the clamped delta the history embed below carries.
     embeds = message.edits[-1]["embeds"]
     assert isinstance(embeds, list)
     assert isinstance(embeds[1], Embed)

--- a/tests/test_economy.py
+++ b/tests/test_economy.py
@@ -652,7 +652,7 @@ async def test_top_n_orders_by_balance_descending() -> None:
 
 
 async def test_top_n_excludes_specified_users() -> None:
-    """Excluded user IDs (e.g. the bot's house ledger) must not appear in the result."""
+    """An excluded account is filtered out even when its balance would top the board."""
     await _add_balance(user_id=1, name="alice", amount=100)
     await _add_balance(user_id=2, name="bob", amount=300)
     await _add_balance(user_id=99, name="house", amount=999)
@@ -1027,7 +1027,7 @@ async def test_blackjack_view_dealer_hits_soft_17(monkeypatch: pytest.MonkeyPatc
 
     await view.finalize(message=as_message(fake=message))
 
-    # Soft 17 must trigger at least one draw, landing the dealer above 17.
+    # Soft 17 must trigger a draw; the drawn K lands a hard 17, where the dealer stands.
     assert len(view.round_state.dealer) >= 3
     assert view.round_state.dealer_played is True
     assert "embeds" not in message.edits[0]
@@ -1671,7 +1671,7 @@ async def test_top_losers_orders_by_loss_magnitude() -> None:
 
 
 async def test_top_losers_excludes_specified_users() -> None:
-    """`exclude_user_ids` filters the house ledger out of the report."""
+    """An excluded user id never appears in the daily loss report."""
     await _add_balance(user_id=1, name="alice", amount=500)
     await apply_round_settlement(
         player_id=1, player_account_name="alice", player_delta=-500, casino_delta=500

--- a/tests/test_economy.py
+++ b/tests/test_economy.py
@@ -1793,7 +1793,7 @@ async def _settle_player(round_state: BlackjackRound) -> BlackjackPlayerSettleme
 
 
 async def test_settle_blackjack_player_surrender_returns_half_bet() -> None:
-    """Surrender refunds half the original bet and writes the audit row."""
+    """Surrender books half the original bet as a loss and mirrors it into the casino ledger."""
     await _add_balance(user_id=1, name="alice", amount=100)
     round_state = BlackjackRound.from_participants(
         rng=SystemRandom(), participants=[_participant(bet=50)]

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -62,7 +62,7 @@ from discordbot.cogs.feedback.database import (
 
 from tests.helpers.discord_mocks import FakeUser, FakeInteraction
 
-# Never a real credential: every test that uses it answers from a scripted transport.
+# Never a real credential: nothing holding it ever reaches the network.
 _FAKE_TOKEN = "not-a-real-value"  # noqa: S105 -- a placeholder, not a secret
 
 

--- a/tests/test_fishing_catch.py
+++ b/tests/test_fishing_catch.py
@@ -386,7 +386,7 @@ def test_every_default_combo_returns_at_least_its_cost() -> None:
 
 
 def test_no_default_combo_prints_past_the_faucet_ceiling() -> None:
-    """The stated ceiling on how much fishing may mint per cast still holds."""
+    """No combo's expected return exceeds the ceiling as a multiple of its own cost."""
     catalog = build_default_catalog()
     for rod, bait in _default_combos(catalog=catalog):
         ratio = _return_ratio(catalog=catalog, rod=rod, bait=bait)

--- a/tests/test_game_cleanup.py
+++ b/tests/test_game_cleanup.py
@@ -269,7 +269,7 @@ async def test_delete_tracked_public_messages_deletes_stale_restart_records() ->
 
 
 async def test_delete_tracked_public_messages_skips_non_messageable_cached_channel() -> None:
-    """Cached PartialMessageable-like channels should be resolved via fetch_channel first."""
+    """A cached channel that is not Messageable is re-resolved through fetch_channel."""
     message = _DeletableMessageStub(message_id=10, channel_id=20)
     await track_public_message(message=as_message(fake=message))
     bot = _BotStub(cached_channel=_NonMessageableChannelStub())

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -1,4 +1,4 @@
-"""Tests for AI reply routing, attachment handling, streaming, and regeneration."""
+"""Tests for AI reply routing, attachment handling, streaming, and memory injection."""
 
 from __future__ import annotations
 
@@ -1004,7 +1004,7 @@ def _default_turn_events() -> list[SimpleNamespace]:
 
 
 async def _ready_reply_context() -> ReplyContext:
-    """An empty reply context for directly exercising `_handle_image_reply`."""
+    """An empty reply context for directly exercising the IMAGE and VIDEO handlers."""
     return ReplyContext()
 
 
@@ -1382,7 +1382,7 @@ async def test_voice_too_big_without_hosting_drops_with_hint(economy_isolated_db
 
 
 def _hosting_service(*, serve_dir: Path) -> MediaHostingService:
-    """Builds a real media-hosting service writing into a temp serve dir for streamer tests."""
+    """Builds a real media-hosting service writing into a temp serve dir for the media routes."""
     return MediaHostingService(
         config=make_media_hosting_config(
             enabled=True, base_url="https://media.test", serve_dir=str(serve_dir)
@@ -3671,7 +3671,8 @@ async def test_gen_reply_routes_and_handlers_without_api(monkeypatch: pytest.Mon
         context_task=asyncio.create_task(_ready_reply_context()),
     )
     assert len(message.replies) == 1
-    # Text-to-video: the (director-expanded) request reaches omni as the interaction input text.
+    # Text-to-video: the fake director returns no draft, so `refine` falls back to the raw
+    # request, which reaches omni as the interaction input text.
     create_input = _recorded_video(cog).create_inputs[0]
     assert [part["text"] for part in create_input if part["type"] == "text"] == ["video"]
 
@@ -3681,7 +3682,7 @@ async def test_gen_reply_routes_and_handlers_without_api(monkeypatch: pytest.Mon
         context_task=asyncio.create_task(_ready_reply_context()),
     )
     assert _recorded(cog).images.generate_calls
-    # No director: the raw request reaches images.generate directly.
+    # The director returns no draft here either, so images.generate gets the raw request.
     assert _recorded(cog).images.generate_prompts == ["image"]
     # The image is delivered first, then a conversational reply streams onto that same
     # message via the flash media_reply_model with no tools.

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -42,7 +42,7 @@ def _answer_request(
     server_memory: str | None = None,
     callable_ids: dict[int, str] | None = None,
 ) -> ResponseInputParam:
-    """Builds a recorded answer input mirroring what the pipeline assembles."""
+    """Assembles a request from whichever blocks a case needs, in this helper's own order."""
     request: ResponseInputParam = []
     if callable_ids is not None:
         request.append(

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -350,7 +350,7 @@ def test_append_raw_entry_creates_timestamped_entries(memory_isolated_dir: Path)
 
 def test_append_raw_entry_headers_omit_identity(memory_isolated_dir: Path) -> None:
     # Raw entries flow verbatim into the detail file, so author identity stays
-    # confined to the main file and headers carry only the timestamp.
+    # confined to the fact files and the header carries only the timestamp.
     append_raw_entry(scope=USER_SCOPE, entry_text="偏好訊號:\n- 喜歡簡短")
     on_disk = (memory_isolated_dir / str(USER_ID) / "raw.md").read_text(encoding="utf-8")
     header = on_disk.splitlines()[0]
@@ -553,7 +553,7 @@ async def test_extract_filters_weak_observations() -> None:
 
 async def test_extract_accepts_permanent_and_rejects_volatile_durability() -> None:
     # The freshness tiers hinge on the durability gate: an immutable identity fact
-    # tagged `permanent` must pass (it routes to the never-aged 永久事實 section),
+    # tagged `permanent` must pass (the sweep never ages a `permanent` fact out),
     # while a `volatile` observation on a stable category is still dropped.
     extractor, fake_client = _extractor()
     fake_client.responses.output_parsed = RawMemoryDraft(
@@ -2001,7 +2001,7 @@ async def test_schedule_memory_regeneration_dedupes_in_flight(
     )
 
     assert first is True
-    # A rebuild already in flight must not double-schedule the whole-file rewrite.
+    # A rebuild already in flight must not double-schedule the whole-scope rebuild.
     assert second is False
     release.set()
     task = pipeline._regeneration_tasks.get(key=USER_SCOPE)
@@ -3125,8 +3125,9 @@ def test_filter_duplicate_observations_is_source_aware() -> None:
         source="guild 111",
     )
     assert same_source == ()
-    # The same key re-stated from another guild re-enters raw so consolidation
-    # can widen the bullet's source tag; key-only dedupe would lock it forever.
+    # The same key re-stated from another guild re-enters raw so consolidation can file
+    # it in that guild's compartment too; key-only dedupe would lock it to the first
+    # source that ever observed it.
     other_source = filter_duplicate_observations(
         observations=(_observation(summary="重述", normalized_key="preference.reply.short"),),
         existing_text=existing,
@@ -4131,7 +4132,7 @@ async def test_memory_clear_second_click_does_not_overwrite_the_outcome(
 async def test_memory_clear_failure_keeps_memory_and_says_so(
     memory_isolated_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A reply.db failure must not half-clear: the row deletion runs before any unlink."""
+    """A reply.db failure must not half-clear: the tombstone write runs before any unlink."""
     _populate_every_tier()
 
     async def exploding_clear_job(*, scope: str, flavor: str, token: int) -> bool:
@@ -4161,7 +4162,8 @@ async def test_memory_clear_reports_a_file_failure_without_claiming_success(
     """The file half walks the tiers one at a time, so it can stop part way.
 
     The message must not claim the memory survived intact (the reply.db row is
-    already gone by then) nor that the clear succeeded; a retry finishes it.
+    already a scrubbed tombstone by then) nor that the clear succeeded; a retry
+    finishes it.
     """
     _populate_every_tier()
     await memory_db.upsert_pending(

--- a/tests/test_memory_facts.py
+++ b/tests/test_memory_facts.py
@@ -791,7 +791,7 @@ def test_existing_facts_render_with_the_ids_the_model_must_echo(memory_isolated_
 
 
 def test_sections_are_flavor_scoped() -> None:
-    """A user scope has no member-alias table and a server scope has no permanent tier."""
+    """A user scope has no member-alias table and a server scope has no preference section."""
     assert "member_alias" in sections_for_flavor(flavor="server")
     assert "member_alias" not in sections_for_flavor(flavor="user")
     assert "preference" in sections_for_flavor(flavor="user")

--- a/tests/test_memory_git.py
+++ b/tests/test_memory_git.py
@@ -44,7 +44,7 @@ async def _wait_for(check: Callable[[], bool]) -> None:
     """Waits for the single worker to produce an observable outcome.
 
     Polls the outcome rather than the queue: the queue empties when the worker picks a
-    request up, not when it has finished the two subprocesses that request runs.
+    request up, not when it has finished the git commands that request runs.
     """
     for _ in range(200):
         if check():

--- a/tests/test_model_pricing.py
+++ b/tests/test_model_pricing.py
@@ -216,7 +216,7 @@ def test_each_mirror_write_uses_its_own_temp_file(
 def test_a_mirror_write_failure_never_costs_the_fetched_table(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """A serve directory that cannot be written loses the mirror, never the loaded table."""
+    """A directory the mirror cannot be written into loses the mirror, never the loaded table."""
     blocker = tmp_path / "blocker"
     blocker.write_text("a file where the mirror wants a directory", encoding="utf-8")
     monkeypatch.setattr(

--- a/tests/test_package_layering.py
+++ b/tests/test_package_layering.py
@@ -113,7 +113,7 @@ def test_a_lower_layer_never_imports_a_higher_one(layer: str, forbidden: tuple[s
 def test_the_layering_scan_reads_relative_and_type_checking_imports() -> None:
     """The scan is only worth its assertions if it sees the forms the tree actually uses.
 
-    `cogs/maplestory/cog.py` is the one place using relative imports, and
+    `cogs/maplestory/` is the one cog using relative imports, and
     `cogs/games/blackjack_views.py` imports a cog module under `TYPE_CHECKING`. A scan that
     silently skipped either would pass the tests above while seeing nothing.
     """

--- a/tests/test_parse_bilibili.py
+++ b/tests/test_parse_bilibili.py
@@ -485,9 +485,9 @@ async def test_the_fetch_bound_is_released_before_the_upload(
     """A slow upload must not keep another link waiting on the Bilibili bound.
 
     The bound exists for the host's disk and bandwidth; the upload talks to Google, so holding
-    it across the upload would throttle unrelated links for no protective reason. Capacity 1
-    makes "still held" mean "the other link cannot start", which is exactly the property under
-    test.
+    it across the upload would throttle unrelated links for no protective reason. Capacity 1 is
+    set so a bound still held would show, but the second link here takes no media and so never
+    reaches the bound: what this actually pins is that a stalled upload blocks nothing behind it.
     """
     monkeypatch.setattr(bilibili_builder, "BILIBILI_FETCH_CONCURRENCY", 1)
     _stub_bilibili(monkeypatch)

--- a/tests/test_parse_douyin.py
+++ b/tests/test_parse_douyin.py
@@ -168,7 +168,8 @@ async def test_the_clip_is_uploaded_and_referenced_by_files_uri(
     assert isinstance(source, Path)
     assert mime_type == "video/mp4"
     assert filename.endswith(".mp4")
-    # Only the provider's own ceiling is applied; a full-resolution clip is the point.
+    # A fail-fast Content-Length guard, not a quality lever: the resolution is chosen separately
+    # by `quality=AI_INGEST_QUALITY`, deliberately below what the human-facing expansion posts.
     assert recorded["max_bytes"] == douyin_builder.FILES_API_MAX_BYTES
 
 

--- a/tests/test_parse_threads.py
+++ b/tests/test_parse_threads.py
@@ -914,7 +914,7 @@ async def test_comments_the_page_carried_but_could_not_be_read_are_not_called_mi
 
 
 async def test_comment_media_is_noted_but_never_ingested(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Only the target's media is fetched, so a picture-only comment says so instead of reading blank."""
+    """A comment's media is never fetched, so a picture-only comment says so instead of reading blank."""
     _stub_parse(
         monkeypatch,
         [_post(text="target", images=["https://cdn.test/target.jpg"])],
@@ -1055,7 +1055,7 @@ async def test_one_failed_item_does_not_sink_the_others(monkeypatch: pytest.Monk
     """Media items are independent, so an expired image url still leaves the video attached.
 
     What survives is the video; what must NOT survive is the separator claiming the post's media
-    while one of three signed CDN urls expired between the page fetch and the upload.
+    while one of its signed CDN urls expired between the page fetch and the upload.
     """
     _stub_parse(
         monkeypatch, [_post(images=["https://cdn.test/a.jpg"], videos=["https://cdn.test/v.mp4"])]

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -646,7 +646,7 @@ async def test_active_thread_for_owner_excludes_terminal(research_isolated_db: N
 
 
 async def test_list_resumable_only_returns_researching(research_isolated_db: None) -> None:
-    # One session per phase, so only the researching one may come back as resumable.
+    # A researching session beside two terminal ones: only the first may come back resumable.
     seeded: tuple[tuple[int, ResearchPhase], ...] = (
         (20, "researching"),
         (21, "cancelled"),

--- a/tests/test_stock_views.py
+++ b/tests/test_stock_views.py
@@ -841,5 +841,5 @@ async def test_stock_public_view_timeout_deletes_bound_message(
 
 
 def test_stock_readme_and_capability_metadata_are_covered() -> None:
-    """Stock command metadata stays discoverable by the capability-doc and readme tests."""
+    """`/stock` keeps the English description it registers with Discord."""
     assert StockCogs.stock.description == "Open the simulated stock market."

--- a/tests/test_view_callbacks.py
+++ b/tests/test_view_callbacks.py
@@ -20,10 +20,11 @@ def _import_every_module() -> None:
 def test_the_module_walk_reaches_a_nested_subpackage() -> None:
     """`walk_packages` skips a directory with no `__init__.py`, and does so silently.
 
-    Views live inside cog directories now, some of them a level down (`games/fishing/`,
-    `gen_reply/link_sources/`). A subpackage missing its `__init__.py` still imports
-    fine by name and the cog still loads, so nothing else would notice that every
-    `View` inside it dropped out of the shadowing check below.
+    Views live inside cog directories now, some of them a level down (`games/fishing/`),
+    and a cog may nest a subpackage that holds none yet (`gen_reply/link_sources/`). A
+    subpackage missing its `__init__.py` still imports fine by name and the cog still
+    loads, so nothing else would notice that every `View` inside it dropped out of the
+    shadowing check below.
     """
     _import_every_module()
     walked = {

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -122,7 +122,7 @@ def test_to_interactions_input_maps_media_parts_by_kind() -> None:
 
 
 def test_to_interactions_input_skips_empty_and_handles_no_user_step() -> None:
-    """Empty content is dropped, and a video with no prior user step still gets one."""
+    """An answer input with no messages still yields one user step carrying just the video."""
     steps = step_dicts(
         steps=to_interactions_input(answer_input=[], youtube_url="https://youtu.be/abcdefghijk")
     )


### PR DESCRIPTION
Closes #503

Sweeps every docstring and `#` comment under `tests/` against the test it sits on, per the standard and the working constraints in #501. No assertion, fixture, import or signature moved: the diff is comments and docstrings only, and every deleted line is a sentence that was replaced.

## What the tree looked like

`tests/` started in far better shape than `src/`, exactly as #503 predicted. Two things shaped the pass:

**No keyword finds this drift.** A grep for the names this tree is known to have dropped returns **zero** hits across all 67 files: `main.md`, `mypy`, `generate_content`, `ResultEscalationView`, `mock_testing_*`. Widening it to names that do still appear (`/help`, `[src:...]`, `collaborative_planning`, `deep-research-preview`) finds six mentions and **all six are correct** — five are accurate past-tense prose about something having been removed, one is deliberate legacy fixture data. So a keyword pass over this tree returns a clean bill of health, and every correction below came from reading the assertions first and the prose second.

**The clearest stale claim was an inline comment, not a docstring.** `test_append_raw_entry_headers_omit_identity` read `identity stays confined to the main file` over a body asserting `IDENTITY not in on_disk` — false twice over, and `main.md` has not existed since #408.

## Ruled explicitly, so fifteen slices did not each rule it differently

An **existing** docstring that merely restates its own function name **stays**. There are ~77 of them, plus 57 opening with filler (`Verifies` / `Ensures` / `Checks`). They are not wrong, so they mislead nobody, and removing ~130 harmless lines would have buried the real corrections under a diff nobody could review. #503 forbids *adding* one; it does not license removing one.

Nothing was added: **0 docstrings added** across the whole sweep. An AST count over both refs confirms it exactly — 1,564 test functions, 166 without a docstring at `main` and 166 at `HEAD`, with the all-function totals identical too. Nothing was added *or* deleted anywhere; every change is a rewrite in place.

## The corrections

48 rewrites across 28 files. Grouped by what was wrong rather than listed one by one, because the group is the part worth reading:

**Named a design the tree dropped** — `main.md` and the per-bullet `[src:...]` tag (#408) in four places in `test_memory.py`; `clear_job` deleting a row when it writes a scrubbed tombstone; "the bot's house ledger" in `test_economy.py`, when casino P&L lives in `casino_ledger` and neither leaderboard caller excludes the bot at all; `max_size` in `test_cogs_smoke.py`, a variable #325 deleted; "either checker's method-assign rule" in `test_douyin.py`, from before #356 removed mypy; "the dealer embed" twice in `test_dragon_gate.py`, which #303 deleted; "the capability-doc and readme tests" in `test_stock_views.py`, when no readme test exists; "writes the audit row" in `test_economy.py`, when there is no audit table anywhere in the system.

**Contradicted the assertion directly below it** — `test_gen_reply.py` carried two comments ten lines apart saying the VIDEO route's director *had* run and the IMAGE route's had *not*; both kill-switches default `True`, so both run, and the fake director returning `None` is why both see the raw request. Elsewhere: "landing the dealer above 17" over a hand that is exactly 17; "surface the base and boosted deltas" when `settlement_metadata` uses `base_delta` only as a gate; "locks the first-action-only buttons" over a body asserting they are removed *and* that nothing is disabled; "gives up its tenth image" over `== 8`; "one of three signed CDN urls" on a two-item fixture; "a server scope has no permanent tier" over a body asserting `preference`; "Empty content is dropped" over an input with no messages at all; "one session per phase" over three of four phases.

**Named the wrong mechanism** — "a full-resolution clip is the point" when the AI path ingests at `AI_INGEST_QUALITY = "low"`; "only the target's media is fetched" when `_media_plan` also ingests the quoted post (#399); the bot's zero balance keeping it out of a lobby that reads `get_account`; "surprising under freezegun", a library absent from this repository; `link_sources/` named as a home for views when it holds none; "the one place using relative imports" when it is the one *cog*, across four files; "a serve directory" in `test_model_pricing.py`, which is media-hosting vocabulary for a module that serves nothing; "every cog setup function" over a list of 7 of 16; "PartialMessageable-like" for a path `PartialMessageable` cannot take, since it *is* `Messageable`; "the two subprocesses" when the guard makes it three.

**Claimed a property the test does not pin** — `test_parse_bilibili.py`'s bound-release test says capacity 1 makes a held bound observable, but its second link takes no media and never reaches the bound; `test_helpers.py`'s request builder claimed to mirror the pipeline while ordering the blocks differently and including one the pipeline's selection input never carries. Both docstrings now say what the test actually pins. The assertions are untouched, and the coverage gaps behind them are follow-ups.

**Described one part of a shared contract** — `conftest.py`'s module docstring covered one of nine fixtures and none of the four autouse ones; `helpers/llm_input.py` said the anchors track `memory_tool.py` when they also track all three `link_sources` separators, so a reader editing one would have concluded it was untracked.

Two things this deliberately does **not** fix, since #503 moves no code: `test_stock_readme_and_capability_metadata_are_covered` and the three `..._disables_...` names in `test_blackjack_view_buttons.py` still carry the drift their docstrings just lost. Renaming a test is a code change; they are in the follow-up list.

## What was deliberately not cut

Every measurement, provider quirk and named regression stays at full length, and the protection was widened past #503's wording after a plan review found the hole: `test_threads.py::_quoted_tombstone` is a *private helper* whose docstring carries "measured across 15 of 96 live quote relations", one of the numbers `CLAUDE.md`'s Threads section argues from, and a one-line-per-private-helper rule would have destroyed it. Same for `test_prompt_guards.py`'s 8/15 · 6/15 · 0/15 A/B measurement, `test_fishing_catch.py`'s pre-#351 EV arithmetic, and the `# order-contract:` markers another guard scans for.

`git diff -U0` over the whole branch: every deleted line has a successor. Nothing was removed without one.

## Rule 2 ledger — all 67 files

Re-enumerated at pick-up and again at `HEAD`: `git ls-files tests | grep '\.py$'` gives **67 files at both refs**, matching #503's inventory exactly. No file moved while the sweep ran. Every file was read in full; none was skipped.

**Edited (28 files, 48 rewrites)**

`test_memory.py` 6 · `test_gen_reply.py` 5 · `test_blackjack_view_buttons.py` 4 · `test_cogs_smoke.py` 4 · `test_economy.py` 4 · `test_dragon_gate.py` 2 · `test_parse_threads.py` 2 · `conftest.py` 1 · `helpers/discord_mocks.py` 1 · `helpers/llm_input.py` 1 · `test_blackjack.py` 1 · `test_discord_embed_utils.py` 1 · `test_douyin.py` 1 · `test_download.py` 1 · `test_feedback.py` 1 · `test_fishing_catch.py` 1 · `test_game_cleanup.py` 1 · `test_helpers.py` 1 · `test_memory_facts.py` 1 · `test_memory_git.py` 1 · `test_model_pricing.py` 1 · `test_package_layering.py` 1 · `test_parse_bilibili.py` 1 · `test_parse_douyin.py` 1 · `test_research.py` 1 · `test_stock_views.py` 1 · `test_view_callbacks.py` 1 · `test_youtube.py` 1

**Read, no change needed (39 files)**

`__init__.py` (empty) · `helpers/__init__.py` · `helpers/casting.py` · `helpers/economy_invariants.py` · `helpers/embeds.py` · `test_amount_parsing.py` · `test_async_order_contracts.py` · `test_avatar_utils.py` · `test_bilibili.py` · `test_blackjack_ev.py` · `test_blackjack_history.py` · `test_bot_player.py` · `test_capabilities.py` · `test_economy_boards.py` · `test_files_api.py` · `test_finance.py` · `test_fishing_db.py` · `test_fishing_views.py` · `test_images.py` · `test_llm.py` · `test_loan.py` · `test_log_msg.py` · `test_maplestory.py` · `test_media_cleanup.py` · `test_media_delivery.py` · `test_mentions.py` · `test_model_media_parts.py` · `test_modify_balance.py` · `test_number_text.py` · `test_parse_douyin_cog.py` · `test_prompt_guards.py` · `test_regen_memories.py` · `test_runtime_models.py` · `test_seed_fishing.py` · `test_server_memory.py` · `test_shoe.py` · `test_stock.py` · `test_threads.py` · `test_usage_log.py`

## How it was reviewed

Fifteen workers each owned a disjoint slice, so nobody held the whole tree and no ledger count is self-evidencing. Four passes on top:

1. **Deletions.** All 53 first-round deleted lines read against the code still standing beside them. This is where the previous sweep in this parent (#506) needed a second commit; none was needed here.
2. **Rewrites.** Every rewritten sentence re-read against the test body and the `src/` symbol under test, by a reviewer told to refute rather than approve. **It found two claims the sweep itself got wrong**, both now fixed: `test_blackjack_view_buttons.py` said split aces alone removes every control, when `sync_buttons` consults `is_split_aces` for Hit and Stand only and `is_split_hand` removes the other three; and `test_douyin.py` attributed a `method-assign` rule to `ty`, which is mypy's code and does not exist in `ty`. A third, `conftest.py`, understated `memory_isolated_dir` — it swaps the `memory_job` engine and resets a dozen process-local globals, not just a directory.
3. **Files reported clean**, which never enter the diff and are therefore invisible to anyone reading it. A second reviewer swept them independently and found **nine more stale comments** the fifteen slices had missed, in `test_discord_embed_utils.py`, `test_economy.py`, `test_game_cleanup.py`, `test_youtube.py`, `test_memory_git.py`, `test_research.py`, `test_helpers.py`, `test_parse_bilibili.py` and `test_download.py`. All nine are in the diff above.
4. **PR metadata**, against the diff and the repository. It caught a wrong correction count and a missing ledger in an earlier revision of this body.

## Verification

- `uv run pytest` — **1762 passed**, identical to the pre-sweep baseline. The AST counts above prove the diff changes no collected test, so the equivalence is structural rather than coincidental.
- `uvx pre-commit run -a` — all hooks pass, no file rewritten. `D200` / `D212` are live in this repo, so shortened docstrings were checked against them.
- `git diff --name-only` — every path is under `tests/`.

⚠️ **`Run Tests` does not run on this PR.** `.github/workflows/test.yml` gates the job on the head branch name and skips every `docs/` branch, so the pytest evidence here is the local run alone. That is #486, not fixed here, and renaming the branch is not a workaround — the prefix is what `.github/labeler.yml` reads to label the PR. `Code Quality Check` does run and does exercise this diff: it runs `uvx pre-commit run -a`, so ruff and `ty` saw every changed file.

## Follow-ups, not fixed here

Per #501, defects found while reading are tracked rather than fixed in this diff. This was the closest reading the suite has had, and the ~30 it surfaced are filed:

- **#509** — tests that assert nothing which could fail while their names promise coverage. The one to look at first is a wrong constant rather than a weak assertion: `tests/test_media_delivery.py` filters temp files on `.tmp-` while `utils/media_delivery.py:100` writes `.mediahost-tmp-`, so a "no leftover temp" guard can never fail. Also carries the four test *names* this PR could not fix, since #503 moves no code and a rename is a code change.
- **#510** — dead scaffolding, unused fixtures, assertions left standing after #273 and #303 deleted what they checked, and two stale annotations.
- **#502** — the `src/` half. Commented there rather than filed separately, since that issue is exactly this sweep one tree over: six confirmed drifts, including two implementation docstrings that contradict the test prose this PR just corrected, and one that contradicts its own module twelve lines away.

---

Opened-by: Claude Opus 5
