### PR TITLE
docs(src): sweep comments and docstrings against the code they sit on

### DIFF
--- a/src/discordbot/__init__.py
+++ b/src/discordbot/__init__.py
@@ -1,3 +1,5 @@
+"""Package root: loads `.env` on import, and defines the console + file logging setup."""
+
 import re
 import sys
 from typing import TextIO, cast
@@ -79,7 +81,8 @@ def setup_logging() -> None:
         send_to_logfire=False,
         scrubbing=False,
         inspect_arguments=False,
-        # We can remove `console` if log is no longer needed to be saved in a file.
+        # `output` is what tees the console to a file; the rest of this block carries
+        # the console format and the `LOG_LEVEL` floor, so dropping it loses those too.
         console=logfire.ConsoleOptions(
             colors="auto",
             span_style="show-parents",

--- a/src/discordbot/cli.py
+++ b/src/discordbot/cli.py
@@ -172,7 +172,10 @@ class DiscordBot(commands.Bot):
             logfire.error("model price table refresh failed; retrying next pass", _exc_info=exc)
 
     async def on_message(self, message: Message) -> None:
-        """Handles incoming messages.
+        """Awards the cooldown-gated message reward, then dispatches commands.
+
+        This and `/checkin` are the only two faucets that pay an action reward; it is
+        best-effort, so command dispatch runs whether or not the credit lands.
 
         Args:
             message: The message that was sent.

--- a/src/discordbot/cogs/auto_unmute/cog.py
+++ b/src/discordbot/cogs/auto_unmute/cog.py
@@ -24,12 +24,13 @@ class AutoUnmuteCogs(commands.Cog):
 
     Per-guild we remember the channel ID where a human last spoke; that's
     where the AI's post-timeout reply lands. We do not track a per-moderator
-    "current channel", Discord's audit log entry for a timeout does not carry
-    a channel, and using `last_active_channel` keeps the dict O(guilds).
+    "current channel", because Discord's audit log entry for a timeout does not
+    carry a channel, and using `last_active_channel` keeps the dict O(guilds).
 
     Attributes:
         bot: The Discord bot instance that owns this cog.
         config: The LLM client configuration loaded for reply generation.
+        runtime_models: Catalog the reply's model tier is read from.
     """
 
     def __init__(self, bot: commands.Bot) -> None:

--- a/src/discordbot/cogs/auto_unmute/prompts.py
+++ b/src/discordbot/cogs/auto_unmute/prompts.py
@@ -1,3 +1,8 @@
+"""The instructions behind the post-timeout auto-unmute reply.
+
+Model input rather than documentation, so a wording change is a behavior change.
+"""
+
 UNMUTE_PROMPT = """
 You are a Discord bot that just got timed out by a server moderator. You have already
 released yourself from the timeout via the API; now write a single short Discord message

--- a/src/discordbot/cogs/economy/boards.py
+++ b/src/discordbot/cogs/economy/boards.py
@@ -61,7 +61,11 @@ class _RankingBoardSpec(BaseModel):
         ..., description="Label prefixed to each amount cell, empty for none."
     )
     accent: tuple[int, int, int] = Field(
-        ..., description="Accent RGB color for headers and medals."
+        ...,
+        description=(
+            "Accent RGB color for the PUBLIC badge, the amount column header, "
+            "and the top-three rank numbers."
+        ),
     )
     rows: tuple[tuple[str, int], ...] = Field(
         ..., description="Ranked (name, amount) rows to render."

--- a/src/discordbot/cogs/economy/cog.py
+++ b/src/discordbot/cogs/economy/cog.py
@@ -1,4 +1,4 @@
-"""Slash commands that surface point balances, leaderboards, transfers, and loans."""
+"""Slash commands for balances, leaderboards, transfers, loans, check-in, VIP, and admin tax."""
 
 from io import BytesIO
 from datetime import UTC, datetime
@@ -81,10 +81,13 @@ def _parse_collect_amount(raw_amount: str | None) -> tuple[bool, int | None]:
 
 
 class EconomyCogs(commands.Cog):
-    """Player-facing point balance, leaderboards, loans, VIP, and check-in commands.
+    """Point balance, leaderboard, loan, VIP, check-in, and economy-admin commands.
 
     Attributes:
         bot: The Discord bot instance that owns this cog.
+        economy_config: Environment-backed economy settings; only
+            `allow_central_bank_self_approval` is read, and only by
+            `/central_bank borrow`.
     """
 
     def __init__(self, bot: commands.Bot) -> None:
@@ -848,7 +851,7 @@ class EconomyCogs(commands.Cog):
         },
     )
     async def credit_status(self, interaction: Interaction[commands.Bot]) -> None:
-        """Shows the caller's active personal credit contracts."""
+        """Shows the active personal credit contracts the caller borrowed or lent on."""
         await interaction.response.defer(ephemeral=True)
         if interaction.user is None:
             return

--- a/src/discordbot/cogs/economy/embeds.py
+++ b/src/discordbot/cogs/economy/embeds.py
@@ -62,7 +62,13 @@ class TransferParticipant(BaseModel):
     mention: str = Field(
         ..., description="Discord mention string (<@user_id>) shown in the embed."
     )
-    display_name: str = Field(..., description="Display name shown next to the mention.")
+    display_name: str = Field(
+        ...,
+        description=(
+            "Display name shown in the post-transfer balances, and in the author line for "
+            "the sender only."
+        ),
+    )
 
 
 class LoanParty(BaseModel):
@@ -73,8 +79,13 @@ class LoanParty(BaseModel):
     mention: str = Field(
         ..., description="Discord mention string (<@user_id>) shown in the embed."
     )
-    display_name: str = Field(default="", description="Display name shown next to the mention.")
-    avatar_url: str = Field(default="", description="Avatar URL for the embed thumbnail.")
+    display_name: str = Field(
+        default="", description="Display name shown as the embed author; set only on the borrower."
+    )
+    avatar_url: str = Field(
+        default="",
+        description="Avatar URL: author icon for the borrower, thumbnail for the lender.",
+    )
 
 
 def _vip_perk_lines(checkin_streak: int = 1) -> str:

--- a/src/discordbot/cogs/economy/views.py
+++ b/src/discordbot/cogs/economy/views.py
@@ -257,7 +257,11 @@ class CreditLoanDecisionView(LoanDecisionViewBase):
         await send_ephemeral_response(interaction=interaction, embed=embed)
 
     async def _require_lender(self, interaction: Interaction[commands.Bot]) -> bool:
-        """Returns whether the clicking user is the requested lender."""
+        """Returns whether the clicking user is the requested lender.
+
+        Someone other than the lender is answered with the permission notice
+        before this returns `False`, so the caller must not reply again.
+        """
         if interaction.user is None:
             return False
         if interaction.user.id == self.lender_id:

--- a/src/discordbot/cogs/feedback/auth.py
+++ b/src/discordbot/cogs/feedback/auth.py
@@ -176,8 +176,9 @@ class AppCredentials(BaseModel):
 def _parse_expiry(*, value: object) -> datetime:
     """Reads GitHub's expiry timestamp, falling back to the documented one-hour life.
 
-    A missing or odd timestamp is not worth failing over: the fallback is shorter than
-    the real life, so the worst case is minting a token slightly more often than needed.
+    A missing or odd timestamp is not worth failing over: the fallback counts the hour
+    from now rather than from when GitHub minted the token, so it lands a moment past the
+    real expiry, and `_RENEW_BEFORE` is what absorbs the difference.
     """
     if isinstance(value, str):
         try:

--- a/src/discordbot/cogs/feedback/cog.py
+++ b/src/discordbot/cogs/feedback/cog.py
@@ -78,7 +78,8 @@ from discordbot.cogs.feedback.database import (
 )
 
 # How often the sweep tries again for reports whose issue was never opened, and how many
-# it takes per pass. Small: this only ever runs after a GitHub outage.
+# it takes per pass. Small: the queue is whatever still has no issue number, which is
+# usually a GitHub refusal or a deployment without credentials yet.
 RETRY_INTERVAL_MINUTES = 10
 RETRY_BATCH_SIZE = 10
 

--- a/src/discordbot/cogs/feedback/database.py
+++ b/src/discordbot/cogs/feedback/database.py
@@ -268,9 +268,11 @@ async def store_write_up(
 ) -> None:
     """Stores the background write-up next to the original text.
 
-    Written only after the issue itself carries it, so the panel's summary line can never
-    describe a report in words the issue does not use. Kept locally as well so a later
-    pass over the store can read the drafts without calling GitHub.
+    A report that already has an issue has that issue rewritten first, so the panel's
+    summary line can never describe a report in words the issue does not use. A report
+    still waiting for credentials has no issue to rewrite, and the draft stored here is
+    what its issue is later opened from; the retry sweep reads it back to tell that case
+    apart and skip a rewrite it no longer needs.
     """
     await _ensure_schema()
     async with open_session() as session:

--- a/src/discordbot/cogs/feedback/github.py
+++ b/src/discordbot/cogs/feedback/github.py
@@ -2,7 +2,7 @@
 
 REST over `httpx`, which is already a dependency. Not the `gh` CLI (absent from the
 runtime image, and it would need its own credential setup) and not an MCP server (an
-agent-side tool, not a runtime library). Only five calls are needed, so the client is a
+agent-side tool, not a runtime library). Only six calls are needed, so the client is a
 thin object rather than a dependency.
 
 Every call raises `GitHubIssuesError` on a non-2xx answer. Nothing is degraded here: the
@@ -271,8 +271,8 @@ class GitHubIssues(BaseModel):
         Paged rather than one call: the endpoint answers 30 at a time by default, and the
         panel shows the *newest* replies, so a thread past the first page would hide the
         very answer the reporter came to read while the status still said someone had
-        replied. `_MAX_COMMENT_PAGES` bounds it — past that many the oldest are dropped,
-        which is the end nobody is looking at.
+        replied. `_MAX_COMMENT_PAGES` bounds it at the first 300 comments; the endpoint
+        orders oldest first, so past that the newest replies are the ones left unread.
 
         Raises:
             GitHubIssuesError: The comments could not be read.

--- a/src/discordbot/cogs/feedback/views.py
+++ b/src/discordbot/cogs/feedback/views.py
@@ -45,7 +45,9 @@ _MAX_EMBED_TITLE_CHARS = 240
 _MAX_QUOTED_CHARS = 900
 _MAX_SUMMARY_CHARS = 120
 
-# Nothing is dropped quietly: each cap has a line that says what is not on screen.
+# Marks the three body caps that run through `_clipped`, so a trimmed report does not read as
+# the bot having garbled it. The embed title and the select label are hard slices instead: both
+# are one line of chrome the reader can open the full text from.
 _TRUNCATED_SUFFIX = "…"
 
 REPORT_TITLE = "🎫 回報中心"

--- a/src/discordbot/cogs/games/blackjack.py
+++ b/src/discordbot/cogs/games/blackjack.py
@@ -26,11 +26,11 @@ _CARD_SUITS = ("♠", "♥", "♦", "♣")
 def draw_card(rng: Random) -> Card:
     """Draws one card from a notional infinite shoe (independent rank + suit).
 
-    Production paths build a shuffled 4-deck shoe inside `BlackjackRound` and
-    draw from there, so rank/suit frequency is finite even though duplicate
-    rank/suit labels can appear from different decks. This helper stays as the
-    round-bootstrap fallback (and the test-monkeypatch seam) for when the shoe
-    is empty.
+    Production rounds deal from a shuffled multi-deck shoe (`build_shoe`,
+    carried across rounds per channel by `BlackjackShoeStore`), so rank/suit
+    frequency is finite even though duplicate rank/suit labels can appear from
+    different decks. This helper stays as `_draw_one_card`'s empty-shoe
+    fallback, and as the seam tests monkeypatch for deterministic draws.
 
     Args:
         rng: Random source used to choose rank and suit.
@@ -279,8 +279,8 @@ class BlackjackPlayerHand(BaseModel):
         hands: All active sub-hands in display order.
         insurance_bet: Insurance side bet amount, `0` when none was taken.
         insurance_resolved: True once the player has made an insurance choice
-            (yes or no) and the surrounding round phase has progressed past
-            insurance.
+            (yes or no). It flips while the round is still in the insurance
+            phase; the phase closes only once every player is resolved.
     """
 
     participant: GameParticipant = Field(..., description="Discord player and wager metadata.")
@@ -328,8 +328,8 @@ def can_double(
 
     Returns:
         True only when no actions have been taken yet, the hand has exactly
-        two cards, the DAS rule allows it, and the player can still afford
-        the extra wager.
+        two cards, the DAS rule allows it, the doubled stake still fits
+        `MAX_SINGLE_BET`, and the player can still afford the extra wager.
     """
     if hand.finished or hand.surrendered or hand.doubled:
         return False
@@ -453,10 +453,11 @@ def _settle_regular_hand(
 def settle_hand(hand: BlackjackHandState, dealer: list[Card]) -> tuple[SettleOutcome, int]:
     """Resolves one finished sub-hand into an outcome label and net delta.
 
-    Surrender short-circuits to a half-bet refund. Five-card 21 is flagged
-    before the generic five-card win so split hands can still earn the
-    five-card bonus. Split-derived two-card 21 is handled before natural
-    Blackjack so it never receives the natural Blackjack payout.
+    Surrender short-circuits to a half-bet refund. `is_five_card_win` also
+    matches a five-card 21, so the 21 is tested first or the hand would settle
+    as a plain five-card win and lose the bonus that label carries.
+    Split-derived two-card 21 is handled before natural Blackjack so it never
+    receives the natural Blackjack payout.
 
     Args:
         hand: Finished sub-hand to settle.
@@ -464,7 +465,12 @@ def settle_hand(hand: BlackjackHandState, dealer: list[Card]) -> tuple[SettleOut
 
     Returns:
         `(outcome, delta)` where delta is the signed point change for
-        this single hand.
+        this single hand. A five-card 21 pushes its main leg against a dealer
+        21; the system-funded bonus for that label is added by the settlement
+        layer, not here.
+
+    Raises:
+        ValueError: The hand has not finished yet.
     """
     if not hand.finished:
         raise ValueError("Cannot settle an unfinished Blackjack hand")
@@ -493,6 +499,7 @@ class BlackjackRound(BaseModel):
         rng: Random source used for card draws.
         players: Per-player containers (each holds one or more sub-hands).
         dealer: Dealer cards shared by the table.
+        shoe: Remaining cards in the FIFO multi-deck shoe.
         current_player_index: Index of the player whose turn is active.
         current_hand_index: Index of the active sub-hand within that player.
         dealer_played: True once the dealer has drawn for all standing
@@ -631,6 +638,12 @@ class BlackjackRound(BaseModel):
         Args:
             user_id: Discord user ID placing the insurance.
             amount: Side-bet amount; must equal `participant.bet // 2`.
+
+        Raises:
+            ValueError: The round is not in the insurance phase, the user is
+                not seated at this table, insurance was already decided, half
+                the original bet rounds to zero, the amount is not half the
+                original bet, or the remaining balance cannot cover it.
         """
         if self.phase != "insurance":
             raise ValueError("Insurance is not currently offered")
@@ -654,6 +667,10 @@ class BlackjackRound(BaseModel):
 
         Args:
             user_id: Discord user ID declining the insurance offer.
+
+        Raises:
+            ValueError: The round is not in the insurance phase, the user is
+                not seated at this table, or insurance was already decided.
         """
         if self.phase != "insurance":
             raise ValueError("Insurance is not currently offered")
@@ -677,7 +694,11 @@ class BlackjackRound(BaseModel):
         self._maybe_close_insurance_phase()
 
     def active_player(self) -> BlackjackPlayerHand | None:
-        """Returns the player whose turn is active, if any."""
+        """Returns the player whose turn is active, if any.
+
+        Advances the table past players who have finished, so this is not a
+        pure read: it can move the turn cursor and settle the round.
+        """
         if self.finished or self.phase != "player_actions":
             return None
         if self.current_player_index >= len(self.players):
@@ -689,7 +710,11 @@ class BlackjackRound(BaseModel):
         return player
 
     def active_hand(self) -> BlackjackHandState | None:
-        """Returns the active sub-hand of the active player, if any."""
+        """Returns the active sub-hand of the active player, if any.
+
+        Advances past finished sub-hands, with the same non-pure-read caveat as
+        `active_player`.
+        """
         player = self.active_player()
         if player is None:
             return None
@@ -712,7 +737,8 @@ class BlackjackRound(BaseModel):
             The drawn card.
 
         Raises:
-            ValueError: The user is not the active player.
+            ValueError: The round is not in the player-action phase, the user
+                is not the active player, or the hand came out of split Aces.
         """
         _, hand = self._require_active(user_id=user_id)
         if hand.is_split_aces:
@@ -726,7 +752,12 @@ class BlackjackRound(BaseModel):
         return card
 
     def stand(self, user_id: int) -> None:
-        """Marks the active sub-hand as standing and advances the table."""
+        """Marks the active sub-hand as standing and advances the table.
+
+        Raises:
+            ValueError: The round is not in the player-action phase or the
+                user is not the active player.
+        """
         _, hand = self._require_active(user_id=user_id)
         hand.finished = True
         self._advance_or_finish()
@@ -739,6 +770,10 @@ class BlackjackRound(BaseModel):
 
         Returns:
             The single card drawn after the bet was doubled.
+
+        Raises:
+            ValueError: The round is not in the player-action phase, the user
+                is not the active player, or `can_double` rejects the hand.
         """
         player, hand = self._require_active(user_id=user_id)
         balance_remaining = player.participant.balance_at_start - committed_wagers(player=player)
@@ -762,6 +797,10 @@ class BlackjackRound(BaseModel):
 
         Args:
             user_id: Discord user ID that must match the active player.
+
+        Raises:
+            ValueError: The round is not in the player-action phase, the user
+                is not the active player, or `can_split` rejects the hand.
         """
         player, hand = self._require_active(user_id=user_id)
         balance_remaining = player.participant.balance_at_start - committed_wagers(player=player)
@@ -787,7 +826,12 @@ class BlackjackRound(BaseModel):
         self._advance_or_finish()
 
     def surrender(self, user_id: int) -> None:
-        """Surrenders the active hand for a half-bet refund."""
+        """Surrenders the active hand for a half-bet refund.
+
+        Raises:
+            ValueError: The round is not in the player-action phase, the user
+                is not the active player, or `can_surrender` rejects the hand.
+        """
         _, hand = self._require_active(user_id=user_id)
         if not can_surrender(hand=hand, peeked_blackjack=self.peeked_blackjack):
             raise ValueError("Cannot surrender this hand")
@@ -797,7 +841,11 @@ class BlackjackRound(BaseModel):
         self._advance_or_finish()
 
     def stand_all_remaining(self) -> None:
-        """Marks every unresolved hand as standing, then finishes the table."""
+        """Declines undecided insurance, stands every unresolved hand, finishes.
+
+        The forced-finish entry point for view timeouts and settlement, so it
+        must leave the round settled from any phase.
+        """
         if self.phase == "insurance":
             self.decline_insurance_for_all_unresolved()
         for player in self.players:
@@ -810,7 +858,7 @@ class BlackjackRound(BaseModel):
         return hand_value(cards=self.dealer)
 
     def dealer_visible_value(self) -> int:
-        """Returns the visible dealer card value for hint prompts."""
+        """Returns the Blackjack value of the dealer's visible up-card."""
         return dealer_visible_value(dealer=self.dealer)
 
     def dealer_is_soft_17(self) -> bool:
@@ -828,7 +876,7 @@ class BlackjackRound(BaseModel):
         return card
 
     def mark_dealer_played(self) -> None:
-        """Marks the dealer phase complete."""
+        """Closes the dealer phase and settles the round."""
         self.dealer_played = True
         self.finished = True
         self.phase = "settled"

--- a/src/discordbot/cogs/games/blackjack_ev.py
+++ b/src/discordbot/cogs/games/blackjack_ev.py
@@ -1,18 +1,25 @@
 """Blackjack expected-value engine for the bot player.
 
-An LLM reasons poorly about multi-step no-replacement probability, so this pure
-module turns the table state into decision-grade numbers: the dealer's H17
-final-total distribution and the expected value of every legal action, measured
-in multiples of the base hand bet.
+The bot plays off exact multi-step no-replacement probability rather than a
+heuristic strategy table, so this pure module turns the table state into
+decision-grade numbers: the dealer's H17 final-total distribution and the
+expected value of every legal action, measured in multiples of the base hand
+bet. `bot_player.py` falls back to its up-card-only table only when a call
+here fails.
 
-The engine runs two passes. The exact pass knows the dealer hole card and drives
-the recommended action only; it is the bot's private informational edge and is
-never surfaced verbatim. The marginal pass integrates a hypothetical hole out
-over the remaining shoe (the real hole is never added back, so every exposed
-number depends only on the up-card and the shoe) and, when the dealer has
-already peeked under an Ace/ten up-card, conditions on "no dealer Blackjack".
-Only the marginal dealer distribution and marginal per-action EVs are exposed,
-so nothing handed to the model can reveal or reconstruct the actual hole card.
+The engine runs two passes. The exact pass knows the dealer hole card and
+drives `recommended_action` only; its own EVs never leave this module, so the
+hole stays the bot's private informational edge. The marginal pass integrates a
+hypothetical hole out over the remaining shoe (the real hole is never added
+back, so every reported number depends only on the up-card and the shoe) and,
+when the dealer has already peeked under an Ace/ten up-card, conditions on "no
+dealer Blackjack". Every NUMBER on the returned `ActionEvAnalysis` comes from
+that marginal pass, so none of them can reveal or reconstruct the real hole;
+`recommended_action` is the single exception, an action rather than a value,
+which is why `compute_action_evs` looks its reported EV back up in the marginal
+table instead of carrying the exact one across. Nothing renders those numbers
+today — the bot reads only `basic_strategy_action` — so the split is upkeep for
+the turn they do reach the table, and it has to be kept until then.
 
 Everything here is deterministic and order-independent: the shoe is collapsed
 to a 10-bucket value-count multiset (`2..9`, ten-value, ace), so results depend
@@ -183,8 +190,10 @@ def _dealer_distribution(
     shoe_total = sum(shoe)
     if shoe_total == 0:
         # Defensive guard for a degraded/empty shoe (callers may pass one): the
-        # dealer cannot draw, so treat the sub-17 total as terminal and never
-        # divide by zero.
+        # dealer cannot draw, so the sub-17 total stands. The tuple has no slot
+        # below 17, so that stand is reported in the 17 bucket. Without the
+        # guard the loop below would skip every bucket and return an unnormalised
+        # all-zero distribution rather than raise.
         return (1.0, 0.0, 0.0, 0.0, 0.0, 0.0)
     accumulator = [0.0] * 6
     for bucket, count in enumerate(shoe):
@@ -537,15 +546,15 @@ def compute_action_evs(  # noqa: PLR0913 -- one EV-engine entry point mirroring 
     EV is expressed in multiples of the base hand bet. Two passes run over H17
     rules and this table's five-card payouts:
 
-    - The exact pass knows the hole card and selects `recommended_action`; this
-      is the bot's private edge and is never surfaced directly.
-    - The marginal pass integrates the hole out over the unseen deck (remaining
-      shoe plus the hole as one anonymous unknown) and supplies the
-      `dealer_outcome` distribution and every `action_evs` value. These hole-free
-      numbers are all that the model ever sees, so they cannot reveal the hole.
+    - The exact pass knows the hole card and selects `recommended_action`; its
+      EVs are dropped, so the bot's private edge never leaves this function.
+    - The marginal pass integrates a hypothetical hole out over the remaining
+      shoe (the real hole is never added back) and supplies the
+      `dealer_outcome` distribution and every `action_evs` value. Those numbers
+      depend only on the up-card and the shoe, so they cannot reveal the hole.
 
     `recommended_expected_value` is reported as the recommended action's marginal
-    EV to stay consistent with the exposed numbers.
+    EV to stay consistent with the other reported numbers.
 
     Args:
         hand_cards: The bot's active sub-hand cards.

--- a/src/discordbot/cogs/games/blackjack_views.py
+++ b/src/discordbot/cogs/games/blackjack_views.py
@@ -277,10 +277,11 @@ def build_dealer_seat_embed(  # noqa: PLR0913 -- dealer seat needs round + ident
 ) -> Embed:
     """Builds the dealer seat embed shown alongside player seats.
 
-    Pass `hide_hole=False` during the dealer phase or peek-reveal animations so
-    the hole card is visible; `dealer_steps` populates the rule-driven action
-    log once dealer play starts. When `is_settled=True`, `results` drives the
-    color from the casino-vs-table outcome rather than the dealer hand total.
+    Only the peek-reveal frame passes `hide_hole=False` before settlement, which is
+    what makes the hole visible there; `dealer_steps` populates the rule-driven
+    action log once dealer play starts. When `is_settled=True`, `results` drives the
+    color from the casino-vs-table outcome; otherwise the color tracks the
+    round phase.
     """
     description_parts: list[str] = [
         _format_dealer_block(round_state=round_state, hide_hole=hide_hole)
@@ -289,7 +290,7 @@ def build_dealer_seat_embed(  # noqa: PLR0913 -- dealer seat needs round + ident
     if decision_path:
         description_parts.append(metadata_line(text=f"動作: {decision_path}"))
     if not is_settled and not hide_hole:
-        # We are still showing the table while the dealer plays.
+        # Hole card face-up on a round that has not settled: the peek-reveal frame.
         description_parts.append(metadata_line(text="莊家正在依規則出牌"))
     elif not is_settled:
         description_parts.append(metadata_line(text="莊家暗牌待揭示"))
@@ -1466,7 +1467,7 @@ class BlackjackView(View):
             )
 
     def _track_background_task(self, coroutine: Coroutine[Any, Any, None]) -> None:
-        """Tracks a background UI refresh task until it finishes."""
+        """Holds a strong reference to an off-critical-path task until it finishes."""
         task = asyncio.create_task(coro=coroutine)
         self._background_tasks.add(task)
 
@@ -1476,7 +1477,10 @@ class BlackjackView(View):
         task.add_done_callback(_discard_task)
 
     async def wait_for_background_tasks(self) -> None:
-        """Waits for currently scheduled background UI refreshes."""
+        """Waits for the round's off-critical-path tasks (round-history persistence).
+
+        Only tests await this; the round itself never blocks on them.
+        """
         while self._background_tasks:
             await asyncio.gather(*tuple(self._background_tasks))
 

--- a/src/discordbot/cogs/games/bot_player.py
+++ b/src/discordbot/cogs/games/bot_player.py
@@ -91,11 +91,11 @@ class ShoeSummary(BaseModel):
 
 
 class DealerKnowledge(BaseModel):
-    """Dealer state exposed to the bot player AI.
+    """Dealer state exposed to the bot player.
 
     Only the up-card is shared, exactly what any seated player sees. The hole
     card, the combined two-card total, and the natural-Blackjack flag are
-    deliberately withheld so nothing the model receives can reveal the hole.
+    deliberately withheld so nothing carried here can reveal the hole.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -330,7 +330,7 @@ def build_shoe_summary(*, shoe: list[Card]) -> ShoeSummary:
 
 
 def build_dealer_knowledge(*, dealer_up: Card | None) -> DealerKnowledge:
-    """Builds the up-card-only dealer state exposed to the bot player AI."""
+    """Builds the up-card-only dealer state exposed to the bot player."""
     return DealerKnowledge(
         up_card=str(dealer_up) if dealer_up is not None else "unknown",
         up_value=_dealer_up_value(up_card=dealer_up),
@@ -418,7 +418,7 @@ def kelly_bet(  # noqa: PLR0913 -- exposes the Kelly tuning knobs (fraction, cap
 
     Returns:
         A positive integer wager within `[1, max_fraction * balance]`, never above
-        `balance`.
+        `balance`. A non-positive balance returns 1, the one case above `balance`.
     """
     if balance <= 0:
         return 1
@@ -560,7 +560,7 @@ def build_bot_action_context(  # noqa: PLR0913 -- context builder mirrors the fu
     balance_remaining: int,
     doubled: bool = False,
 ) -> BotPlayerActionContext:
-    """Builds computed AI context without exposing the future shoe order."""
+    """Builds the bot's computed decision context without exposing the future shoe order."""
     hand_total, _is_soft = _hand_total_and_soft(cards=hand_cards)
     ev_analysis = _safe_compute_action_evs(
         hand_cards=hand_cards,
@@ -641,9 +641,10 @@ def choose_bot_action(  # noqa: PLR0913 -- deterministic action picker mirrors t
 ) -> BotAction:
     """Returns the deterministic action the bot plays this turn.
 
-    The action is the EV engine's hole-aware recommendation carried on the
-    action context (always one of `allowed_actions`); it degrades to the
-    up-card-only basic-strategy fallback only when the context is missing.
+    The choice is whatever the action context already resolved (always one of
+    `allowed_actions`): the EV engine's hole-aware recommendation, or the
+    basic-strategy fallback the builder substituted when the engine failed.
+    This function only recomputes that fallback when the context is missing.
     """
     if action_context is not None:
         return action_context.action_analysis.basic_strategy_action
@@ -661,8 +662,8 @@ def build_bot_insurance_context(
 ) -> BotPlayerInsuranceContext:
     """Builds insurance context from the remaining-shoe ten density only.
 
-    The dealer hole card is never passed in, so it cannot reach the decision or
-    the prompt. Insurance pays only on a ten-value hole, so the remaining shoe's
+    The dealer hole card is never passed in, so it cannot reach the decision.
+    Insurance pays only on a ten-value hole, so the remaining shoe's
     ten-value fraction is the fair probability a counter would use. Insurance is
     +EV only when that fraction clears 1/3; the probability matches the exposed
     shoe counts exactly, leaving nothing to cross-solve.

--- a/src/discordbot/cogs/games/cog.py
+++ b/src/discordbot/cogs/games/cog.py
@@ -1,4 +1,4 @@
-"""Casino-style games (`/games blackjack`, `/games dragon_gate`) wagering economy points."""
+"""The `/games` group: Blackjack, 射龍門, the Blackjack history lookup, and fishing."""
 
 from random import SystemRandom
 from functools import partial
@@ -50,7 +50,11 @@ from discordbot.cogs.games.fishing.presentation import build_panel_embed
 
 
 class GamesCogs(commands.Cog):
-    """Slash commands for multiplayer casino games against the casino system.
+    """Slash commands for the `/games` group.
+
+    Blackjack and 射龍門 are multiplayer tables played against the casino
+    system; fishing is a single-player panel and blackjack_history only reads
+    stored rounds.
 
     Attributes:
         bot: The Discord bot instance that owns this cog.
@@ -69,7 +73,7 @@ class GamesCogs(commands.Cog):
         self._blackjack_shoes = BlackjackShoeStore()
 
     async def _system_identity(self, guild: Guild | None = None) -> SystemIdentity:
-        """Returns the casino system identity used for narrator embeds.
+        """Returns the casino system identity that labels the house in game embeds.
 
         Slash commands only fire after the gateway has connected, so
         `self.bot.user` is guaranteed non-None at call time. We still fall back
@@ -265,7 +269,7 @@ class GamesCogs(commands.Cog):
         nsfw=False,
     )
     async def games(self, interaction: Interaction[commands.Bot]) -> None:
-        """Slash command group for casino games."""
+        """Slash command group; every game runs from one of its subcommands."""
 
     @games.subcommand(
         name="blackjack",

--- a/src/discordbot/cogs/games/dragon_gate.py
+++ b/src/discordbot/cogs/games/dragon_gate.py
@@ -88,7 +88,11 @@ def has_open_gate(pillars: list[Card]) -> bool:
 
 
 class DragonGateTurn(BaseModel):
-    """Mutable state for one active player's 射龍門 attempt."""
+    """Frozen state for one active player's 射龍門 attempt.
+
+    A pair-gate direction choice replaces the whole turn rather than mutating
+    it; see `DragonGateRound.choose_pair_direction`.
+    """
 
     model_config = ConfigDict(frozen=True)
 
@@ -172,7 +176,11 @@ class DragonGateRound(BaseModel):
     def from_participants(
         cls, rng: Random, participants: list[GameParticipant]
     ) -> "DragonGateRound":
-        """Builds and starts a 射龍門 round from lobby participants."""
+        """Builds a 射龍門 round from lobby participants and deals the first gate.
+
+        Raises:
+            ValueError: `participants` is empty.
+        """
         if not participants:
             raise ValueError("At least one participant is required")
         round_state = cls(rng=rng, participants=participants)
@@ -220,7 +228,8 @@ class DragonGateRound(BaseModel):
 
         Args:
             user_id: Discord user ID that must match the active player.
-            amount: Bet amount, constrained to current min bet..jackpot.
+            amount: Bet amount, constrained to the `current_min_bet` /
+                `current_max_bet` range for the supplied jackpot.
             jackpot: Live jackpot balance used to bound the legal bet
                 range; tracked outside this module.
 
@@ -263,7 +272,12 @@ class DragonGateRound(BaseModel):
         return self.player_deltas.get(user_id, 0)
 
     def replace_last_result_delta(self, user_id: int, delta: int) -> DragonGateTurnResult:
-        """Replaces the latest result delta after database-side clamping."""
+        """Replaces the latest result delta after database-side clamping.
+
+        Raises:
+            DragonGateParticipantUnknownError: No turn has resolved yet, or the
+                latest one belongs to another player.
+        """
         result = self.last_result
         if result is None or result.participant.user_id != user_id:
             raise DragonGateParticipantUnknownError("No latest result for user")

--- a/src/discordbot/cogs/games/dragon_gate_views.py
+++ b/src/discordbot/cogs/games/dragon_gate_views.py
@@ -116,7 +116,7 @@ def _outcome_presentation(outcome: DragonGateOutcome) -> tuple[str, int]:
 
 
 def _result_line(result: DragonGateTurnResult) -> str:
-    """Formats the latest resolved turn for the main embed."""
+    """Formats the last resolved turn for the final embed's last-hand block."""
     outcome_label, _color = _outcome_presentation(outcome=result.outcome)
     direction = f" · {_direction_label(direction=result.direction)}" if result.direction else ""
     pillars = " ".join(str(card) for card in result.pillars)
@@ -440,7 +440,7 @@ class DragonGateView(View):
         self.sync_controls()
 
     async def interaction_check(self, interaction: Interaction[commands.Bot]) -> bool:
-        """Restricts bet/direction to the active player; leave is open to all seated."""
+        """Restricts every control to a seated player who has not withdrawn."""
         if self._settled or interaction.user is None:
             return False
         data = (
@@ -555,7 +555,7 @@ class DragonGateView(View):
         await self._place_bet_locked_by_interaction(interaction=interaction, amount=amount)
 
     def sync_controls(self) -> None:
-        """Updates button labels and select options from the current table state."""
+        """Rebuilds control labels, options, and visibility from the table state."""
         active = self.round_state.active_turn
         needs_pair_choice = not self._settled and self.round_state.needs_pair_choice()
         minimum = self.round_state.current_min_bet(jackpot=self._jackpot_snapshot)
@@ -651,8 +651,8 @@ class DragonGateView(View):
         Losses already clamp at the player's balance, so bounding the bet by the
         same balance closes the asymmetric free option where a low-balance player
         risks only their wallet yet could win the full pool. If the balance drops
-        below the table minimum, the betting controls are hidden until the player
-        leaves instead of flooring the maximum back above their wallet.
+        below the table minimum, `sync_controls` hides the bet select until the
+        player leaves instead of flooring the maximum back above their wallet.
         """
         pool_max = self.round_state.current_max_bet(jackpot=self._jackpot_snapshot)
         if user_id is None:
@@ -821,7 +821,7 @@ class DragonGateView(View):
                 self._refunded_to_pool[participant.user_id] = refunded_to_pool
 
     async def _finalize_locked(self, message: Message, reason: str) -> None:
-        """Builds final results, disables controls, and schedules cleanup."""
+        """Builds final results, clears the controls, and schedules cleanup."""
         if self._settled:
             return
         self._settled = True

--- a/src/discordbot/cogs/games/fishing/catch.py
+++ b/src/discordbot/cogs/games/fishing/catch.py
@@ -159,6 +159,10 @@ def roll_catch(  # noqa: PLR0913 -- a roll needs rng, configs, species, rod, bai
     intra-grade weights within that grade, and the size uniformly across the
     species' basis-point range. The final value applies the size multiplier and
     the bait value bonus, then clamps to `max_value`.
+
+    Raises:
+        ValueError: The species catalog is empty, or every grade that could be
+            rolled is disabled by a zero base weight.
     """
     if not species:
         msg = "cannot roll a catch from an empty species catalog"

--- a/src/discordbot/cogs/games/fishing/database.py
+++ b/src/discordbot/cogs/games/fishing/database.py
@@ -9,8 +9,9 @@ Two operations cross databases. A purchase debits (burns) the wallet first, then
 grants gear in games.db, refunding on a grant failure. A cast consumes bait and
 durability and logs the catch in games.db first, then credits the payout in the
 economy database; a payout that fails after the catch is logged is reported as
-deferred rather than rolled back, which only ever deflates further. Hard crashes
-between the two file commits are an accepted non-atomicity.
+deferred rather than rolled back, so the failure can only ever leave currency
+unminted. Hard crashes between the two file commits are an accepted
+non-atomicity.
 """
 
 from random import Random, SystemRandom
@@ -861,8 +862,8 @@ async def fetch_recent_catches(user_id: int, limit: int = 10) -> tuple[CatchLogV
 async def reset_all_fishing() -> int:
     """Clears all per-user fishing state, leaving the tunable catalog intact.
 
-    Used by the offline economy reset so stale rods, bait, and catch history do
-    not survive a wallet deflation. Grade, species, and gear catalog rows are
+    Nothing in the tree calls this: #248 deleted `scripts/reset_economy.py`, the
+    offline reset it was written for. Grade, species, and gear catalog rows are
     intentionally left untouched.
 
     Returns:

--- a/src/discordbot/cogs/games/history_text.py
+++ b/src/discordbot/cogs/games/history_text.py
@@ -38,7 +38,11 @@ _RESULT_TAGS: Final[dict[SettleOutcome, str]] = {
 
 
 class _HistorySummary(BaseModel):
-    """Aggregate win/loss/push counts and net delta over the rendered rounds."""
+    """Aggregate win/loss/push counts and net delta over every fetched round.
+
+    Computed before the description budget trims the table, so it can legitimately
+    count more rounds than the embed lists.
+    """
 
     model_config = ConfigDict(frozen=True)
 
@@ -143,7 +147,12 @@ def _net_color(net_delta: int) -> int:
 def build_blackjack_history_embed(
     *, player_name: str, records: Sequence[BlackjackHistoryRecord]
 ) -> Embed:
-    """Builds the public embed for a player's recent Blackjack rounds."""
+    """Builds the public embed for a player's recent Blackjack rounds.
+
+    The summary line counts every record passed in, while the table below it
+    drops the oldest rows until the block fits `_DESCRIPTION_BUDGET` and states
+    how many it dropped, so the two can legitimately disagree on round count.
+    """
     title = f"🃏 {player_name} 的二十一點紀錄"
     if not records:
         return Embed(title=title, description="還沒有任何二十一點對局紀錄。", color=PUSH_COLOR)

--- a/src/discordbot/cogs/games/interactions.py
+++ b/src/discordbot/cogs/games/interactions.py
@@ -39,6 +39,10 @@ async def edit_message_with_retry(
     couple of seconds; the game-start edits must succeed or the lobby is left
     stopped with antes already charged. Backoff grows 0.5s, 1.0s, ... so the
     final attempt covers ~1.5s of upstream flakiness before propagating.
+
+    Pass `kwargs_factory` whenever the payload carries files: a failed attempt
+    has already consumed those upload streams, so every retry needs a payload
+    built from scratch.
     """
 
     def edit_kwargs() -> dict[str, Any]:

--- a/src/discordbot/cogs/games/lobby.py
+++ b/src/discordbot/cogs/games/lobby.py
@@ -42,7 +42,8 @@ class PrepareParticipant(Protocol):
 class RefreshParticipants(Protocol):
     """Callable used by lobby start to re-check balances.
 
-    Wager / mode are bound by the caller via `functools.partial`.
+    The wager mode is bound by the caller via `functools.partial`; each
+    participant's own wager rides on the participant passed in.
     """
 
     async def __call__(self, participants: list[GameParticipant]) -> RefreshParticipantsResult:

--- a/src/discordbot/cogs/games/presentation.py
+++ b/src/discordbot/cogs/games/presentation.py
@@ -128,8 +128,8 @@ def settlement_metadata(  # noqa: PLR0913 -- final result metadata has several o
         five_card_bonus: System-funded bonus from five-card 21.
 
     Returns:
-        `-# 本局 +X · 餘額 Y` style metadata, with an `· all-in` suffix
-        when the round was all-in.
+        `-# 本局 +X · 餘額 Y` style metadata, with an `all-in` segment inserted
+        before the balance when the round was all-in.
     """
     segments = [f"本局 {amount_code(amount=delta, signed=True, compact=True)}"]
     if vip_bonus > 0 and base_delta is not None:

--- a/src/discordbot/cogs/games/settlement.py
+++ b/src/discordbot/cogs/games/settlement.py
@@ -1,4 +1,4 @@
-"""Settlement helpers shared by game commands and interactive views."""
+"""Settlement helpers for the Blackjack interactive views."""
 
 from discordbot.typings.games import (
     Card,
@@ -29,7 +29,7 @@ from discordbot.services.economy.database import (
 
 
 def _blackjack_detail_for_hand(cards: list[Card], dealer: list[Card]) -> str:
-    """Builds a concise Blackjack result summary for dealer banter.
+    """Builds a concise Blackjack result summary for one settled hand.
 
     Args:
         cards: Player sub-hand cards.
@@ -67,7 +67,7 @@ def _blackjack_detail_for_hand(cards: list[Card], dealer: list[Card]) -> str:
 def _blackjack_hand_detail_part(
     index: int, settlement: BlackjackHandSettlement, dealer_total: int
 ) -> str:
-    """Formats one settled Blackjack sub-hand for dealer banter detail."""
+    """Formats one settled Blackjack sub-hand for the multi-hand detail line."""
     hand_total = hand_value(cards=settlement.cards)
     prefix = f"手{index}"
     if settlement.surrendered:
@@ -99,7 +99,7 @@ def blackjack_detail_player(
     hand_settlements: list[BlackjackHandSettlement],
     insurance: BlackjackInsuranceSettlement | None,
 ) -> str:
-    """Builds a multi-hand Blackjack summary for dealer banter.
+    """Builds a multi-hand Blackjack summary for `BlackjackPlayerSettlement.detail`.
 
     Args:
         player: Player whose hands are being summarized.
@@ -108,8 +108,8 @@ def blackjack_detail_player(
         insurance: Optional insurance side-bet result.
 
     Returns:
-        Short Chinese summary. Single-hand players keep the concise detail
-        shape used by dealer banter.
+        Short Chinese summary. A lone hand with no insurance keeps the concise
+        single-hand shape instead.
     """
     if len(hand_settlements) == 1 and insurance is None:
         only = hand_settlements[0]
@@ -281,7 +281,7 @@ async def settle_blackjack_player(
     sum).
 
     Args:
-        round_state: Round providing the dealer cards, RNG, and peek state.
+        round_state: Round providing the dealer cards and peek state.
         player: Player to settle.
         player_id: Discord user ID for the player account.
         player_account_name: Account name to store for the player.

--- a/src/discordbot/cogs/games/shoe.py
+++ b/src/discordbot/cogs/games/shoe.py
@@ -55,9 +55,11 @@ class BlackjackShoeStore(BaseModel):
         depletion by saving the round's remaining shoe with `save_shoe` once it
         settles (the round may deal from a copy, so the returned list itself is not
         relied on to mutate). The `reshuffled` flag is True only for a genuine
-        penetration cut, not for the first shoe in a channel, so the table only
-        announces a real reshuffle. The `generation` stamps this round; pass it back to
-        `save_shoe` so an older in-flight round cannot overwrite a newer table's shoe.
+        penetration cut, not for the first shoe in a channel, so a caller can
+        announce a real reshuffle without announcing the channel's first deal;
+        `BlackjackLobbyView._start_game` discards it today. The `generation` stamps
+        this round; pass it back to `save_shoe` so an older in-flight round cannot
+        overwrite a newer table's shoe.
         """
         generation = self._take_generation.get(channel_id, 0) + 1
         self._take_generation[channel_id] = generation

--- a/src/discordbot/cogs/games/wagers.py
+++ b/src/discordbot/cogs/games/wagers.py
@@ -10,7 +10,11 @@ WagerMode = Literal["clamp", "exact"]
 
 
 def parse_wager_amount(raw_amount: str | None) -> int | None:
-    """Parses user-entered wager text; zero is allowed and means all-in."""
+    """Parses user-entered wager text; zero parses rather than being rejected.
+
+    What zero means is the caller's rule: an all-in Blackjack table stake, but
+    an ordinary out-of-range amount for a 射龍門 custom bet.
+    """
     return parse_decimal_amount(raw=raw_amount)
 
 
@@ -21,6 +25,10 @@ def build_wager_participant(
 
     `clamp` allows a lower-balance player to join by wagering their full balance.
     `exact` requires the player to cover the full wager, which is used for antes.
+
+    Returns:
+        The seated participant, or None when the wager or the balance is
+        non-positive, or when `exact` mode meets a balance below the wager.
     """
     if wager <= 0 or balance <= 0:
         return None
@@ -29,9 +37,10 @@ def build_wager_participant(
 
     bet = min(wager, balance)
     if mode == "clamp":
-        # MAX_SINGLE_BET caps player-chosen table bets so balances cannot compound
-        # exponentially through repeated all-in doubling. Exact-mode antes must be
-        # paid in full, so they are never reduced by the cap.
+        # MAX_SINGLE_BET caps every clamp-mode table stake, the bot player's own
+        # Kelly bet included, so balances cannot compound exponentially through
+        # repeated all-in doubling. Exact-mode antes must be paid in full, so
+        # they are never reduced by the cap.
         bet = min(bet, MAX_SINGLE_BET)
     return GameParticipant(
         user_id=identity.user_id,

--- a/src/discordbot/cogs/gen_reply/attachment/anthropic_file_api.py
+++ b/src/discordbot/cogs/gen_reply/attachment/anthropic_file_api.py
@@ -21,8 +21,9 @@ not this renderer, builds the message that cites the file): the answer request m
 not auto-add that header for file references; LiteLLM's Anthropic mapper needs the file format,
 not a bare `file_id`, to emit a `document` block rather than a code-execution `container_upload`,
 so PDF / text references must preserve their MIME; and Anthropic document blocks only cover
-PDF / plain text / images, so keep the type narrowing `InlineRenderer` does today (UTF-8 files
-as `input_text`, the rest dropped) instead of uploading every MIME and referencing it blindly.
+PDF / plain text / images, so keep the type narrowing `InlineRenderer` does today (PDFs as
+base64 `input_file`, UTF-8 files as `input_text`, the rest dropped) instead of uploading every
+MIME and referencing it blindly.
 """
 
 import io

--- a/src/discordbot/cogs/gen_reply/attachment/base.py
+++ b/src/discordbot/cogs/gen_reply/attachment/base.py
@@ -47,20 +47,24 @@ class AttachmentRenderer(BaseModel):
     swapped by injecting a different renderer into `MessageInputBuilder`, not by branching
     inside it. Both methods return the rendered part plus the cache expiry the per-message
     render cache reuses it until, or None when the source is dropped (unsupported / failed).
-    `cache_key` and `allow_dead_cache` drive the shared dead-source cache below (and the Gemini
-    uploader's per-class re-poll cache); a stateless renderer inherits the cache attributes for
+    `cache_key` and `allow_dead_cache` drive the dead-source cache below (and the Gemini
+    uploader's own re-poll cache); a stateless renderer inherits the cache attributes for
     interface parity but never uses them.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    # Sources whose byte fetch failed, keyed by cache_key -> first-failure time. Shared by every
-    # uploading renderer so the Files-API uploaders cannot drift; a hit within DEAD_SOURCE_TTL
-    # skips the fetch fast, past it the entry is dropped and the source retried once. Bounded at
-    # 128 entries. A stateless renderer (InlineRenderer) inherits but never touches it.
+    # Sources whose byte fetch failed, keyed by cache_key -> first-failure time. Held here rather
+    # than on each uploader so the Files-API uploaders cannot drift (the dict itself is per
+    # instance); a hit within DEAD_SOURCE_TTL skips the fetch fast, past it the entry is dropped
+    # and the source retried once. Bounded at 128 entries. A stateless renderer (InlineRenderer)
+    # inherits but never touches it.
     _dead_sources: OrderedDict[int | str, datetime] = PrivateAttr(default_factory=OrderedDict)
-    # Caps concurrent media fetch + upload work; see MEDIA_CONCURRENCY. Created in-loop on first
-    # access (during message handling), so it binds to the running event loop.
+    # Caps concurrent media fetch + upload work; see MEDIA_CONCURRENCY. A plain Semaphore is safe
+    # here only because a renderer never outlives one loop: it is reachable solely through one
+    # cog instance's `input_builder` cached_property, and there is one cog per process and a
+    # fresh one per test. It binds to the loop of the first call that WAITS on it, not the one it
+    # was built on, so anything shared more widely needs `utils/asyncio_locks.py` instead.
     _media_semaphore: SkipValidation[asyncio.Semaphore] = PrivateAttr(
         default_factory=lambda: asyncio.Semaphore(MEDIA_CONCURRENCY)
     )

--- a/src/discordbot/cogs/gen_reply/attachment/gemini_file_api.py
+++ b/src/discordbot/cogs/gen_reply/attachment/gemini_file_api.py
@@ -1,9 +1,10 @@
 """Gemini Files API attachment renderer: direct-SDK upload, activation poll, re-poll cache.
 
 Owns the mechanical side-channel that turns attachment bytes into an ACTIVE Gemini file URI
-referenced as an `input_file` part: the direct-SDK upload, the activation poll, the pending
-re-poll, and the per-source dead-source / pending / concurrency caches. Kept separate from
-`input.py` so the upload state machine does not tangle with source-to-part rendering.
+referenced as an `input_file` part: the direct-SDK upload, the activation poll, and the
+per-source pending re-poll cache. The dead-source cache and the media semaphore it works
+against are inherited from `base.AttachmentRenderer`. Kept separate from `input.py` so the
+upload state machine does not tangle with source-to-part rendering.
 """
 
 import io

--- a/src/discordbot/cogs/gen_reply/attachment/inline.py
+++ b/src/discordbot/cogs/gen_reply/attachment/inline.py
@@ -37,12 +37,14 @@ def _inline_expiry() -> datetime:
 
 
 class InlineRenderer(AttachmentRenderer):
-    """Inlines attachments as base64 / text parts (OpenAI / Anthropic answer models).
+    """Inlines attachments as base64 / text parts.
 
-    Stateless: every render fetches the source and embeds it directly in the request, so
-    there is no upload handle to track and the `cache_key` / `allow_dead_cache` re-poll
-    arguments are ignored. Images inline as `input_image` base64, PDFs as base64
-    `input_file`, UTF-8 files as `input_text`, and anything else is dropped.
+    Selected for any non-Gemini answer model, none of which can resolve a Gemini Files URI,
+    and for every provider (Gemini included) while `file_api_enabled` is off. Stateless:
+    every render fetches the source and embeds it directly in the request, so there is no
+    upload handle to track; `allow_dead_cache` is ignored and `cache_key` only labels a
+    failure log. Images inline as `input_image` base64, PDFs as base64 `input_file`, UTF-8
+    files as `input_text`, and anything else is dropped.
     """
 
     async def render_image(

--- a/src/discordbot/cogs/gen_reply/attachment/loaders.py
+++ b/src/discordbot/cogs/gen_reply/attachment/loaders.py
@@ -1,7 +1,8 @@
 """Shared byte loaders for attachment rendering (image fetch + downscale, mime resolution).
 
-Used by both renderer strategies and by the IMAGE route's raw-bytes path, so the
-download/downscale logic lives in one place independent of how the bytes are later consumed.
+Used by every renderer strategy, by the IMAGE route's raw-bytes path and by the Threads link
+builder, so the download/downscale logic lives in one place independent of how the bytes are
+later consumed.
 """
 
 import asyncio
@@ -16,9 +17,11 @@ async def load_image_bytes(source: Attachment | StickerItem | str) -> tuple[byte
     """Fetches and downscales an image source to upload-ready bytes and MIME type.
 
     URL sources fetch over the network and attachments decode/re-encode, so the blocking
-    work runs off the event loop. Raises on any fetch/decode failure. Callers bound their
-    own concurrency (the Gemini uploader's media semaphore) or fetch a single current-turn
-    image (the IMAGE route, the inline render).
+    work runs off the event loop. Raises on any fetch/decode failure. This bounds nothing
+    itself: the Gemini uploader holds its media semaphore across the call, while the inline
+    renderer, the IMAGE route and the Threads link builder do not, so each of those fans
+    out as wide as whatever it passes in (the Threads builder slices to its own media-part
+    budget first, the other two do not).
     """
     if isinstance(source, str):
         file_bytes = await asyncio.to_thread(get_image_data, image_file=source)

--- a/src/discordbot/cogs/gen_reply/cog.py
+++ b/src/discordbot/cogs/gen_reply/cog.py
@@ -183,9 +183,11 @@ EFFORT_GRACE_SECONDS = 5.0
 # preparation and effort grading. Tune against the `gen_reply link context done` latency log.
 LINK_CONTEXT_GRACE_SECONDS = 180.0
 
-# Bound on the ACTIVE poll for a generated clip uploaded so the persona reply can watch it.
-# Generous relative to an image because video sits in PROCESSING longer, but far under the
-# link-media bound: the clip was just produced here, so it is small and known-good.
+# Bound on the whole Files API upload of a generated clip the persona reply then watches:
+# `upload_to_files_api` covers the transfer as well as the ACTIVE poll under this one timeout,
+# started once an upload slot is free. Generous relative to an image because video sits in
+# PROCESSING longer, but far under the link-media bound: the clip was just produced here, so it
+# is small and known-good.
 GENERATED_VIDEO_ACTIVATION_TIMEOUT_SECONDS = 60.0
 
 # Recorded as a reply's route when the pipeline failed before the router returned one.
@@ -224,7 +226,7 @@ def _authored_link_texts(message: Message) -> list[str]:
     Narrower than `_message_link_texts` by exactly one thing: an embed card never counts,
     neither the message's own nor a forwarded snapshot's. One hop out an embed is a card the
     author did not write, and the bot's own Threads expansion is the common one:
-    `parse_threads._build_embeds` emits one permalink per post in the reply chain, ROOT first,
+    `parse_threads._build_embed_plan` emits one permalink per post in the reply chain, ROOT first,
     so a scan keyed on it would read the thread's top post rather than the one the human
     linked — and it disappears entirely when an oversize video pushes hosted URLs into
     `content`. A link a person typed always lives in `content` (or in the content of what they
@@ -443,9 +445,10 @@ async def _discard_task[TaskResultT](
     """Cancels and drains a speculative task so its exception is retrieved.
 
     The except is deliberately broad: this drains unrelated subsystems (prep, effort, parts,
-    threads, douyin, memory selection), so anything they can raise must be swallowed here rather
-    than surfacing on a route that already decided it does not need the result. `label` names
-    which one failed, since the tasks are otherwise indistinguishable at this point.
+    memory selection), so anything they can raise must be swallowed here rather than surfacing on
+    a route that already decided it does not need the result. `label` names which one failed,
+    since the tasks are otherwise indistinguishable at this point. A link-context build is drained
+    by `_drain_deadline_bound_task` instead, which must not steal its own deadline's cancellation.
     """
     task.cancel()
     try:
@@ -625,7 +628,9 @@ def _bilibili_media_ingest_allowed(config: LLMConfig) -> bool:
 
 # The linked-content sources gen_reply reads into answer context, in splice order: the blocks
 # land in the answer input in this order, just before the current message. Adding a source is
-# one entry here plus its builder module; the pipeline loops stay untouched.
+# one entry here, its builder module, and its name in `RouteClassification.link_context_sources`
+# (a source the router cannot name is never selected, so its builder never starts); the pipeline
+# loops stay untouched.
 LINK_CONTEXT_SOURCES: tuple[LinkContextSource, ...] = (
     LinkContextSource(
         name="threads",
@@ -728,6 +733,8 @@ class ReplyGeneratorCogs(commands.Cog):
     Attributes:
         bot: The Discord bot instance that owns this cog.
         config: The LLM client configuration loaded for reply generation.
+        runtime_models: The model strings and per-tier settings every call here dispatches on.
+        usage_recorder: The per-reply usage-record writer read by `scripts/usage_report.py`.
     """
 
     def __init__(self, bot: commands.Bot) -> None:
@@ -763,16 +770,21 @@ class ReplyGeneratorCogs(commands.Cog):
     def gemini_client(self) -> genai.Client:
         """The cached native Gemini client for every DIRECT-to-Google runtime path.
 
-        DIRECT to Google (`gemini_api_key`, no proxy): it serves the two runtime paths the
-        LiteLLM proxy cannot, and the swap only ever fires when the answer model is already
-        Gemini so the direct credential is always the right one:
+        DIRECT to Google (`gemini_api_key`, no proxy): it serves the runtime paths the LiteLLM
+        proxy cannot.
+
         - native omni video generation / editing (`interactions.create`, delivery=uri + Files
-          download); and
+          download), for both the VIDEO route and the inline `<generate-video>` marker;
+        - the inline `<generate-music>` Lyria render, also on the Interactions API;
+        - Files API uploads, so a generated clip (and, through
+          `gemini_client_if_configured`, a linked post's media) can be referenced by uri; and
         - the YouTube-aware QA answer turn that streams through the native Interactions API (the
-          only path that can actually watch a linked video).
-        Both forgo proxy-side cost/usage tracking, like the deep-research direct path. An empty
-        key raises at construction, so a caller that is reachable without one must go through
-        `gemini_client_if_configured` instead of touching this.
+          only path that can actually watch a linked video). That last swap only ever fires when
+          the answer model is already Gemini, so the direct credential is always the right one.
+
+        All of them forgo proxy-side cost/usage tracking, like the deep-research direct path. An
+        empty key raises at construction, so a caller that is reachable without one must go
+        through `gemini_client_if_configured` instead of touching this.
 
         Returns:
             A Gemini client for native media generation and the Interactions answer turn.
@@ -836,12 +848,13 @@ class ReplyGeneratorCogs(commands.Cog):
 
     @cached_property
     def video_generator(self) -> VideoGenerator:
-        """The cached video renderer for the VIDEO route.
+        """The cached video renderer shared by the VIDEO route and the QA-route `<generate-video>` marker.
 
         Returns:
             A generator bound to this cog's DIRECT-to-Google Gemini client and the video model
             (the Interactions API is Gemini-only, not reachable via the proxy); the route calls
-            `render` (raises).
+            `render` (raises) while the inline path calls `generate` (best-effort, gated on
+            `allow_video` and `config.video_available`).
         """
         return VideoGenerator(
             client=self.gemini_client, video_model=self.runtime_models.video_model
@@ -922,10 +935,10 @@ class ReplyGeneratorCogs(commands.Cog):
         )
 
     async def _fetch_history(self, message: Message, limit: int) -> list[Message]:
-        """Fetches up to `limit` channel-history messages once (a single Discord API call).
+        """Fetches up to `limit` channel-history messages once.
 
         Returned raw so both the optional selector's text-only render and the answer's
-        uploaded render derive from one fetch, without a second history round-trip.
+        uploaded render derive from one fetch, without a second walk of history.
         """
         hist_messages: list[Message] = []
         async for m in message.channel.history(limit=limit, before=message, oldest_first=True):
@@ -1207,8 +1220,9 @@ class ReplyGeneratorCogs(commands.Cog):
         path, and a fresh hosted-case base that never received content is deleted (never an orphan).
         Builds the answer-path input (history, selected user memory, tone note, reference, current),
         appends the just-made media as the focus, and streams onto the base (its content edits keep an
-        attached media). Injects only the selected user memory (already source-filtered) plus the
-        author's tone note, never the server memory block, and seeds the
+        attached media). Injects only the selected user memory (already read through the
+        compartments this conversation may open) plus the author's tone note, never the server
+        memory block, and seeds the
         selection-call usage / memory labels so the footer matches the QA path. Consumes the
         speculative `context_task` (awaited here so its build overlaps generation); any failure
         leaves the delivered media untouched.
@@ -1219,8 +1233,8 @@ class ReplyGeneratorCogs(commands.Cog):
             context = await context_task
             base = await self._persona_base_reply(message=message, reply=reply)
             # Mirror the answer path's order (history, memory, tone, reference, current),
-            # injecting only the selected user memory (already source-filtered) and the
-            # author's tone note, never the server memory block.
+            # injecting only the selected user memory (already compartment-scoped by
+            # `resolve_user_memories`) and the author's tone note, never the server memory block.
             response_input: ResponseInputParam = [*context.hist_messages]
             response_input.extend(
                 block for block in (context.memory_block, context.tone_block) if block is not None
@@ -1397,11 +1411,12 @@ class ReplyGeneratorCogs(commands.Cog):
     ) -> RouteClassification:
         """Classifies the message into a reply mode using pre-built context parts.
 
-        Only the handler choice is decided here; the answer effort is graded by
-        `_grade_effort` in a parallel call, so this stays a short single-purpose
-        classification on the critical path. The reference + current parts arrive already
-        text-only (attachment markers, no file ids), so the route classifies on the text
-        without reading or waiting on uploads.
+        The handler choice and the two content-read decisions that ride with it
+        (`watch_video`, `link_context_sources`) all come from this one call; the answer
+        effort is graded by `_grade_effort` in a parallel call, so this stays short on the
+        critical path. The reference + current parts arrive already text-only (attachment
+        markers, no file ids), so the route classifies on the text without reading or
+        waiting on uploads.
         """
         message_list = [*reference_messages, *current_message]
 
@@ -1683,8 +1698,10 @@ class ReplyGeneratorCogs(commands.Cog):
                 allowed=deterministic_allowed, memory=server_memory, include_absent=False
             )
             if _source_channel_is_public(message=message):
-                # No credit label: the conversation never names these members, so the
-                # footer falls back to the identity their own memory carries.
+                # No credit label: the conversation never names these members, so
+                # `resolve_user_memories` credits them by their bare id. Deliberately NOT the
+                # identity their own memory carries, which is the display name of whichever
+                # guild's consolidation last wrote that fact (see `MemoryCandidate`).
                 optional_allowed = {
                     user_id: MemoryCandidate(prompt_label=label)
                     for user_id, label in allowlist_ids_from_server_memory(
@@ -2107,7 +2124,7 @@ class ReplyGeneratorCogs(commands.Cog):
                 ),
             )
         # Server memory is not gated by `memory_enabled`: the SUMMARY route runs with it
-        # off (no per-user memory) yet its ~100-message digest is high-quality community
+        # off (no per-user memory) yet its 200-message digest is high-quality community
         # signal worth recording. DMs and non-public channels are dropped by the guards
         # inside `_schedule_server_memory_update`.
         self._schedule_server_memory_update(
@@ -2421,7 +2438,8 @@ class ReplyGeneratorCogs(commands.Cog):
                     # A digest recaps channel history, not one linked post, so intent-gated link
                     # builders never start here. A URL-bearing SUMMARY is already rerouted to QA.
                     reactions.advance(emoji="<:stacks:1517562531365912607>")
-                    # so it neither biases the digest nor floods extraction, but the
+                    # A digest reads 200 channel messages, so it is rebuilt with per-user memory
+                    # off: it neither biases the digest nor floods extraction, but the
                     # per-server memory is still recorded since the digest is rich
                     # community signal. Cancelling the speculative prep leaves `parts_task`
                     # running (prep awaits it through asyncio.shield), so the shared

--- a/src/discordbot/cogs/gen_reply/files_api.py
+++ b/src/discordbot/cogs/gen_reply/files_api.py
@@ -13,9 +13,9 @@ client can poll a file to ACTIVE: the proxy's file resource reports a deprecated
 status, and referencing a not-yet-ACTIVE file intermittently 400s the whole answer request.
 
 Distinct from `attachment/gemini_file_api.py`, which owns the same upload for Discord
-attachments plus a per-source render cache and a pending-upload re-poll keyed on the message
-that carried them. A file this module uploads has no such later reference to adopt, so it
-gets a plain bounded wait instead.
+attachments plus a pending-upload re-poll keyed on the attachment source (the per-message
+render cache is a third thing again, and lives in `input.py`). A file this module uploads
+has no such later reference to adopt, so it gets a plain bounded wait instead.
 """
 
 import io
@@ -64,7 +64,8 @@ async def upload_to_files_api(
 ) -> str | None:
     """Uploads media to the Gemini Files API and returns its ACTIVE uri; None on any failure.
 
-    Best-effort by design: every caller has a text-only degradation to fall back on, so a
+    Best-effort by design: every caller degrades rather than failing — the link builders to
+    their text-only block, the generated-clip path by skipping its persona reply — so a
     failure here must not raise into the reply pipeline. That is also what lets the
     `file_api_enabled` kill-switch sit here rather than at each caller: a switched-off upload
     takes the same path a failed one already takes. It is the backstop, not the saving —

--- a/src/discordbot/cogs/gen_reply/generation.py
+++ b/src/discordbot/cogs/gen_reply/generation.py
@@ -10,13 +10,14 @@ render goes through the same calling convention instead of a half-free-function 
   proxy like the answer model. The QA-route inline
   `<generate-image>` marker does NOT refine (its description is already written by the answer model).
 - `ImageGenerator` runs the downstream image model on the LiteLLM proxy (`AsyncOpenAI`). `render`
-  is the raising primitive shared by the router IMAGE route (which also edits source pixels) and
-  the best-effort inline path; `generate` is the QA-route `<generate-image>` marker's best-effort wrapper
-  (generation-only, timeout, None on any failure) so a slow inline render never blocks anything but
-  its own reply.
+  is the raising primitive shared by the router IMAGE route and the best-effort inline path (both
+  edit source pixels when the message carried an image); `generate` is the QA-route
+  `<generate-image>` marker's best-effort wrapper (timeout, None on any failure) so a slow inline
+  render never blocks anything but its own reply.
 - `VoiceGenerator` runs the text-to-speech model on the same LiteLLM proxy (`AsyncOpenAI`) as the
   image generator. Kept on the proxy on purpose: TTS has many interchangeable providers, so the
-  one-SDK proxy path stays the most portable, unlike Veo / Lyria below which can only go direct.
+  one-SDK proxy path stays the most portable, unlike the omni video and Lyria music renders
+  below, which can only go direct.
   `generate` is best-effort but returns a `VoiceClip` carrying a `VoiceOutcome`
   (OK / EMPTY / TIMEOUT / ERROR) rather than a bare None, so the caller can hint a timeout (⏱️)
   apart from any other failure (⚠️). The `speechify_discord_markup` helper that prepares its spoken
@@ -523,8 +524,11 @@ class _InteractionResult(Protocol):
     attributes are declared here and cast to instead. Naming the response class is its own
     trap: `google.genai.interactions` star-imports `Interaction` from both the request-union
     alias (which carries none of these attributes) and the response module, and only the
-    runtime import order makes the response class win. `ty` resolves it to the response class;
-    mypy bound the request union, which is what a nominal cast used to get wrong.
+    runtime import order makes the response class win. `ty` resolves it to the response class,
+    so a nominal `cast("Interaction", ...)` is no longer wrong there, merely fragile: its
+    meaning rests on that import order, while this Protocol pins the attributes actually read.
+    That the collision is real rather than theoretical was demonstrated by mypy, which bound
+    the request union before it was dropped in #356; no checker in the tree will show it again.
     """
 
     @property
@@ -639,7 +643,7 @@ class VideoGenerator(BaseModel):
             )
         # No `stream=True`, so this is the interaction rather than an event stream: exclude the
         # stream at runtime, then read the result through the structural `_InteractionResult`
-        # view (its docstring has why the genai response class cannot be named or narrowed to).
+        # view (its docstring has why naming the genai response class is not enough on its own).
         if isinstance(interaction, AsyncIterator):
             raise RuntimeError("Video generation returned an event stream, not an interaction")
         result = cast("_InteractionResult", interaction)

--- a/src/discordbot/cogs/gen_reply/input.py
+++ b/src/discordbot/cogs/gen_reply/input.py
@@ -184,9 +184,10 @@ class MessageInputBuilder(BaseModel):
     def forwarded_request_text(self, message: Message) -> str:
         """Concatenated raw forwarded text (no `[forwarded message]` tag) across snapshots.
 
-        Used as the media prompt when a pure forward carries no comment of its own, so a
-        forwarded "draw a cat" reaches the IMAGE/VIDEO handler as its actual request instead
-        of the generic fallback. Empty for a normal message or a media-only forward.
+        Merged into the media prompt by the caller (after the forwarder's own comment, when
+        there is one), so a forwarded "draw a cat" reaches the IMAGE/VIDEO handler as its actual
+        request even when the `@bot` trigger comment left text of its own behind. Empty for a
+        normal message or a media-only forward.
         """
         texts = [
             text
@@ -196,7 +197,12 @@ class MessageInputBuilder(BaseModel):
         return "\n".join(texts)
 
     async def get_cleaned_content(self, message: Message) -> str:
-        """Returns the textual content of a message without the author prefix."""
+        """Renders one message's text: its content, or an embed / system-content fallback.
+
+        The bot's own usage footer is stripped from its own messages so the model / token /
+        cost line does not ride back in as part of the answer. The sender prefix is added
+        later, by `_assemble_input_message`.
+        """
         content = message.content
         content_present = bool(content.strip())
         if content and self.bot.user and message.author.id == self.bot.user.id:
@@ -336,8 +342,9 @@ class MessageInputBuilder(BaseModel):
         rather than reusing the Files-API handles `get_attachment_parts` produces. Only
         image sources are collected; non-image files are not editable as images. The
         IMAGE/VIDEO routes run on the image/video model, so the slow model's modality gate
-        is not applied here. The MIME is kept because the native Veo `types.Image` requires
-        it; the IMAGE route drops it via `get_image_source_bytes`.
+        is not applied here. The MIME is kept because omni's `ImageContentParam` requires a real
+        one (an empty mime 400s "Unsupported MIME type: "); the IMAGE route, which needs only the
+        pixels, drops it via `get_image_source_bytes`.
         """
         tasks: list[Coroutine[object, object, tuple[bytes, str]]] = []
         for source in self.collect_attachment_sources(message=message):

--- a/src/discordbot/cogs/gen_reply/link_sources/douyin.py
+++ b/src/discordbot/cogs/gen_reply/link_sources/douyin.py
@@ -171,7 +171,9 @@ async def _fetch_and_upload(
 
     The cap handed to `download` is the Files API's own 2 GB ceiling, so an impossible file is
     refused from its `Content-Length` in seconds instead of consuming the whole media budget.
-    Nothing below that is refused: a full-resolution clip is exactly what the model should see.
+    Nothing below that is refused: it is a fail-fast guard, not a quality lever. Resolution is
+    the separate lever and is already turned down — `AI_INGEST_QUALITY` asks Douyin for its
+    lowest preset, so the bytes that arrive are not the ones the expansion posts to Discord.
     """
     with tempfile.TemporaryDirectory(prefix="douyin-ai-") as download_dir:
         downloader = DouyinDownloader(output_folder=download_dir)

--- a/src/discordbot/cogs/gen_reply/link_sources/threads.py
+++ b/src/discordbot/cogs/gen_reply/link_sources/threads.py
@@ -44,14 +44,15 @@ from discordbot.cogs.gen_reply.attachment.loaders import load_image_bytes
 if TYPE_CHECKING:
     from openai.types.responses.response_input_image_param import ResponseInputImageParam
 
-# Cap on media parts injected for the linked post, mirroring the parse_threads cog's
-# 10-embed ceiling so a huge carousel cannot bloat the answer input — and, now that each
-# part costs a fetch plus an upload, cannot blow the media budget either.
+# Cap on media parts injected for the whole block, shared by the linked post and the post it
+# quotes (`_media_plan` splits it, target first). Mirrors the parse_threads cog's 10-embed
+# ceiling so a huge carousel cannot bloat the answer input — and, now that each part costs a
+# fetch plus an upload, cannot blow the media budget either.
 MAX_THREADS_MEDIA_PARTS = 10
 
 # Cap on posts rendered from a reply chain, mirroring the cog's deep-chain trim
-# (`results[-max_embeds:]`): a linked reply deep in a long Threads thread would otherwise
-# render every ancestor's text and bloat or overflow the answer input. The chain is
+# (`results[-_MAX_EMBEDS_PER_MESSAGE:]`): a linked reply deep in a long Threads thread would
+# otherwise render every ancestor's text and bloat or overflow the answer input. The chain is
 # ordered oldest-first, so the tail keeps the target plus its nearest ancestors.
 MAX_THREADS_POSTS = 6
 
@@ -346,12 +347,13 @@ def _reply_label(*, post: ThreadsOutput, depth: int, target_author: str) -> str:
 
 
 def _reply_media_note(*, post: ThreadsOutput) -> str:
-    """Notes the media a comment carries, which is never fetched (only the target's is).
+    """Notes the media a comment carries, which is never fetched.
 
-    Without it a picture-only comment renders as a blank body, which reads as an empty comment
-    rather than as one whose content the model simply did not receive. Never inverted into a
-    "this comment has no media" claim: a comment the page serialises without media URLs is not
-    the same thing as a comment that had none.
+    `_media_plan` ingests the target's media and that of the post it quotes; a comment's is
+    never among them. Without this note a picture-only comment renders as a blank body, which
+    reads as an empty comment rather than as one whose content the model simply did not
+    receive. Never inverted into a "this comment has no media" claim: a comment the page
+    serialises without media URLs is not the same thing as a comment that had none.
     """
     counts = [
         f"{len(urls)} {noun}"

--- a/src/discordbot/cogs/gen_reply/markers.py
+++ b/src/discordbot/cogs/gen_reply/markers.py
@@ -5,9 +5,10 @@ The answer model wraps the parts of its reply it wants read aloud in `<generate-
 but they STAY in the visible reply (only the tags are stripped). It may also wrap short
 descriptions in `<generate-image>...</generate-image>` to have images generated and attached, one
 `<generate-music>...</generate-music>` description to have a music clip generated and attached, or
-one `<generate-video>...</generate-video>` description to have a short video generated and attached;
-each such block (tags AND content) is REMOVED from the visible reply so the generation prompt never
-leaks into chat. `ResponseStreamer` extracts them at finalize time via `extract_inline_markers` and
+one `<generate-video>...</generate-video>` description to have a short video generated and
+attached, or one `<deep-research>...</deep-research>` brief to launch a research thread; each such
+block (tags AND content) is REMOVED from the visible reply so the generation prompt never leaks
+into chat. `ResponseStreamer` extracts them at finalize time via `extract_inline_markers` and
 scrubs partial/complete tags from the live preview via `scrub_markers_for_preview`, so none flickers
 mid-stream. The asymmetry is deliberate: voice content is meant to stay visible, image / music /
 video content are meant to be pulled.
@@ -38,8 +39,8 @@ DEEP_RESEARCH_CLOSE = "</deep-research>"
 # 10-attachment ceiling. The prompt tells the model this limit; the streamer enforces it by
 # dropping any extra blocks so a confused model never blows past the attachment cap. A reply
 # may also carry one music clip and one video clip (each single per reply by design), so a rare
-# voice + music + video + 9 images would be 12 attachments; the streamer's
-# `[:DISCORD_ATTACHMENT_LIMIT]` clamp is the backstop.
+# voice + music + video + 9 images would be 12 attachments; `MediaDeliveryPlanner.plan`'s
+# attachment-count clamp is the backstop, dropping the trailing overflow.
 MAX_INLINE_IMAGES = 9
 
 # Complete blocks: non-greedy, DOTALL so a multi-line segment is captured, IGNORECASE so a

--- a/src/discordbot/cogs/gen_reply/prompts.py
+++ b/src/discordbot/cogs/gen_reply/prompts.py
@@ -1,3 +1,8 @@
+"""Runtime prompt text for the reply pipeline, sent verbatim to the models.
+
+Every string here is model input, not documentation: a wording change is a behavior change.
+"""
+
 from discordbot.cogs.gen_reply.markers import (
     IMAGE_OPEN,
     MUSIC_OPEN,
@@ -122,7 +127,8 @@ VIDEO_INSTRUCTION = f"""
     * Never mention the tags and never wrap them in backticks or a code block.
 """
 
-# Appended to the QA system prompt only when deep research is enabled (kill-switch on, QA route).
+# Appended to the QA system prompt only when deep research can actually run (kill-switch on,
+# direct Gemini key present, QA route).
 # Kept out of REPLY_PROMPT for the same reason as INLINE_IMAGE_INSTRUCTION: a deployment with
 # DEEP_RESEARCH_ENABLED=false must not be told about a marker the streamer would strip with no effect.
 DEEP_RESEARCH_INSTRUCTION = f"""
@@ -232,9 +238,9 @@ Output ONLY the final image prompt text. Nothing else.
 
 # Director instructions for the VIDEO route: the image prompt's video twin, faithful about WHAT is
 # in the clip but allowed restrained, fitting cinematography (single continuous shot, gentle camera,
-# suitable light/mood) per omni's prompt guide. Unlike `IMAGE_PROMPT` it carries NO default aesthetic
-# (the visual style is left entirely to the model); it keeps only the spoken-language order for any
-# dialogue (Chinese first, Japanese second, English only on explicit request). Run by
+# suitable light/mood) per omni's prompt guide. Like `IMAGE_PROMPT` it carries NO default aesthetic
+# (the visual style is left entirely to the model); what it adds on top is the spoken-language order
+# for any dialogue (Chinese first, Japanese second, English only on explicit request). Run by
 # `PromptGenerator.refine` with grounding tools; the edit path skips the director entirely.
 VIDEO_PROMPT = """
 You are an expert video prompt engineer working behind a Discord bot. A user asked the bot to create a short video. Your job is NOT to make the video and NOT to chat with the user. Your only job is to restate the user's request as ONE clear, self-contained prompt that a downstream text-to-video model will render directly. You are faithful about WHAT is in the clip: you never invent subjects, characters, props, settings, actions, events, on-screen text, or audio the user did not state. You MAY add restrained, fitting cinematography (a single continuous shot, a gentle camera move, and lighting / mood that simply suit the stated subject), because this downstream model renders its best results with a little scene, camera, and lighting direction — but keep it minimal and never let it smuggle in content or a storyline.

--- a/src/discordbot/cogs/gen_reply/streaming.py
+++ b/src/discordbot/cogs/gen_reply/streaming.py
@@ -128,7 +128,10 @@ class ResponseStreamer(BaseModel):
     )
     input_builder: SkipValidation[MessageInputBuilder | None] = Field(
         default=None,
-        description="Loads the message's uploaded image bytes so an inline <generate-image> can edit them.",
+        description=(
+            "Loads the message's uploaded images so an inline <generate-image> edits them and an "
+            "inline <generate-video> references them."
+        ),
     )
     music_generator: SkipValidation[MusicGenerator | None] = Field(
         default=None,
@@ -426,10 +429,11 @@ class ResponseStreamer(BaseModel):
         cost = input_rate * self.input_tokens + output_rate * self.output_tokens
 
         self.stored_content = CODED_MENTION_RE.sub(r"\1", self.stored_content)
-        # The answer model may wrap a <generate-voice> segment (spoken aloud, kept in the reply) and an
-        # <generate-image> block (a generation request, removed from the reply). Extract both before the
-        # footer is built or anything is written. The <generate-voice> segment stays in the visible text;
-        # only it (not the whole reply) feeds the spoken clip so the audio matches what is read.
+        # The answer model may wrap <generate-voice> segments (spoken aloud, kept in the reply) plus
+        # <generate-image> / <generate-music> / <generate-video> / <deep-research> blocks (requests,
+        # removed from the reply). Extract them all before the footer is built or anything is
+        # written. The <generate-voice> segments stay in the visible text; only they (not the whole
+        # reply) feed the spoken clip so the audio matches what is read.
         markers = extract_inline_markers(text=self.stored_content)
         self.stored_content = markers.cleaned_text
         self.voice_requested = markers.voice_requested
@@ -458,7 +462,8 @@ class ResponseStreamer(BaseModel):
                 memory_line = f"\n-# <:tag:1517563887573143595> {', '.join(names[:2])} 等 {len(names)} 人的記憶"
             else:
                 memory_line = f"\n-# <:tag:1517563887573143595> {', '.join(names)} 的記憶"
-        # Footer format must stay matchable by `input.USAGE_FOOTER_RE`; the ⬆/⬇ icons are its anchor.
+        # Footer format must stay matchable by `utils/llm_transcript.py::USAGE_FOOTER_RE`; the
+        # ⬆/⬇ icons are its anchor.
         model_label = (
             f"{self.model_name} ({self.model_effort})" if self.model_effort else self.model_name
         )
@@ -555,11 +560,11 @@ class ResponseStreamer(BaseModel):
             # Nothing to say (the segment was empty after stripping): no hint.
             return None
         if clip.outcome is VoiceOutcome.TIMEOUT:
-            # synthesize() logged the timeout; cue the user that the clip ran out of time.
+            # generate() logged the timeout; cue the user that the clip ran out of time.
             await self._hint_media_unavailable(emoji="⏱️")
             return None
         if clip.audio is None:
-            # Any other synthesis failure (most often a policy refusal); synthesize() logged it.
+            # Any other synthesis failure (most often a policy refusal); generate() logged it.
             await self._hint_media_unavailable(emoji="⚠️")
             return None
         return MediaItem(source=clip.audio, filename=VOICE_REPLY_FILENAME)
@@ -735,8 +740,9 @@ class ResponseStreamer(BaseModel):
         (one edit, because `edit` replaces the attachment list). Anything too big to upload (a
         long voice WAV in a DM, or almost any video clip) is hosted on the external static server
         and its URL appended to the reply instead of being dropped; if hosting is unavailable it
-        degrades to today's drop + ⚠️ hint. Voice/music/video are ordered first so the rare
-        over-cap overflow peels a trailing image, not a clip.
+        degrades to the drop + ⚠️ hint. Voice/music/video are ordered first because the planner
+        applies Discord's attachment-count cap to the tail, so the rare over-cap overflow drops a
+        trailing image rather than a clip.
         """
         if self._reply_deleted:
             # There is no message left to attach to, and the user removed it themselves, so a

--- a/src/discordbot/cogs/log_msg/cog.py
+++ b/src/discordbot/cogs/log_msg/cog.py
@@ -147,7 +147,7 @@ class MessageLogger(BaseModel):
 
     @staticmethod
     def sanitize_text(s: str | None) -> str:
-        """Sanitizes text by removing control characters (null bytes).
+        """Sanitizes text by removing null bytes.
 
         Args:
             s: The string to sanitize.
@@ -289,10 +289,12 @@ class LogMessageCog(commands.Cog):
         """Re-logs message edits so streaming bot replies converge to their final state.
 
         `on_message` only fires on the initial `reply()` call, which for the
-        streaming text path in `cogs/gen_reply/streaming.py` captures only the
-        first ~30 chars. Every subsequent `reply.edit(...)` fires here; the UPSERT on
-        `discord_message_id` collapses them into a single row whose content
-        matches what is actually on Discord.
+        streaming text path in `cogs/gen_reply/streaming.py` usually carries the
+        transient reasoning preview rather than the answer (a stream that finishes
+        before the first preview tick creates the reply complete instead, and never
+        reaches here). Every subsequent `reply.edit(...)` fires
+        here; the UPSERT on `discord_message_id` collapses them into a single row
+        whose content matches what is actually on Discord.
 
         Args:
             _before: The pre-edit message snapshot (unused; only `after.id`

--- a/src/discordbot/cogs/maplestory/__init__.py
+++ b/src/discordbot/cogs/maplestory/__init__.py
@@ -1,5 +1,6 @@
 """MapleStory cog package.
 
 This package contains the MapleStory cog for the Discord bot, providing
-commands to look up monster, equipment, NPC, quest, and map data for Artale.
+commands to look up monster, equipment, scroll, NPC, quest, map and item data
+for Artale, plus statistics about the local dataset.
 """

--- a/src/discordbot/cogs/maplestory/cog.py
+++ b/src/discordbot/cogs/maplestory/cog.py
@@ -53,7 +53,7 @@ class MapleStoryCogs(commands.Cog):
         self.service = MapleStoryService.from_directory(data_dir)
 
     def _ensure_data(self) -> bool:
-        """Ensures that game data is loaded."""
+        """Reloads from disk once when nothing is loaded, and reports the result."""
         if self.service.has_data():
             return True
         self.service.reload(self.data_dir)
@@ -71,7 +71,7 @@ class MapleStoryCogs(commands.Cog):
         return self._translate(category="misc", name=item)
 
     async def _send_error(self, interaction: Interaction[commands.Bot]) -> None:
-        """Sends a generic error message to the user."""
+        """Tells the user the local dataset could not be loaded."""
         embed = Embed(
             title=":x: 錯誤", description="無法載入資料，請聯絡管理員", color=_ERROR_COLOR
         )
@@ -98,7 +98,11 @@ class MapleStoryCogs(commands.Cog):
         },
     )
     async def maplestory(self, interaction: Interaction[commands.Bot]) -> None:
-        """Slash command group for MapleStory Artale data queries."""
+        """Slash command group for MapleStory Artale data queries.
+
+        Never invoked: nextcord dispatches the subcommands directly, so this
+        docstring is the whole body and removing it is a SyntaxError.
+        """
 
     # ── /maplestory monster ─────────────────────────────────────────
 

--- a/src/discordbot/cogs/maplestory/embeds.py
+++ b/src/discordbot/cogs/maplestory/embeds.py
@@ -43,7 +43,9 @@ class TranslateFn(Protocol):
             name: Source name to translate.
 
         Returns:
-            The translated name, or an implementation-defined fallback.
+            The translated name, or `name` unchanged when the category holds no
+            entry for it. Callers detect a miss by comparing the result against
+            the name they passed in.
         """
         ...
 
@@ -59,7 +61,11 @@ def _truncate(text: str, limit: int = 1024) -> str:
 
 
 def _translate_map_name(name: str, translate: TranslateFn) -> str:
-    """Translate composite map names like 'Amherst > Weapon Store'."""
+    """Translates a composite map name like 'Rainbow Street: Amherst > Weapon Store'.
+
+    The translation table keys each half separately, so the whole string never
+    resolves on its own.
+    """
     parts = [translate(category="maps", name=p.strip()) for p in name.split(" > ")]
     return " > ".join(parts)
 

--- a/src/discordbot/cogs/maplestory/service.py
+++ b/src/discordbot/cogs/maplestory/service.py
@@ -31,8 +31,10 @@ def _load_json[T: BaseModel](path: Path, model: type[T]) -> list[T]:
             _exc_info=exc,
         )
     except (json.JSONDecodeError, ValidationError, OSError, UnicodeDecodeError, TypeError) as exc:
-        # TypeError covers a JSON document that parses but is not a list, which
-        # would otherwise escape into the synchronous cog load and kill startup.
+        # A JSON document that is not a list still has to be caught here or it
+        # escapes into the synchronous cog load and kills startup: a bare scalar
+        # or null raises TypeError from the iteration, while a dict or a string
+        # reaches model_validate and raises ValidationError.
         logfire.error(
             "failed to load maplestory data",
             path=str(path),
@@ -135,7 +137,9 @@ class MapleStoryService(BaseModel):
         """Checks if the service has loaded data.
 
         Returns:
-            True if data is loaded, False otherwise.
+            True if monsters are loaded. Monsters stand in for every category, so
+            a load where only monsters.json failed reports False while one where
+            only monsters.json succeeded reports True.
         """
         return bool(self._monsters)
 
@@ -444,7 +448,9 @@ class MapleStoryService(BaseModel):
             query: The search query string.
 
         Returns:
-            A sorted list of matching item names.
+            A sorted list of matching source item names. A Chinese query matches
+            through the translation table, but the untranslated name is returned,
+            since that is the key monster drops are recorded under.
         """
         key = query.lower()
         if key not in self._item_cache:
@@ -513,7 +519,9 @@ class MapleStoryService(BaseModel):
         """Gets a list of item names sorted by drop popularity.
 
         Returns:
-            A list of item names, sorted by the number of monsters that drop them.
+            A list of item names, sorted descending by how many drop entries name
+            them. A monster listing one item under two drop categories counts
+            twice, so this is close to but not exactly a monster count.
         """
         counts: dict[str, int] = {}
         for m in self._monsters:

--- a/src/discordbot/cogs/media_cleanup/cog.py
+++ b/src/discordbot/cogs/media_cleanup/cog.py
@@ -1,7 +1,7 @@
 """Periodically reaps hosted media so the serve dir stays bounded by size and age.
 
 Each publish enforces the size cap eagerly; this cog is the backstop that also applies the age cap
-and clears crash-left temp files, on a timer and once at startup (to catch a restart). It self-
+and clears crash-left temp files, on a timer whose first iteration fires at startup. It self-
 disables when hosting is unavailable or both caps are off, so it never starts the loop or touches
 the serve dir then. The sweep only ever deletes the bot's own content-addressed files (see
 `MediaHostingService`), never a foreign file parked in the serve dir.
@@ -42,9 +42,9 @@ class MediaCleanupCogs(commands.Cog):
     async def on_ready(self) -> None:
         """Starts the cleanup loop once, only when hosting and at least one cap are configured.
 
-        `on_ready` fires on every reconnect, so `_started` guards a single start. The loop fires only
-        after the first interval, so a startup sweep is spawned immediately to catch a restart. When
-        cleanup is disabled the loop never starts and nothing in the serve dir is touched.
+        `on_ready` fires on every reconnect, so `_started` guards a single start; a one-off startup
+        sweep is spawned beside the loop. When cleanup is disabled neither runs and nothing in the
+        serve dir is touched.
         """
         if self._started:
             return

--- a/src/discordbot/cogs/memory/cog.py
+++ b/src/discordbot/cogs/memory/cog.py
@@ -303,7 +303,8 @@ class MemoryCogs(commands.Cog):
             )
             await interaction.response.send_message(embed=embed, ephemeral=True)
             return
-        # The rebuild is one whole-file LLM rewrite that runs far past Discord's
+        # The rebuild is one LLM call per non-empty compartment plus one for the tone
+        # note, and runs far past Discord's
         # ack window, so it is dispatched to the background task queue and the
         # command replies immediately; the user checks back with `/memory show`.
         scheduled = schedule_memory_regeneration(

--- a/src/discordbot/cogs/memory/views.py
+++ b/src/discordbot/cogs/memory/views.py
@@ -1,4 +1,4 @@
-"""Views and embed builders for the /memory show and /memory clear commands."""
+"""Views and embed builders for /memory show, /memory server show and /memory clear."""
 
 from typing import cast
 import contextlib
@@ -85,7 +85,7 @@ def memory_footer_text(pending_count: int) -> str:
 def build_memory_embed(
     page_text: str, page_index: int, page_count: int, footer_text: str, title: str
 ) -> Embed:
-    """Builds one /memory show embed page with the shared footer."""
+    """Builds one memory embed page with the shared footer, for either show command."""
     embed = Embed(title=title, description=page_text, color=MEMORY_EMBED_COLOR)
     footer = footer_text
     if page_count > 1:
@@ -234,7 +234,7 @@ class MemoryClearConfirmView(View):
 
 
 class MemoryPagesView(View):
-    """Ephemeral pagination view for an oversized personal memory embed.
+    """Ephemeral pagination view for an oversized memory embed, personal or per-server.
 
     Attributes:
         pages: Pre-split page texts, each within one embed description.

--- a/src/discordbot/cogs/parse_douyin/cog.py
+++ b/src/discordbot/cogs/parse_douyin/cog.py
@@ -8,9 +8,10 @@ Expansion is skipped when the message is addressed to the bot (a DM, or an expli
 mention): `gen_reply` reads the linked post and answers about it, so expanding as well would
 fetch the same media twice and post an attachment nobody asked for. The two paths are
 mutually exclusive, and `is_addressed_to_bot` is the single predicate deciding which runs.
-One link therefore costs one clip download, which matters here more than anywhere, since the
-WAF below bans on volume. Handing the model the play URL instead saves nothing on the path
-the reply takes: the proxy fetches it and inlines it rather than forwarding it.
+One message carrying a link therefore costs one clip download, which matters here more than
+anywhere, since the WAF below bans on volume. Handing the model the play URL instead saves
+nothing on the path the reply takes: the proxy fetches it and inlines it rather than
+forwarding it.
 
 That predicate is deliberately coarser than `gen_reply`'s own guards, so a few addressed
 messages get neither treatment: one typed inside an active research thread (the reply
@@ -73,6 +74,8 @@ class DouyinCogs(commands.Cog):
         bot: The Discord bot instance that owns this cog.
         config: Runtime configuration carrying the auto-expansion kill-switch.
         media_delivery: Planner deciding which files attach and which are hosted as a URL.
+        downloader_factory: Builds the per-invocation downloader, one per scratch directory;
+            the seam a test replaces to keep an expansion off the network.
     """
 
     # A retryable block gets its own reaction so it never reads like the ⚠️ "could not read

--- a/src/discordbot/cogs/parse_threads/cog.py
+++ b/src/discordbot/cogs/parse_threads/cog.py
@@ -207,6 +207,7 @@ class ThreadsCogs(commands.Cog):
         bot: The Discord bot instance that owns this cog.
         output_folder: Directory where downloaded Threads media is stored.
         downloader: Downloader used to parse Threads posts and fetch media.
+        media_delivery: Planner deciding whether a downloaded video is attached, hosted or dropped.
     """
 
     def __init__(self, bot: commands.Bot):
@@ -304,7 +305,10 @@ class ThreadsCogs(commands.Cog):
         chain_depth: int,
         quoted_index: int,
     ) -> set[int]:
-        """Selects complete posts by relevance until the message-wide text budget is full."""
+        """Selects complete posts by relevance until the message-wide text budget is full.
+
+        The target is kept whatever its own text costs; every other post has to fit.
+        """
         selected: set[int] = set()
         text_budget = _EMBED_TOTAL_LENGTH_LIMIT
         for index in priority:
@@ -647,7 +651,7 @@ class ThreadsCogs(commands.Cog):
                 # appended by `_build_post_embeds` AFTER any check on the raw body, so a text
                 # sitting just under the limit crossed it and turned a ⚠️ skip into a Discord 400
                 # and a ❌. A body past the limit cannot be rescued by hosting, so it stays the ⚠️
-                # refusal. (Image count is not guarded: _build_embeds caps the message at 10
+                # refusal. (Image count is not guarded: _build_embed_plan caps the message at 10
                 # embeds and shows as many images as fit.)
                 longest_text = max(
                     (_utf16_length(value=embed.description or "") for embed in embeds), default=0

--- a/src/discordbot/cogs/research/agent.py
+++ b/src/discordbot/cogs/research/agent.py
@@ -3,7 +3,7 @@
 The one research agent (`antigravity-preview-05-2026`) runs through an injected `genai.Client`
 that talks DIRECT to Google (`gemini_api_key`, no proxy): a managed agent rides the native
 Interactions API, which this project always calls direct rather than through the LiteLLM proxy's
-interactions transform. Every call uses `background=True` + `store=True` + `stream=True`, so the
+interactions transform. The create uses `background=True` + `store=True` + `stream=True`, so the
 agent's reasoning streams live to the thread (`_StreamDriver` + `ResearchProgressStreamer`) while
 it works.
 
@@ -17,7 +17,9 @@ last_event_id=...)`. The final result is ALWAYS read through `_poll_until_termin
 non-stream `interactions.get(id)` with retry-on-error): the streamed deltas are the live view
 only, `interaction.completed` carries no report body on purpose, and the poll both settles a run
 whose stream died and waits out any brief `in_progress` visibility lag, then `_to_result` maps it.
-These functions can raise (network errors, `TimeoutError`); the cog maps failure to a friendly message.
+There is no wall-clock timeout anywhere here, so what escapes is either the SDK error from a create
+or a poll that never recovered, or a `RuntimeError` when the stream ended before any interaction id
+existed; the cog maps both to a friendly message.
 """
 
 import time
@@ -59,7 +61,9 @@ RESEARCH_POLL_INTERVAL_SECONDS = 15.0
 # bounds each request and the agent settles server-side on its own budget.
 MAX_CONSECUTIVE_POLL_ERRORS = 30
 
-# Reports progress to the thread: (latest thought summary or None, elapsed seconds).
+# `_poll_until_terminal`'s optional progress hook: (latest thought summary or None, elapsed
+# seconds). Nothing passes one today -- the live view is the streamer's, and the only call site
+# polls with `on_progress=None` -- so `_latest_thought` is unreached outside its tests.
 type ProgressCallback = Callable[[str | None, float], Awaitable[None]]
 
 

--- a/src/discordbot/cogs/research/cog.py
+++ b/src/discordbot/cogs/research/cog.py
@@ -91,6 +91,11 @@ class ResearchCogs(commands.Cog):
     """Owns the deep-research thread lifecycle, slash command, and restart resume."""
 
     def __init__(self, bot: commands.Bot) -> None:
+        """Initializes the research cog.
+
+        Args:
+            bot: The Discord bot instance.
+        """
         self.bot = bot
         self.config = LLMConfig()
         self.runtime_models = RuntimeModelCatalog()
@@ -108,9 +113,11 @@ class ResearchCogs(commands.Cog):
         """The Gemini Interactions client, built lazily on first use.
 
         DIRECT to Google (`gemini_api_key`, no base_url / proxy): a managed agent rides the native
-        Interactions API, which this project always calls direct. Built inline here (not via a
-        `utils/llm.py` factory) so no new factory caller is added. A missing key does not fail
-        construction; it surfaces at the first interaction call, which the run loop catches.
+        Interactions API, which this project always calls direct. Built inline like every other
+        direct-to-Google path (the `create_*_client` factories are gone). `genai.Client` raises
+        `ValueError` on a missing key rather than deferring it to the first call (measured), and
+        both run loops read this property inside their own try, so that raise still lands as a
+        thread failure notice instead of an unhandled background-task error.
         """
         return genai.Client(api_key=self.config.gemini_api_key)
 
@@ -118,8 +125,9 @@ class ResearchCogs(commands.Cog):
     def responses_client(self) -> AsyncOpenAI:
         """The LiteLLM-proxy Responses client for small side calls (the thread-title generator).
 
-        Built inline (no `utils/llm.py` factory) per the no-new-factory convention; distinct from
-        the direct `interactions_client` since a plain Responses call rides the proxy fine.
+        Built inline like every other client here (there is no `utils/llm.py` client factory left);
+        distinct from the direct `interactions_client` since a plain Responses call rides the proxy
+        fine.
         """
         return AsyncOpenAI(base_url=self.config.base_url, api_key=self.config.api_key)
 
@@ -390,7 +398,12 @@ class ResearchCogs(commands.Cog):
         agent: str,
         status: Message | None,
     ) -> None:
-        """Delivers a terminal result, finalizes the opening status message, and records the phase."""
+        """Delivers a terminal result, records its phase, and releases the thread.
+
+        On a completed run the opening status message is spent by `deliver_report`, which edits the
+        report's first chunk into it; any other terminal status finalizes it with a failure line
+        instead.
+        """
         if not result.ok:
             await self._post_failure(
                 thread=thread,

--- a/src/discordbot/cogs/research/database.py
+++ b/src/discordbot/cogs/research/database.py
@@ -2,15 +2,16 @@
 
 One row per launched research thread. The row lets a bot restart resume an
 in-flight research: the Gemini interaction runs server-side with `store=True`,
-so after a restart the cog reloads the rows still in `researching` and re-enters
-the poll loop on each `interaction_id`. It is also the per-user concurrency
+so after a restart the cog reloads the rows still in `researching` and re-attaches
+a live stream to each `interaction_id`. It is also the per-user concurrency
 guard (one active research per owner).
 
 The engine is a module-level `AsyncEngine` singleton, exactly like
 `services/economy/database.py`: a per-instance `cached_property` engine would leak
 the connection pool / dialect cache for every interaction. `reply.db` is the
-shared file for reply-side persistence (research today, room for more later);
-it has no money columns, so no `StoredInteger`. Each call opens an `AsyncSession`
+shared file for reply-side persistence (this table plus the memory pipeline's
+phase-1 inbox in `services/memory/database.py`, which keeps its own engine on the
+same file); it has no money columns, so no `StoredInteger`. Each call opens an `AsyncSession`
 bound to the current `_engine`, so tests can monkeypatch `_engine` per-test.
 
 This module deliberately avoids `from __future__ import annotations`: SQLAlchemy
@@ -68,8 +69,9 @@ class ResearchSessionRow(Base):
     Attributes:
         thread_id: Discord thread ID; primary key.
         owner_id: Discord user ID that launched the research.
-        channel_id: Parent channel ID (the thread's parent, or the DM-fallback channel).
-        guild_id: Guild ID, or `None` for a DM-fallback session with no thread.
+        channel_id: The thread's parent channel ID.
+        guild_id: Guild ID. Nullable in the schema, but never written `None`: a launch outside a
+            guild text channel is refused before any row exists.
         source_message_id: The message the thread was anchored to.
         agent: The Gemini agent string currently running this session.
         interaction_id: The running interaction's id; `None` before it starts.
@@ -103,8 +105,10 @@ class PersistentResearchSession(BaseModel):
 
     thread_id: int = Field(..., description="Discord thread ID; primary key.")
     owner_id: int = Field(..., description="Discord user ID that launched the research.")
-    channel_id: int = Field(..., description="Parent channel ID for the thread or DM fallback.")
-    guild_id: int | None = Field(..., description="Guild ID, or None for a DM-fallback session.")
+    channel_id: int = Field(..., description="Parent channel ID the thread hangs off.")
+    guild_id: int | None = Field(
+        ..., description="Guild ID; nullable in the schema but never written None."
+    )
     source_message_id: int = Field(..., description="The message the thread was anchored to.")
     agent: str = Field(..., description="The Gemini agent string currently running this session.")
     interaction_id: str | None = Field(

--- a/src/discordbot/cogs/research/delivery.py
+++ b/src/discordbot/cogs/research/delivery.py
@@ -1,11 +1,12 @@
 """Posts a finished research report body into its Discord thread.
 
 The report is long cited markdown. It is delivered two ways at once so nothing is
-lost: chunked inline messages (split on paragraph boundaries so citations and
-headings survive) for in-thread readability, plus the full report as a `research.md`
-File attachment (the durable artifact). A generated chart, if any, rides a follow-up
-message. Every send is best-effort. The completion line (usage footer, owner ping) is
-owned by the cog, which edits the opening status message.
+lost: chunked inline messages (split on `---` sections, then paragraph boundaries, so
+citations and headings survive) for in-thread readability, plus the full report as a
+`research.md` File attachment (the durable artifact). A generated chart, if any, rides
+the same message as that attachment. Every send is best-effort. The cog supplies the
+completion line's parts (usage footer, owner ping); this module places them on the
+last chunk, having spent the opening status message on the first.
 """
 
 from typing import TYPE_CHECKING

--- a/src/discordbot/cogs/research/streaming.py
+++ b/src/discordbot/cogs/research/streaming.py
@@ -167,8 +167,8 @@ class ResearchProgressStreamer(BaseModel):
         """Paints reasoning onto the status message until the event stream ends.
 
         Starts the editor up front so the elapsed timer ticks from t=0 even before the first
-        thought, then feeds every event; the editor is always stopped in `finally` so the last
-        snapshot lands before the caller delivers the report on the same message.
+        thought, then feeds every event; the editor is always stopped in `finally` so any
+        in-flight edit lands before the caller delivers the report on the same message.
         """
         self._ensure_editor_started()
         try:

--- a/src/discordbot/cogs/stock/presentation.py
+++ b/src/discordbot/cogs/stock/presentation.py
@@ -172,8 +172,8 @@ def _market_board_spec(
     )
 
 
-# The cache key is the digest of every pixel-affecting quote field, so any quote
-# change yields a new key and a fresh render; stale entries are never served.
+# The cache key is the immutable spec holding every pixel-affecting quote field, so any
+# quote change yields a new key and a fresh render; stale entries are never served.
 @lru_cache(maxsize=128)
 def _build_market_board_image_cached(spec: _MarketBoardSpec) -> bytes:
     """Renders the market list as a fixed-layout PNG board."""
@@ -552,7 +552,7 @@ def _recent_trade_lines(detail: StockDetailViewData) -> str:
 
 
 def _position_summary_lines(detail: StockDetailViewData) -> str:
-    """Formats public non-zero stock positions."""
+    """Formats the public positions that still hold long shares."""
     positions = sorted(
         (position for position in detail.public_positions if position.long_shares > 0),
         key=lambda position: position.long_shares,

--- a/src/discordbot/cogs/stock/views.py
+++ b/src/discordbot/cogs/stock/views.py
@@ -102,7 +102,7 @@ class _StockQuantitySubmission(BaseModel):
 
 
 class StockMarketView(StockPublicView):
-    """Stock select and tutorial controls for the market list."""
+    """Stock select, pagination and tutorial controls for the market list."""
 
     def __init__(
         self, quotes: tuple[StockMarketQuote, ...], owner_id: int, page_index: int = 0
@@ -251,7 +251,7 @@ class StockDetailView(StockPublicView):
     async def news(
         self, _button: Button["StockDetailView"], interaction: Interaction[commands.Bot]
     ) -> None:
-        """Shows recent deterministic news in the public stock message."""
+        """Shows the stock's recent news in the public stock message."""
         news = await get_stock_news(symbol=self.symbol)
         self.stop()
         await edit_owned_public_message(
@@ -523,7 +523,12 @@ async def edit_stock_action_prompt(
 
 
 async def submit_stock_quantity(submission: _StockQuantitySubmission) -> None:
-    """Submits a stock quantity from either a dropdown preset or modal."""
+    """Settles one stock quantity submitted from the quantity modal.
+
+    Re-checks panel ownership: a modal submit is dispatched straight to the modal and
+    never passes through the parent view's `interaction_check`, so this is the only
+    ownership test on the settle path rather than a second one.
+    """
     interaction = submission.interaction
     user = require_stock_user(interaction=interaction)
     if submission.owner_id != user.id:

--- a/src/discordbot/cogs/template/cog.py
+++ b/src/discordbot/cogs/template/cog.py
@@ -29,11 +29,9 @@ class TemplateCogs(commands.Cog):
         Args:
             message: The message that was sent.
         """
-        # 忽略來自機器人的訊息
         if message.author.bot:
             return
 
-        # 如果訊息內容是 "debug"，對該訊息按讚
         if message.content.lower() == "debug":
             await message.add_reaction("🤬")
         if message.content.lower() == "可愛捏":
@@ -58,13 +56,9 @@ class TemplateCogs(commands.Cog):
             interaction: The interaction that triggered the command.
         """
         await interaction.response.defer()
-        bot_latency = round(self.bot.latency * 1000, 2)  # 取得 API 延遲
+        bot_latency = round(self.bot.latency * 1000, 2)
 
-        embed = Embed(
-            title=":ping_pong: Pong!",
-            color=0x00FF00,  # 綠色
-            timestamp=nextcord.utils.utcnow(),
-        )
+        embed = Embed(title=":ping_pong: Pong!", color=0x00FF00, timestamp=nextcord.utils.utcnow())
         embed.add_field(name="Bot Latency", value=f"`{bot_latency}ms`")
         user = interaction.user
         if user is not None:
@@ -77,7 +71,6 @@ class TemplateCogs(commands.Cog):
         )
 
 
-# 註冊 Cog
 def setup(bot: commands.Bot) -> None:
     """Adds the TemplateCogs to the bot.
 

--- a/src/discordbot/cogs/video/cog.py
+++ b/src/discordbot/cogs/video/cog.py
@@ -43,6 +43,7 @@ class VideoCogs(commands.Cog):
 
     Attributes:
         bot: The Discord bot instance that owns this cog.
+        media_delivery: Planner deciding which files attach and which are hosted as a URL.
     """
 
     def __init__(self, bot: commands.Bot):
@@ -365,7 +366,6 @@ class VideoCogs(commands.Cog):
         )
 
 
-# 註冊 Cog
 def setup(bot: commands.Bot) -> None:
     """Adds the VideoCogs to the bot.
 

--- a/src/discordbot/services/economy/database.py
+++ b/src/discordbot/services/economy/database.py
@@ -28,8 +28,9 @@ monkeypatch `_engine` per-test and every subsequent call sees the swap.
 VIP, admin status, and leaderboard visibility are boolean columns on
 `user_account`. VIP bumps daily check-in rewards and the player's winning
 payout from games. The flag is permanent once set. Admin and central-banker
-status gate maintenance-only economy commands and are managed out-of-band by
-scripts. Daily casino counters live on `casino_account` so
+status gate maintenance-only economy commands and are set out-of-band by a
+direct DB write; `set_admin` / `set_central_banker` exist for that path, but
+nothing at runtime calls them. Daily casino counters live on `casino_account` so
 `/loss_leaderboard` can read current-day gross losses without scanning an audit
 log.
 
@@ -186,6 +187,9 @@ class UserAccount(Base):
         checkin_streak: Consecutive-day streak (1..`CHECKIN_STREAK_CYCLE`),
             persisted after the latest `/checkin`. 0 means never checked in.
         is_admin: Whether the user can run Discord-side economy admin commands.
+        is_central_banker: Whether the user can decide central-bank loan
+            proposals and force collection with `/central_bank call`; separate
+            from `is_admin` and set out-of-band.
         hide_from_leaderboard: Whether the account is omitted from public balance
             and daily casino loss leaderboards.
     """
@@ -247,8 +251,10 @@ class CasinoAccount(Base):
 
     __tablename__ = "casino_account"
     __table_args__ = (
-        # /loss_leaderboard filters to one Taipei day and orders by gross loss.
-        # SQLite can read the daily loss suffix backwards for DESC ordering.
+        # /loss_leaderboard filters to one Taipei day, which this index serves.
+        # Its ordering half does not: the counters are decimal text, so the
+        # query sorts by length(daily_loss) first and SQLite falls back to a
+        # temp B-tree for the ORDER BY.
         Index("ix_casino_account_day_loss", "day_started_at", "daily_loss"),
     )
 
@@ -409,8 +415,8 @@ CASINO_LEDGER_ID: Final[str] = "casino"
 
 
 # On-the-house seed amount for each registered jackpot pool. The seed is
-# bookkeeping only — the bot's user_account row is never decremented to fund
-# it, so /casino P&L stays unaffected by the donation. Seeded pools are also
+# bookkeeping only — no wallet and no casino ledger row is debited to fund it,
+# so /casino P&L stays unaffected by the donation. Seeded pools are also
 # topped back up to this amount whenever they are drained.
 _JACKPOT_SEEDS: Final[tuple[tuple[str, int], ...]] = (("dragon_gate", 1_000),)
 
@@ -671,10 +677,11 @@ def _build_signed_delta_upsert(
 ) -> ReturningInsert[tuple[int]]:
     """UPSERT applying a signed `delta` with NO clamp on wallet balance.
 
-    Used for the dealer's house-ledger row, which is allowed to go negative
-    when the casino has paid out more than it took in. `total_earned` /
-    `total_spent` still accumulate gross flows so `/house` can show the
-    direction of the volume, not just the net.
+    Reached only by `adjust_balance(allow_negative=True)`, i.e. the offline
+    `scripts/modify_balance.py --allow-negative` path; the casino's own
+    negative P&L is a `casino_ledger` row, not a wallet. `total_earned` /
+    `total_spent` still accumulate gross flows, so
+    `balance == total_earned - total_spent` holds through a negative balance.
 
     Returns:
         A SQLAlchemy `Insert` with `on_conflict_do_update` and `returning(balance)`.
@@ -894,8 +901,9 @@ async def _apply_signed_delta_in_session(  # noqa: PLR0913 -- session helper nee
 ) -> int:
     """Applies a signed delta without clamping.
 
-    Used for casino-mirror or other ledger rows that may run cumulative
-    negative P&L. Player-side losses use the clamped path instead.
+    Reached only by `adjust_balance(allow_negative=True)`. Player-side losses
+    use the clamped path, and the casino mirror has its own row writer
+    (`_apply_casino_ledger_delta_in_session`).
     """
     await _upsert_user_metadata_in_session(
         session=session, user_id=user_id, name=name, avatar_url=avatar_url, now=now
@@ -1105,8 +1113,8 @@ async def credit_with_repayment(
     Args:
         user_id: Discord user ID receiving the credit.
         name: Last-seen Discord username to store on the account.
-        amount: Gross income amount; must be positive for the repayment
-            path to run.
+        amount: Gross income amount; a non-positive amount credits nothing
+            and returns the current balance.
         avatar_url: Last-seen Discord avatar URL to store when available.
 
     Returns:
@@ -1142,7 +1150,7 @@ async def adjust_balance(
     """Applies an explicit manual balance adjustment.
 
     This is the public maintenance API for scripts and admin tooling. It does
-    does not touch loan contracts or daily casino counters, so leaderboards and
+    not touch loan contracts or daily casino counters, so leaderboards and
     house P&L remain clean.
 
     Args:
@@ -1432,8 +1440,8 @@ async def _apply_jackpot_delta_in_session(
         now: `_database_now()` value pinned for this transaction.
 
     Returns:
-        A tuple containing the pool balance after the write and any automatic
-        replenishment, plus whether the pool was depleted by this write.
+        The pool snapshot after the write and any automatic replenishment,
+        plus whether this write depleted the pool.
     """
     contributed_add = max(delta, 0)
     claimed_add = max(-delta, 0)
@@ -1888,13 +1896,14 @@ async def checkin(user_id: int, name: str, avatar_url: str = "") -> CheckinResul
     """Records a daily check-in and credits the streak-adjusted reward.
 
     Returns `None` when the user has already checked in today (Taipei
-    local date). On first check-in or after a missed day the streak resets
-    to 1; otherwise the streak advances by 1 and cycles back to 1 after
-    reaching `CHECKIN_STREAK_CYCLE`. The reward is computed with
-    `checkin_reward` and persisted alongside the streak counter in the
-    same write. VIP perks (2x base) read the persisted flag inside the
-    same transaction so a freshly-bought VIP immediately applies on the
-    next check-in.
+    local date), and also when the retry budget below is exhausted; the
+    caller cannot tell the two apart. On first check-in or after a missed
+    day the streak resets to 1; otherwise the streak advances by 1 and
+    cycles back to 1 after reaching `CHECKIN_STREAK_CYCLE`. The reward is
+    computed with `checkin_reward` and persisted alongside the streak
+    counter in the same write. VIP perks (2x base) read the persisted flag
+    inside the same transaction so a freshly-bought VIP immediately applies
+    on the next check-in.
 
     The SELECT-then-conditional-UPDATE pattern (gated on the
     observed `last_checkin_at` value) prevents two parallel coroutines
@@ -1909,7 +1918,7 @@ async def checkin(user_id: int, name: str, avatar_url: str = "") -> CheckinResul
 
     Returns:
         `CheckinResult` describing the credit, or `None` when the user
-        already checked in today.
+        already checked in today or the retry budget ran out.
     """
     await _ensure_schema()
     now = _database_now()
@@ -1970,8 +1979,9 @@ async def checkin(user_id: int, name: str, avatar_url: str = "") -> CheckinResul
 async def buy_vip(user_id: int, name: str, avatar_url: str = "") -> VipPurchaseResult | None:
     """Promotes the user to VIP after debiting `VIP_PURCHASE_COST` points.
 
-    Returns `None` when the user is already VIP, has insufficient balance,
-    or the retry budget for the conditional UPDATE was exhausted.
+    Returns `None` when the user is missing either the account or the wallet
+    row, is already VIP, has insufficient balance, or the retry budget for the
+    conditional UPDATE was exhausted.
 
     Args:
         user_id: Discord user ID purchasing VIP.
@@ -2101,10 +2111,10 @@ async def get_admin(user_id: int) -> bool:
 async def set_admin(user_id: int, name: str, is_admin: bool, avatar_url: str = "") -> bool:
     """Sets the economy admin flag for a Discord user.
 
-    Granting admin creates a zero-balance account row if the user has never
-    touched the economy system. Revoking admin updates an existing row only;
-    missing users are left untouched so revoke operations do not create empty
-    account rows.
+    Granting admin creates the `user_account` identity row if the user has
+    never touched the economy system; no wallet row is created, so the balance
+    still reads 0. Revoking admin updates an existing row only; missing users
+    are left untouched so revoke operations do not create empty account rows.
 
     Args:
         user_id: Discord user ID to modify.
@@ -2184,7 +2194,15 @@ async def get_central_banker(user_id: int) -> bool:
 async def set_central_banker(
     user_id: int, name: str, is_central_banker: bool, avatar_url: str = ""
 ) -> bool:
-    """Sets the central banker flag for a Discord user."""
+    """Sets the central banker flag for a Discord user.
+
+    Mirrors `set_admin`: granting creates the identity row when missing, while
+    revoking touches an existing row only.
+
+    Returns:
+        `True` when a row was created or updated; `False` when revoking a
+        missing user.
+    """
     await _ensure_schema()
     now = _database_now()
     effective_name = name or str(user_id)
@@ -2361,11 +2379,12 @@ async def top_n(
 ) -> list[LeaderboardEntry]:
     """Returns accounts ordered by balance descending.
 
-    `exclude_user_ids` filters out specific accounts (notably the bot's
-    own house ledger row) before applying the limit, so the leaderboard
-    always shows real players. Stored integer values are sorted in SQL with
-    explicit decimal-text aware order terms so the query can still apply
-    `LIMIT` before rows reach Python.
+    Hidden accounts are the only thing dropped by default (`include_hidden`).
+    Neither production caller passes `exclude_user_ids`: the bot is an ordinary
+    player here and the casino's own P&L is a `casino_ledger` row, not a
+    wallet. Stored integer values are
+    sorted in SQL with explicit decimal-text aware order terms so the query
+    can still apply `LIMIT` before rows reach Python.
 
     Args:
         limit: Maximum number of accounts to return, or `None` to return all

--- a/src/discordbot/services/memory/constants.py
+++ b/src/discordbot/services/memory/constants.py
@@ -34,10 +34,12 @@ MEMORY_REGENERATION_COOLDOWN_SECONDS = 600.0
 # latency.
 MEMORY_GLOBAL_CONCURRENCY = 24
 
-# Past the trigger, consolidation is told to run a deep-summarization (compaction)
-# pass over the compartment it is rewriting, aiming at roughly the target size.
-# Compaction merges low-signal and stale facts; it never drops durable memory
-# outright, and fine-grained evidence survives in the detail file regardless.
+# Past the trigger (measured on the compartment's own rendered facts), consolidation
+# is told to spend the pass compacting it toward the target size. Compaction folds
+# overlapping facts together and condenses low-signal ones rather than summarizing the
+# set. A well-supported durable fact is merged or tightened, never dropped outright; what it
+# drops first is the unsupported, weak, stale and one-off, and fine-grained evidence survives
+# in the detail file regardless.
 COMPACTION_TRIGGER_CHARS = 30_000
 COMPACTION_TARGET_CHARS = 15_000
 

--- a/src/discordbot/services/memory/database.py
+++ b/src/discordbot/services/memory/database.py
@@ -97,7 +97,9 @@ class MemoryJobRow(Base):
         flavor: ``user`` or ``server`` so the restart sweep picks the matching extractor.
         subject: The phase-1 directive naming the target (``target_user_id: <id>`` etc.).
         transcript: The rendered phase-1 input; set to NULL once the turn is ``done``.
-        identity: Single-line identity stamped into main.md, persisted so resume needs no Discord context.
+        identity: Single-line identity ``parse_identity`` splits into the ``owner_id`` /
+            ``owner_name`` stamped on every fact this scope writes; persisted so a resume
+            needs no Discord context.
         status: Lifecycle status (see ``MemoryJobStatus``).
         token: Logical version / ordering token; guards newest-wins and the terminal update.
         last_error: Bounded failure blurb when ``status='failed'``.
@@ -139,7 +141,7 @@ class MemoryJob(BaseModel):
     transcript: str | None = Field(
         ..., description="The rendered phase-1 input, or None once the turn is done."
     )
-    identity: str = Field(..., description="Single-line identity stamped into main.md.")
+    identity: str = Field(..., description="Single-line identity stamped onto the scope's facts.")
     status: MemoryJobStatus = Field(..., description="Lifecycle status of the turn.")
     token: int = Field(..., description="Logical version / ordering token.")
     last_error: str | None = Field(..., description="Bounded failure blurb when failed.")
@@ -150,7 +152,7 @@ _schema_lock = LoopLocalLock()
 
 
 async def _ensure_schema() -> None:
-    """Bootstraps the `memory_job` table once per engine (loop-local-locked)."""
+    """Bootstraps this module's tables once per engine (loop-local-locked)."""
     global _schema_ready_for  # noqa: PLW0603 -- module-level cache by engine identity
     ensure_sqlite_hooks(
         engine=_engine,

--- a/src/discordbot/services/memory/deltas.py
+++ b/src/discordbot/services/memory/deltas.py
@@ -71,6 +71,7 @@ class DeltaOutcome(BaseModel):
         deleted: Facts removed.
         dropped: Deltas refused individually (unknown section, empty body, bad id).
         rejected: Why the whole batch was refused, or "" when it was applied.
+        written: Ids this batch created or updated, so a rebuild can drop the rest.
     """
 
     model_config = ConfigDict(frozen=True)

--- a/src/discordbot/services/memory/extraction.py
+++ b/src/discordbot/services/memory/extraction.py
@@ -1,4 +1,8 @@
-"""LLM extraction and consolidation for per-user long-term memory."""
+"""LLM extraction and consolidation for long-term memory, in either flavor.
+
+The phase prompts ride on `MemoryExtractorAI` as fields, so the per-user and the
+per-server memory share every gate, renderer and redaction here.
+"""
 
 import re
 from typing import TYPE_CHECKING, TypeVar, cast
@@ -264,8 +268,7 @@ class ConsolidationRequest(BaseModel):
     raw_entries: str = Field(..., description="This compartment's share of the raw batch.")
     recent_detail: str = Field(..., description="Cold evidence filtered to this compartment.")
     tone_evidence: str = Field(
-        default="",
-        description="Unpartitioned tone signal; global-only, and for the tone note alone.",
+        default="", description="Unpartitioned tone signal; carried only by the tone-note call."
     )
     global_reference: str = Field(
         default="",
@@ -412,8 +415,9 @@ class MemoryExtractorAI(BaseModel):
 
         Delegates to the shared `parse_responses_or_none`, which owns the call surface,
         the timeout, and the degrade-to-None handling (timeout, refused output, an
-        incomplete/truncated response — the last matters here because a model that closed
-        the JSON early could otherwise pass the `v1` header check with an amputated file).
+        incomplete/truncated response — the last matters here because a half-emitted delta
+        batch is indistinguishable from a complete one, and the rebuild path deletes every
+        fact its batch did not re-emit).
         """
         return await parse_responses_or_none(
             client=self.client,
@@ -609,9 +613,9 @@ def filter_duplicate_observations(
 ) -> tuple[MemoryObservation, ...]:
     """Drops observations already evidenced from the SAME conversation source.
 
-    The dedupe key is `(normalized_key, source)`, not the key alone: a fact
-    re-stated in another guild (or a DM) must re-enter raw so consolidation can
-    widen that bullet's source tag; key-only dedupe would lock every fact to the
+    The dedupe key is `(normalized_key, source)`, not the key alone: a fact re-stated in
+    another guild (or a DM) must re-enter raw so `partition_raw_entries` can file it in
+    that conversation's own compartment; key-only dedupe would lock every fact to the
     first source that ever observed it.
     """
     existing_pairs = observation_key_sources_from_text(text=existing_text)

--- a/src/discordbot/services/memory/facts.py
+++ b/src/discordbot/services/memory/facts.py
@@ -168,9 +168,9 @@ def parse_fact_file(text: str, compartment: str) -> MemoryFact | None:
 
     `compartment` is the directory the file was found in and is authoritative: a stored
     `compartment` that disagrees means the tree was hand-edited or a migration stopped
-    half way, and there is no safe way to guess which side is right. Returning None
-    (the caller logs it) keeps the fact out of every reply rather than guessing the
-    permissive answer.
+    half way, and there is no safe way to guess which side is right. Returning None keeps the
+    fact out of every reply rather than guessing the permissive answer; `read_facts` only
+    skips it, so a mismatch is logged here, while an unreadable header is dropped silently.
     """
     header, body = _split_front_matter(text=text)
     if header is None:

--- a/src/discordbot/services/memory/git_history.py
+++ b/src/discordbot/services/memory/git_history.py
@@ -108,7 +108,7 @@ class MemoryGitService(BaseModel):
         queue.put_nowait(_GitRequest(scope=scope, reason=reason))
 
     async def _run(self) -> None:
-        """Drains the queue one request at a time for as long as the service is enabled."""
+        """Drains the queue one request at a time, discarding requests once disabled."""
         queue = self._queue
         if queue is None:
             return

--- a/src/discordbot/services/memory/pipeline.py
+++ b/src/discordbot/services/memory/pipeline.py
@@ -76,9 +76,7 @@ from discordbot.services.memory.extraction import (
 )
 from discordbot.services.memory.git_history import memory_git
 
-# Outcome of a from-scratch main-file rebuild. Aliased so the background
-# scheduler's task dict shares the exact type (asyncio.Task is invariant in its
-# result type, so a Literal cannot stand in for a bare str).
+# The ways a from-scratch rebuild can end, carried on `RegenerationReport.result`.
 _RegenerationResult = Literal["regenerated", "no_evidence", "failed", "cooldown"]
 
 
@@ -106,8 +104,8 @@ class _PendingMemoryUpdate(BaseModel):
         transcript: The rendered phase-1 input captured for the skipped turn
             (already folds in the reply), so the replay needs no re-render.
         extractor: The extraction service to run the replayed update with.
-        identity: Single-line target identity stamped into the main memory
-            file as human-inspection metadata.
+        identity: Single-line target identity `parse_identity` splits into the
+            `owner_id` / `owner_name` stamped on every fact this scope writes.
         captured_at: `time.monotonic()` when the turn was captured, so a clear
             that lands before the replay can abort it via `cleared_since`.
         token: Process-local logical token persisted with the deferred turn's DB
@@ -128,8 +126,8 @@ class _PendingMemoryUpdate(BaseModel):
     identity: str = Field(
         ...,
         description=(
-            "Single-line target identity stamped into the main memory file as "
-            "human-inspection metadata."
+            "Single-line target identity `parse_identity` splits into the `owner_id` / "
+            "`owner_name` stamped on every fact this scope writes."
         ),
     )
     captured_at: float = Field(
@@ -156,15 +154,15 @@ _inflight_loop: asyncio.AbstractEventLoop | None = None
 # not need a loop-change reset. Tests clear it through the conftest fixture.
 _last_consolidation: dict[str, float] = {}
 
-# Consecutive refused consolidation batches per scope. A refusal keeps the raw batch
-# for retry, which is right for a transient LLM failure and wrong for a mass-delete the
-# model reproduces verbatim: that retries every cooldown forever while the scope's memory
-# silently stops updating. Past the threshold the log escalates from warn to error, since
-# CONTRIBUTING puts "an unexpected failure that lost a deliverable" at error.
 # The exact header a tone note must lead with; the tier is injected on every reply,
 # so anything else is a rewrite that did not land and must not be written.
 _TONE_HEADER = "## 語氣偏好"
 
+# Consecutive refused consolidation batches per (scope, compartment). A refusal keeps the
+# raw batch for retry, which is right for a transient LLM failure and wrong for a
+# mass-delete the model reproduces verbatim: that retries every cooldown forever while the
+# scope's memory silently stops updating. Past the threshold the log escalates from warn to
+# error, since CONTRIBUTING puts "an unexpected failure that lost a deliverable" at error.
 _consecutive_rejections: dict[tuple[str, str], int] = {}
 _MAX_QUIET_REJECTIONS = 3
 
@@ -191,7 +189,7 @@ def _memory_semaphore() -> asyncio.Semaphore:
 
 
 # Detached best-effort reply.db writes (the deferred-turn persist), held so the
-# event loop keeps a strong reference until they finish; rebuilt per loop.
+# event loop keeps a strong reference until they finish; reset by the test fixture.
 _db_tasks: set[asyncio.Task[None]] = set()
 
 # A clear and the short reply.db staging transaction must not pass each other:
@@ -611,7 +609,7 @@ async def _run_memory_update(  # noqa: PLR0913, PLR0911 -- schedule_memory_updat
 
 
 async def safe_list_resumable() -> list[memory_db.MemoryJob]:
-    """Returns the persisted non-`done` jobs for the restart sweep, best-effort.
+    """Returns the persisted `pending` and `failed` jobs for the restart sweep, best-effort.
 
     Wrapped so a reply.db read failure degrades to "nothing to resume" instead of
     breaking `on_ready`; the in-memory pipeline keeps working regardless.
@@ -636,10 +634,10 @@ def needs_consolidation(scope: str) -> bool:
 async def consolidate_if_needed(scope: str, extractor: MemoryExtractorAI, identity: str) -> None:
     """Consolidates a scope whose raw backlog is over threshold; best-effort, self-logging.
 
-    The boot-sweep entry point: `_consolidate_locked` / `_should_consolidate` are
-    private and assume the scope lock + semaphore are held, so this wrapper takes
-    both and re-checks the threshold under the lock. It swallows its own errors
-    (a background digest must never surface), so the caller just spawns it.
+    The boot-sweep entry point: `_consolidate_locked` is private and assumes the
+    scope lock and the semaphore permit are held, so this wrapper takes both and
+    re-checks the threshold under the lock. It swallows its own errors (a background
+    digest must never surface), so the caller just spawns it.
     """
     try:
         async with scope_lock(scope=scope), _memory_semaphore():
@@ -1008,14 +1006,12 @@ def _report_injection_size(scope: str, flavor: MemoryFlavor) -> None:
 
 
 def _write_tone_result(scope: str, tone_markdown: str) -> None:
-    """Persists a consolidation's tone note when it is acceptable for this scope.
+    """Persists a tone-note call's output when it is acceptable for this scope.
 
-    Sits on the tone-consuming paths (accepted rewrite AND genuine no-op, both of
-    which retire the raw batch — a main no-op can still carry fresh tone signal
-    that would otherwise be consumed without landing). User scopes only, and only
-    a note starting with the exact `## 語氣偏好` header; an empty or malformed
-    output never deletes the existing note — the tier is best-effort and the next
-    consolidation repairs it.
+    User scopes only, and only a note starting with the exact `## 語氣偏好` header;
+    an empty or malformed output never deletes the existing note — the tier is
+    best-effort and the next consolidation repairs it. Only `_rebuild_tone_note`,
+    which saw the whole evidence corpus, may clear it.
     """
     if flavor_of(scope=scope) != "user":
         return
@@ -1099,9 +1095,10 @@ async def regenerate_main_memory(
     The existing facts are deliberately NOT fed to the model: the rebuild distills the
     detail tail window plus any unconsumed raw entries from scratch, e.g. to redo an
     unsatisfying consolidation with another model. Facts the rebuild did not re-emit are
-    then deleted, which is the one path allowed to lose most of a compartment at once —
-    it is also the path the offline migration runs, and refusing it would leave the old
-    tagged-era content behind forever.
+    then deleted, which is the one path allowed to lose most of a compartment at once:
+    replacing the whole set is what it is for, and that exemption is also what let the
+    #408 compartment migration run through here instead of needing a writer of its own.
+    `scripts/regen_memories.py` drives the same path offline.
 
     On an LLM failure the compartment is left exactly as it was, and the raw batch is
     retired only when every compartment rebuilt. The report carries what the run removed

--- a/src/discordbot/services/memory/prompts.py
+++ b/src/discordbot/services/memory/prompts.py
@@ -1,4 +1,4 @@
-"""Prompts for per-user memory extraction, consolidation, and prompt injection."""
+"""Prompts for per-user memory extraction, evaluation, and consolidation."""
 
 from discordbot.services.memory.constants import COMPACTION_TARGET_CHARS
 

--- a/src/discordbot/services/memory/server_prompts.py
+++ b/src/discordbot/services/memory/server_prompts.py
@@ -2,9 +2,9 @@
 
 These mirror the per-user prompts in ``prompts.py`` but reframe the target from
 one individual to the server / community as a whole. The structured schema,
-validation gates, redaction, and the `v1` consolidation contract are shared
-unchanged; only the framing and the consolidated section headings differ. The
-compaction block is reused from the per-user prompts because it is flavor
+validation gates, redaction, and the delta protocol ``apply_deltas`` enforces are
+shared unchanged; only the framing and the consolidated section headings differ.
+The compaction block is reused from the per-user prompts because it is flavor
 agnostic.
 """
 

--- a/src/discordbot/services/memory/store.py
+++ b/src/discordbot/services/memory/store.py
@@ -7,9 +7,9 @@ memory uses ``server_scope(server_id)`` (``bot_memories/<server_id>``).
 Inside a scope the consolidated tier is **one file per fact**, filed under the
 compartment that decides who may read it — ``global/`` (safe anywhere),
 ``g/<guild_id>/`` (that guild only) and ``dm/`` (the owner's own DMs). The path *is*
-the privacy boundary: reading for guild G is ``global/`` plus ``g/<G>/``, two joins and
-a containment check, with no read-time content filter to get wrong. A server scope has
-exactly one compartment (``global/``) because a server memory is per-guild by
+the privacy boundary: reading for guild G is ``global/`` plus ``g/<G>/``, two joins each
+guarded by ``_COMPARTMENT_RE``, with no read-time content filter to get wrong. A server
+scope has exactly one compartment (``global/``) because a server memory is per-guild by
 construction and its evidence carries no source to route by.
 
 The remaining tiers are per-scope and unchanged: ``raw.md`` accumulates phase-1 entries
@@ -18,7 +18,7 @@ until consolidation consumes them, ``detail.md`` is the append-only cold evidenc
 always-read note of how the user wants the bot to sound.
 
 IO is synchronous, which one fact per file would otherwise make untenable on the reply
-path: ``render_memory_document`` is cached under a per-scope generation counter that
+path: ``read_memory_document`` is cached under a per-scope generation counter that
 every write bumps, so a repeat read costs no syscalls at all. The counter is exact
 because every write in this process goes through here under ``scope_lock``; editing the
 tree from outside while the bot runs is not supported (nor is it today, for
@@ -188,9 +188,9 @@ def iter_scopes() -> list[str]:
     is pending for them.
 
     `bot_memories` is the only directory descended into, and dot directories are
-    skipped outright (the store is itself a git work tree), so a stray directory — or a
-    symlink to this one — can never hand the sweep the same memory twice under another
-    name.
+    skipped outright (the store is itself a git work tree), so nested memory anywhere
+    else — a stray directory, or a symlink to `bot_memories` — can never hand the sweep
+    the same memory under a second name.
     """
     scopes: list[str] = []
     if not _MEMORY_DIR.is_dir():
@@ -429,8 +429,7 @@ def prune_compartment(scope: str, compartment: str, keep: set[str]) -> PrunedCom
     process can be mid-write, since every writer holds the same scope lock. Out of
     process is the offline rebuild's standing caveat rather than a new one — it is why
     `scripts/regen_memories.py` opens by telling the operator to stop the bot. An emptied
-    directory
-    is then removed, so a compartment a rebuild emptied stops being one
+    directory is then removed, so a compartment a rebuild emptied stops being one
     `list_compartments` reports, and stops costing a consolidation call on every later
     rebuild.
 
@@ -601,11 +600,11 @@ def _trim_detail(path: Path) -> None:
 def read_detail_tail(scope: str, max_chars: int) -> str:
     """Returns the newest detail-file window, aligned to a raw-entry header.
 
-    Only a bounded byte window is read from the end of the file so the call
-    stays O(window) as the uncapped detail file grows. The window is aligned
-    to the first raw-entry header inside the tail so a partial entry never
-    leads the result; when no header lands inside the window (e.g. one giant
-    entry) the raw tail is returned as a best effort.
+    Only a bounded byte window is read from the end of the file so the call stays
+    O(window) however far the detail file has grown toward its multi-megabyte cap.
+    The window is aligned to the first raw-entry header inside the tail so a partial
+    entry never leads the result; when no header lands inside the window (e.g. one
+    giant entry) the raw tail is returned as a best effort.
     """
     try:
         with _detail_path(scope=scope).open(mode="rb") as handle:
@@ -685,11 +684,13 @@ def clear_memory(scope: str) -> bool:
 def delete_memory_files(scope: str) -> bool:
     """Deletes the scope's memory files without moving its clear boundary.
 
-    Walks the compartment tree as well as the three single-file tiers, removing only
-    `.md` files and the `.md.tmp` leftovers a crash between a tmp write and its
-    `os.replace` can strand — never a foreign file that shares the directory. Empty
-    directories are then removed bottom-up; a non-empty or missing one is left for
-    offline maintenance instead of failing the clear.
+    Walks the compartment tree as well as the three single-file tiers, taking every
+    `.md` it finds — a foreign one included, because a clear is a wipe its owner asked
+    for and sparing a file that might carry their memory would be the wrong answer here
+    (`unaccounted_files` is the opposite contract) — plus the `.md.tmp` leftovers a crash
+    between a tmp write and its `os.replace` can strand. Anything with another suffix is
+    left alone. Empty directories are then removed bottom-up; a non-empty or missing one
+    is left for offline maintenance instead of failing the clear.
 
     Returns:
         True when at least one memory file existed and was removed.

--- a/src/discordbot/services/stock/database.py
+++ b/src/discordbot/services/stock/database.py
@@ -349,7 +349,7 @@ def _current_news_provider_semaphore() -> asyncio.Semaphore:
 
 
 def _operation_lock(user_id: int, symbol: str) -> AbstractAsyncContextManager[None]:
-    """Returns a per-user stock operation lock bound to the current event loop."""
+    """Returns a per-user, per-symbol operation lock bound to the current event loop."""
     return _operation_locks.hold(key=(user_id, symbol))
 
 
@@ -501,7 +501,14 @@ def _quote_from_profile(profile: StockProfile, pressure_bps: int) -> StockMarket
 async def upsert_stock_profile(
     profile: StockProfileUpsert, now: datetime | None = None
 ) -> StockProfileView:
-    """Creates or updates a DB-owned stock profile from an explicit maintenance payload."""
+    """Creates or updates a DB-owned stock profile from an explicit maintenance payload.
+
+    A new profile also seeds the price tick for the current boundary; an existing
+    one writes a tick only when the maintenance price differs from the stored one.
+
+    Raises:
+        ValueError: `profile.symbol` is empty once trimmed.
+    """
     await _ensure_schema()
     effective_now = now or _database_now()
     normalized_symbol = profile.symbol.strip().upper()
@@ -623,7 +630,15 @@ async def ensure_due_stock_news(
     symbols: tuple[str, ...] | None = None,
     now: datetime | None = None,
 ) -> None:
-    """Creates due stock news rows, using AI when a provider is available."""
+    """Creates due stock news rows, using AI when a provider is available.
+
+    A symbol is due when it has no news at all, or its newest row is older than
+    the profile's `news_cadence_hours`. Passing a provider additionally reworks a
+    still-fresh template row, so a deterministic fallback written while no
+    provider was around is replaced by an AI headline instead of waiting out the
+    cadence. A provider that raises or returns nothing degrades to the templates
+    rather than propagating.
+    """
     await _ensure_schema()
     effective_now = now or _database_now()
     normalized_symbols = tuple(symbol.upper() for symbol in symbols) if symbols else None
@@ -1125,7 +1140,16 @@ async def advance_market_in_session(
     rng: Random | None = None,
     begin_immediate: bool = True,
 ) -> StockMarketQuote:
-    """Advances one stock lazily to the current tick boundary."""
+    """Advances one stock lazily to the current tick boundary.
+
+    Callers hold the per-symbol market lock and own the commit: the materialized
+    ticks and the mutated profile row stay in the caller's session. Pass
+    `begin_immediate=False` only when that session already holds SQLite's write
+    lock.
+
+    Raises:
+        ValueError: No `stock_profile` row exists for `symbol`.
+    """
     if begin_immediate:
         await _begin_immediate(session=session)
     effective_now = now or _database_now()
@@ -2340,7 +2364,24 @@ async def settle_stock_operation(  # noqa: PLR0913 -- Service boundary returns t
     now: datetime | None = None,
     rng: Random | None = None,
 ) -> StockSettlementResult:
-    """Settles a buy/cover or short/sell request through one service boundary."""
+    """Settles a buy/cover or short/sell request through one service boundary.
+
+    `stock.db` and `economy.db` cannot commit together, so the operation row and
+    its legs commit first, then the wallet legs move, then the position is
+    written and the operation marked `applied`. A wallet rejection marks it
+    `failed` with the position untouched; a failure after the wallet moved marks
+    it `reconcile_required`, which `list_reconciliation_operations` reports on and
+    which `_blocking_operation` reads to refuse the user's next trade on that symbol.
+
+    Returns:
+        The settled result, or a `success=False` result carrying the validation
+        or lifecycle error.
+
+    Raises:
+        ValueError: No `stock_profile` row exists for `symbol`.
+        asyncio.CancelledError: Re-raised once the in-flight operation has been
+            marked `reconcile_required`.
+    """
     normalized_symbol = symbol.upper()
     await _ensure_schema()
     async with _operation_lock(user_id=user_id, symbol=normalized_symbol):
@@ -2635,12 +2676,14 @@ async def list_reconciliation_operations() -> tuple[StockReconciliationOperation
 async def reset_all_positions() -> int:
     """Flattens every stock position and finalizes any non-final operation.
 
-    Used by the offline economy reset so stale, inflated positions cannot be
-    re-extracted into wallet cash after balances are deflated. Non-final
-    operations (pending / wallet_applied / reconcile_required) are also forced to
-    `failed`; otherwise `_blocking_operation` would keep the affected users from
-    trading that symbol even though the reset claims to flatten stock state.
-    Market prices in `stock_profile` are intentionally left untouched.
+    An offline wipe, so stale positions inflated under an earlier economy cannot
+    be re-extracted into wallet cash once balances are deflated. Its only caller
+    was `scripts/reset_economy.py`, deleted in #248, so nothing outside the tests
+    reaches it today. Non-final operations (pending / wallet_applied /
+    reconcile_required) are also forced to `failed`; otherwise
+    `_blocking_operation` would keep the affected users from trading that symbol
+    even though the reset claims to flatten stock state. Market prices in
+    `stock_profile` are intentionally left untouched.
 
     Returns:
         The number of position rows affected.

--- a/src/discordbot/services/stock/market.py
+++ b/src/discordbot/services/stock/market.py
@@ -44,7 +44,12 @@ def tick_boundary(dt: datetime) -> datetime:
 
 
 def decay_news_sentiment(sentiment_bps: int, elapsed_seconds: int) -> int:
-    """Applies linear time-based news sentiment decay and clamps the result."""
+    """Applies linear time-based news sentiment decay and clamps the result.
+
+    Ambient context for the news-generation prompt only. Pricing applies each
+    news row as a one-shot impulse at its own firing tick boundary, never as a
+    decayed drift over the ticks after it.
+    """
     clamped = clamp_bps(
         value=sentiment_bps, lower=-NEWS_SENTIMENT_LIMIT_BPS, upper=NEWS_SENTIMENT_LIMIT_BPS
     )
@@ -94,7 +99,7 @@ def execution_price_cents(
 def mean_reversion_bps(
     previous_price_cents: int, fair_value_cents: int, mean_reversion_strength_bps: int
 ) -> int:
-    """Returns the bounded fair-value pull for the next tick."""
+    """Returns the fair-value pull for the next tick, scaled by the reversion strength."""
     if previous_price_cents <= 0 or fair_value_cents <= 0 or mean_reversion_strength_bps <= 0:
         return 0
     fair_value_gap_bps = (fair_value_cents - previous_price_cents) * 10_000 // previous_price_cents
@@ -198,7 +203,14 @@ def _fill_compressed_boundaries(
 
 
 def tick_boundaries_to_apply(latest_tick_at: datetime, now: datetime) -> tuple[datetime, ...]:
-    """Returns tick boundaries that should be materialized for a lazy interaction."""
+    """Returns tick boundaries that should be materialized for a lazy interaction.
+
+    A backlog longer than `MAX_TICKS_PER_INTERACTION` is compressed to that many
+    boundaries. Each Asia/Taipei day rollover keeps both the boundary that opens
+    the new day and the one before it, so the caller still sees every previous
+    close and day open; a backlog holding more rollovers than the cap keeps only
+    the most recent ones.
+    """
     latest_boundary = tick_boundary(dt=latest_tick_at)
     current_boundary = tick_boundary(dt=now)
     if current_boundary <= latest_boundary:

--- a/src/discordbot/typings/colors.py
+++ b/src/discordbot/typings/colors.py
@@ -1,9 +1,9 @@
 """Shared Discord embed color constants.
 
-The economy transfer and in-progress game embeds both use the same neutral
-blurple, and the economy / stock / games embeds all use Discord's
-red/green/yellow status palette. Defining each hex once keeps the theme
-consistent; the semantic aliases document where each color is used.
+Every cog that renders an embed draws its accents from here: the same neutral
+blurple, and Discord's own red/green/yellow status palette. Defining each hex
+once keeps the theme consistent; the semantic aliases document what each color
+means rather than where it is used.
 """
 
 from typing import Final
@@ -11,7 +11,7 @@ from typing import Final
 # Discord blurple, used wherever a neutral/info accent is wanted.
 NEUTRAL_BLUE: Final[int] = 0x5865F2
 
-# Discord's status palette, reused across economy / stock / games embeds.
+# Discord's status palette, reused across every embed-rendering cog.
 DISCORD_RED: Final[int] = 0xED4245  # error / loss
 DISCORD_GREEN: Final[int] = 0x57F287  # success / win / positive balance
 DISCORD_YELLOW: Final[int] = 0xFEE75C  # neutral / push / leaderboard

--- a/src/discordbot/typings/config.py
+++ b/src/discordbot/typings/config.py
@@ -16,7 +16,7 @@ class DiscordConfig(BaseSettings):
 
     discord_bot_token: str = Field(
         ...,
-        description="The token from discord for calling models.",
+        description="The token from Discord the bot authenticates its gateway session with.",
         examples=["MTEz-..."],
         validation_alias=AliasChoices("DISCORD_BOT_TOKEN"),
     )

--- a/src/discordbot/typings/douyin.py
+++ b/src/discordbot/typings/douyin.py
@@ -16,8 +16,9 @@ class DouyinConfig(BaseSettings):
 
     Attributes:
         auto_expand_enabled: Kill-switch for expanding a pasted Douyin link into the channel.
-            The one lever that stops the bot talking to Douyin at all if its WAF starts
-            blocking, since expansion turns every pasted link into a request.
+            The lever for the UNPROMPTED traffic if its WAF starts blocking, since
+            expansion turns every pasted link into a request; `/download_video` and the
+            reply pipeline's ingest have their own switches and are unaffected.
     """
 
     model_config = SettingsConfigDict(arbitrary_types_allowed=True)

--- a/src/discordbot/typings/economy.py
+++ b/src/discordbot/typings/economy.py
@@ -377,13 +377,13 @@ class VipPurchaseResult(BaseModel):
     """Outcome of a successful VIP purchase.
 
     Attributes:
-        new_balance: User balance after the 10M debit.
+        new_balance: User balance after the `VIP_PURCHASE_COST` debit.
         cost: Points deducted for the purchase.
     """
 
     model_config = ConfigDict(frozen=True)
 
-    new_balance: int = Field(..., description="User balance after the 10M debit.")
+    new_balance: int = Field(..., description="User balance after the VIP_PURCHASE_COST debit.")
     cost: int = Field(..., description="Points deducted for the purchase.")
 
 

--- a/src/discordbot/typings/fishing.py
+++ b/src/discordbot/typings/fishing.py
@@ -139,7 +139,7 @@ class AnglerStateView(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     user_id: int = Field(..., description="Discord user ID of the angler.")
-    user_name: str = Field(default="", description="Last-seen display name of the angler.")
+    user_name: str = Field(default="", description="Last-seen Discord username of the angler.")
     rod: GearView | None = Field(
         default=None, description="Currently equipped rod, or None when the angler has no rod."
     )
@@ -182,7 +182,9 @@ class CatchLogView(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     user_id: int = Field(..., description="Discord user ID of the angler who made the catch.")
-    user_name: str = Field(..., description="Stored display name of the angler.")
+    user_name: str = Field(
+        ..., description="Username stored with the catch, or the user id when none was stored."
+    )
     species_id: str = Field(..., description="Identifier of the caught species.")
     species_name: str = Field(..., description="Stored display name of the caught species.")
     grade: FishGrade = Field(..., description="Rarity grade of the catch.")

--- a/src/discordbot/typings/games.py
+++ b/src/discordbot/typings/games.py
@@ -90,14 +90,22 @@ class GameParticipantIdentity(BaseModel):
 
 
 class SystemIdentity(BaseModel):
-    """Discord identity used for the casino system narrator in game views."""
+    """The house label a game view shows, beside the bot's own id and avatar.
+
+    A label, not a speaker: #303 removed the casino narrator, so nothing built from
+    this writes a message. `system_name` is the only part that reaches a render today
+    (the Blackjack dealer seat's embed author); Dragon Gate carries the identity
+    without displaying it.
+    """
 
     model_config = ConfigDict(frozen=True)
 
-    system_id: int = Field(..., description="Discord user ID used for the casino system narrator.")
-    system_name: str = Field(..., description="Display name used for the casino system narrator.")
+    system_id: int = Field(
+        ..., description="Discord user ID of the bot, or 0 when the client user is unavailable."
+    )
+    system_name: str = Field(..., description="House label shown on the casino side of a table.")
     system_avatar_url: str = Field(
-        default="", description="Avatar URL used for the casino system narrator."
+        default="", description="The bot's guild-aware avatar URL, resolved alongside the label."
     )
 
 
@@ -247,7 +255,7 @@ class BlackjackPlayerSettlement(WagerSettlement):
         hands: Per-hand settlements in display order.
         insurance: Insurance side-bet result, or `None` when the player
             never took insurance.
-        detail: Short game-state summary for the dealer AI prompt.
+        detail: Short Chinese round summary built by `blackjack_detail_player`.
         five_card_bonus: Aggregate system-funded five-card 21 bonus.
     """
 
@@ -259,7 +267,9 @@ class BlackjackPlayerSettlement(WagerSettlement):
             "by net base delta."
         ),
     )
-    detail: str = Field(..., description="Short game-state summary for the dealer AI prompt.")
+    detail: str = Field(
+        ..., description="Short Chinese round summary built by `blackjack_detail_player`."
+    )
     hands: list[BlackjackHandSettlement] = Field(
         default_factory=list, description="Per-hand settlements in display order."
     )
@@ -479,15 +489,20 @@ class ActionEv(BaseModel):
 class ActionEvAnalysis(BaseModel):
     """EV analysis for one bot-player action decision.
 
-    `dealer_outcome` and `action_evs` are the hole-unknown (marginalized) numbers
-    shown to the model, while `recommended_action` is selected from the engine's
-    private hole-aware pass; the two never leak the hole card to the model.
+    Every NUMBER that reaches this analysis is the hole-unknown (marginalized) one:
+    `dealer_outcome`, `action_evs` and `recommended_expected_value` depend on the
+    up-card and the remaining shoe alone, so no caller can back out the dealer's real
+    hole from them. `recommended_action` is the single exception, selected from the
+    engine's private hole-aware pass — an action, never a value, which is why the
+    engine looks its reported EV back up in the marginal table rather than carrying
+    the exact one across.
     """
 
     model_config = ConfigDict(frozen=True)
 
     dealer_outcome: DealerOutcome = Field(
-        ..., description="Marginalized dealer final-total distribution shown to the model."
+        ...,
+        description="Marginalized dealer final-total distribution; the real hole never enters it.",
     )
     action_evs: tuple[ActionEv, ...] = Field(
         ...,

--- a/src/discordbot/typings/llm.py
+++ b/src/discordbot/typings/llm.py
@@ -17,8 +17,9 @@ class LLMConfig(BaseSettings):
             Anthropic Files API directly (the side-channel for Claude answer models).
         xai_api_key: The xAI key used to upload attachments to the xAI Files API
             directly (the side-channel for Grok answer models, which the proxy cannot route).
-        inline_voice_enabled: Kill-switch for spoken QA replies; when false the answer
-            model's voice marker is still stripped but no audio clip is synthesized.
+        inline_voice_enabled: Kill-switch for spoken QA and SUMMARY replies; when false
+            the answer model's voice marker is still stripped but no audio clip is
+            synthesized.
         inline_image_enabled: Kill-switch for inline generated images on QA replies; when
             false the answer model's `<generate-image>` marker is still stripped but no image is rendered.
         inline_music_enabled: Kill-switch for inline generated music on QA replies; when false
@@ -82,7 +83,7 @@ class LLMConfig(BaseSettings):
     )
     inline_voice_enabled: bool = Field(
         default=True,
-        description="Whether the bot may synthesize a spoken clip for fierce QA replies.",
+        description="Whether the bot may synthesize a spoken clip for QA and SUMMARY replies.",
         validation_alias=AliasChoices("INLINE_VOICE_ENABLED"),
     )
     inline_image_enabled: bool = Field(

--- a/src/discordbot/typings/memory.py
+++ b/src/discordbot/typings/memory.py
@@ -58,7 +58,9 @@ type MemorySection = Literal[
 
 # What a stored file holds. Derived from `section` by code so it can never disagree
 # with it; kept as its own field so a reader can select alias rows without knowing the
-# section vocabulary (`allowlist_ids_from_server_memory`'s successor).
+# section vocabulary. `allowlist_ids_from_server_memory` is NOT that reader and was not
+# replaced by this: it still parses `## 成員稱呼` out of the rendered document. Today the
+# freshness sweep is the only reader, exempting alias rows from aging.
 type MemoryNodeType = Literal["memory", "member_alias"]
 
 # What one consolidation delta asks for. `create` mints a fresh id, `update` and
@@ -83,8 +85,13 @@ class MemoryOwner(BaseModel):
 class MemoryFact(BaseModel):
     """One distilled memory, stored as a single file inside one compartment.
 
-    Attributes carry their zone in the description: the model authors the first four,
-    code stamps the rest.
+    The model authors `summary`, `section`, `durability` and `text`, except that a
+    `member_alias` body is code-built and its `text` unread. Code owns provenance —
+    `fact_id`, `compartment`, the `owner_*` and timestamp fields — and mints `fact_id`
+    itself so conversation content can never influence it. Provenance is not hidden
+    from the model: an update or delete has to name the id it is editing, so
+    `render_existing_facts` shows the id, `keys` and `subject_id` of every stored fact
+    and the delta schema takes them back.
     """
 
     model_config = ConfigDict(frozen=True)

--- a/src/discordbot/typings/models.py
+++ b/src/discordbot/typings/models.py
@@ -54,8 +54,8 @@ class ModelSettings(BaseModel):
 
         Returns:
             Gemini models receive googleSearch and urlContext tools. Claude models
-            receive web_search and web_fetch tools. Other models receive the OpenAI
-            web_search tool.
+            receive web_search and web_fetch tools. Grok models receive web_search and
+            x_search. Every other model receives the OpenAI web_search tool.
         """
         if "gemini" in self.name:
             return cast("list[ToolParam]", [{"googleSearch": {}}, {"urlContext": {}}])
@@ -105,7 +105,9 @@ class RuntimeModelCatalog(BaseModel):
     def video_model(self) -> ModelSettings:
         """The model settings for video generation.
 
-        Callers: `VideoGenerator.render` (via the VIDEO route `_handle_video_reply`).
+        Callers: `VideoGenerator` (its raising `render` for the VIDEO route
+        `_handle_video_reply`, its best-effort `generate` for the QA-route inline
+        `<generate-video>` marker, which delegates to that same `render`).
 
         Returns:
             Model settings used with the native Gemini Interactions API (`interactions.create`,
@@ -185,8 +187,9 @@ class RuntimeModelCatalog(BaseModel):
         Callers: `VoiceGenerator` (via `ReplyGeneratorCogs.voice_generator`).
 
         Returns:
-            Model settings whose name is dispatched on the `audio.speech` endpoint to
-            render a fierce QA reply to a voice clip. `effort` is unused for TTS.
+            Model settings whose name is dispatched on the `audio.speech` endpoint. Only
+            the reply's `<generate-voice>` segments are synthesized, concatenated into one
+            clip; the rest of the reply is never spoken. `effort` is unused for TTS.
         """
         return ModelSettings(name="gemini-3.1-flash-tts-preview")
 
@@ -228,10 +231,13 @@ class RuntimeModelCatalog(BaseModel):
     def slow_model(self) -> ModelSettings:
         """The model settings for full text replies and strategic reasoning.
 
-        Callers: `_handle_message_reply` (which overrides `effort` with the
-        route-decided level), attachment modality gating, `write_up_report` (the
-        background rewrite of a `/feedback` report into an issue, which nobody waits on),
-        and dev scripts.
+        Dispatched by `_handle_message_reply` (which overrides `effort` with the
+        route-decided level) and by `write_up_report` (the background rewrite of a
+        `/feedback` report into an issue, which nobody waits on). Three more read only
+        the model NAME and dispatch nothing: `_supported_sources` gates attachment
+        modalities on it, `ReplyGeneratorCogs.input_builder` picks the attachment handler
+        off it through `build_attachment_handler`, and `_run_reply_pipeline` derives each
+        link-context builder's `answer_model_is_gemini` from it.
 
         Returns:
             Slow-path model settings for reply generation and summaries.

--- a/src/discordbot/typings/stock.py
+++ b/src/discordbot/typings/stock.py
@@ -1,3 +1,10 @@
+"""Shared vocabulary for the stock market simulation.
+
+Two money units live here and only the field name tells them apart: a `*_cents` field is
+cent-denominated, and every other money field is whole wallet cash, already rounded out of
+cents by `cash_ceil` / `cash_floor` before it was stored.
+"""
+
 from enum import StrEnum
 from typing import Self, Final
 from datetime import datetime
@@ -147,17 +154,17 @@ class StockPositionView(BaseModel):
     user_name: str = Field(default="", description="Stored display name of the position owner.")
     long_shares: int = Field(default=0, description="Number of shares held long.")
     long_cost_basis: int = Field(
-        default=0, description="Aggregate cost basis of the long position in cents."
+        default=0, description="Aggregate cost basis of the long position, in cash."
     )
     short_shares: int = Field(default=0, description="Number of shares held short.")
     short_entry_value: int = Field(
-        default=0, description="Aggregate entry value of the short position in cents."
+        default=0, description="Aggregate entry value of the short position, in cash."
     )
     short_collateral: int = Field(
-        default=0, description="Collateral reserved against the short position in cents."
+        default=0, description="Collateral reserved against the short position, in cash."
     )
     realized_pnl: int = Field(
-        default=0, description="Realized profit and loss for this position in cents."
+        default=0, description="Realized profit and loss for this position, in cash."
     )
 
 
@@ -171,7 +178,7 @@ class StockParticipantPositionView(BaseModel):
     long_shares: int = Field(..., description="Number of shares the participant holds long.")
     short_shares: int = Field(..., description="Number of shares the participant holds short.")
     realized_pnl: int = Field(
-        ..., description="Realized profit and loss for the participant in cents."
+        ..., description="Realized profit and loss for the participant, in cash."
     )
 
 
@@ -189,12 +196,12 @@ class StockTradeLegView(BaseModel):
     shares: int = Field(..., description="Share quantity executed in this leg.")
     price_cents: int = Field(..., description="Per-leg execution price in cents.")
     wallet_delta: int = Field(..., description="Wallet balance change applied by this leg.")
-    basis_delta: int = Field(..., description="Cost-basis change applied by this leg in cents.")
+    basis_delta: int = Field(..., description="Cost-basis change applied by this leg, in cash.")
     collateral_delta: int = Field(
-        ..., description="Short collateral change applied by this leg in cents."
+        ..., description="Short collateral change applied by this leg, in cash."
     )
     realized_pnl_delta: int = Field(
-        ..., description="Realized profit and loss change applied by this leg in cents."
+        ..., description="Realized profit and loss change applied by this leg, in cash."
     )
     created_at: datetime = Field(..., description="Timestamp the leg was created.")
 
@@ -208,7 +215,7 @@ class StockNewsView(BaseModel):
     headline: str = Field(..., description="News headline text.")
     sentiment_bps: int = Field(..., description="News sentiment impulse in basis points.")
     source: str = Field(
-        default="template", description="Origin of the news item, such as template or model."
+        default="template", description="Origin of the news item: `template` or `ai`."
     )
     model: str = Field(default="", description="Model identifier that generated the news, if any.")
     expires_at: datetime | None = Field(
@@ -226,9 +233,7 @@ class StockGeneratedNews(BaseModel):
     sentiment_bps: int = Field(
         ..., description="Generated news sentiment impulse in basis points."
     )
-    source: str = Field(
-        ..., description="Origin of the generated news, such as template or model."
-    )
+    source: str = Field(..., description="Origin of the generated news: `template` or `ai`.")
     model: str = Field(default="", description="Model identifier that generated the news, if any.")
 
 
@@ -313,27 +318,27 @@ class StockPortfolioHolding(BaseModel):
     price_cents: int = Field(..., description="Latest quote price in cents.")
     long_shares: int = Field(..., description="Number of shares held long.")
     long_cost_basis: int = Field(
-        ..., description="Aggregate cost basis of the long position in cents."
+        ..., description="Aggregate cost basis of the long position, in cash."
     )
     long_market_value: int = Field(
-        ..., description="Current market value of the long position in cents."
+        ..., description="Current market value of the long position, in cash."
     )
     short_shares: int = Field(..., description="Number of shares held short.")
     short_entry_value: int = Field(
-        ..., description="Aggregate entry value of the short position in cents."
+        ..., description="Aggregate entry value of the short position, in cash."
     )
     short_collateral: int = Field(
-        ..., description="Collateral reserved against the short position in cents."
+        ..., description="Collateral reserved against the short position, in cash."
     )
     short_cover_cost: int = Field(
-        ..., description="Current cost to cover the short position in cents."
+        ..., description="Current cost to cover the short position, in cash."
     )
-    equity_value: int = Field(..., description="Net equity value of this holding in cents.")
+    equity_value: int = Field(..., description="Net equity value of this holding, in cash.")
     unrealized_pnl: int = Field(
-        ..., description="Unrealized profit and loss for this holding in cents."
+        ..., description="Unrealized profit and loss for this holding, in cash."
     )
     realized_pnl: int = Field(
-        ..., description="Realized profit and loss for this holding in cents."
+        ..., description="Realized profit and loss for this holding, in cash."
     )
 
 
@@ -347,13 +352,13 @@ class StockPortfolioView(BaseModel):
         ..., description="Current stock holdings for the user."
     )
     equity_value: int = Field(
-        ..., description="Total net equity value across all holdings in cents."
+        ..., description="Total net equity value across all holdings, in cash."
     )
     unrealized_pnl: int = Field(
-        ..., description="Total unrealized profit and loss across holdings in cents."
+        ..., description="Total unrealized profit and loss across holdings, in cash."
     )
     realized_pnl: int = Field(
-        ..., description="Total realized profit and loss across holdings in cents."
+        ..., description="Total realized profit and loss across holdings, in cash."
     )
 
 

--- a/src/discordbot/typings/video.py
+++ b/src/discordbot/typings/video.py
@@ -6,9 +6,10 @@ from typing import Literal
 # `Literal` rather than a `StrEnum` because nextcord reads a slash option's type off the
 # annotation and understands `Literal` but rejects an arbitrary enum subclass; an explicit
 # `choices=` still overrides the choices it derives, so the readable labels survive.
-# Every site that maps a preset onto something (`VideoDownloader.quality_formats`,
-# `DouyinDownloader.quality_ratios`, the command's own choices) is keyed by this type and
-# indexed without a default, so a preset added here has to be answered everywhere.
+# The two downloader maps (`VideoDownloader.quality_formats`, `DouyinDownloader.quality_ratios`)
+# are keyed by this type and indexed without a default, so an unanswered preset fails outright
+# instead of silently downgrading; the command's own `QUALITY_CHOICES` carries the presets as its
+# values. A preset added here has to be answered in all three.
 VideoQuality = Literal["best", "high", "medium", "low"]
 
 __all__ = ["VideoQuality"]

--- a/src/discordbot/utils/asyncio_locks.py
+++ b/src/discordbot/utils/asyncio_locks.py
@@ -1,9 +1,11 @@
 """Loop-local asyncio primitives that rebind when the running event loop changes.
 
-Module-level locks / semaphores / registries must rebind per loop: the test suite runs
-each case on a fresh event loop (and swaps the module-level engines tests monkeypatch), so
-a primitive bound to a closed loop would be unusable. Hold one instance per call site; each
-accessor rebinds to the current loop, rebuilding (or clearing) state bound to a stale loop.
+An `asyncio.Lock` / `Semaphore` binds to the loop of the first call that actually waits on
+it rather than to the loop it was built on, so constructing one lazily does not help: the
+next loop to reach it raises `is bound to a different event loop`. Every test case runs on
+a fresh loop, so a primitive held at module level or on a process-wide singleton hits that
+on the second test. Hold one instance per call site; each accessor rebinds to the current
+loop, rebuilding (or clearing) state bound to a stale loop.
 """
 
 import asyncio

--- a/src/discordbot/utils/currency.py
+++ b/src/discordbot/utils/currency.py
@@ -1,8 +1,9 @@
 """Shared cent-to-integer-cash conversion helpers.
 
-Stock execution and presentation convert cent-denominated prices into integer
-`CURRENCY_NAME` cash. These rounding helpers live here so economy code can
-reuse the same conversion without redefining it.
+Stock prices are cent-denominated while wallets hold whole `CURRENCY_NAME` cash, so
+stock execution and stock presentation round every settlement leg and every displayed
+total through one of these two. Picking one is the call site's job: stock settlement
+ceils what a user pays and floors what a user receives.
 """
 
 

--- a/src/discordbot/utils/douyin.py
+++ b/src/discordbot/utils/douyin.py
@@ -29,15 +29,15 @@ from requests.exceptions import RequestException
 from discordbot.typings.video import VideoQuality
 from discordbot.utils.asyncio_locks import KeyedLockManager, LoopLocalSemaphore
 
-# Single source of truth for detecting a Douyin URL, kept module level so the planned
-# auto-expand cog can share it the way `THREADS_URL_RE` is shared by parse_threads and
-# gen_reply. Douyin's own share button emits the link inside a blob of noise
+# Single source of truth for detecting a Douyin URL, kept module level so the expansion cog,
+# gen_reply and `/download_video` all share it, the way `THREADS_URL_RE` is shared by
+# parse_threads and gen_reply. Douyin's own share button emits the link inside a blob of noise
 # ("7.64 gOX:/ w@f.oD ... https://v.douyin.com/iR2syBRn/ 复制此链接，打开Dou音搜索"), so the
 # match has to survive being surrounded by CJK text: the path is matched as ASCII URL
 # characters only and must END on `[A-Za-z0-9_/-]`, which stops the match at a trailing
 # `，`/`。`/`!` instead of swallowing it into the short code and breaking the lookup.
-# `(?:[A-Za-z0-9-]+\.)*` requires the `.com` to be immediately followed by `/`, so a
-# lookalike host such as `douyin.com.attacker.com/x` does not match.
+# Only whole labels may precede the host (`(?:[A-Za-z0-9-]+\.)*`) and the `.com` must be followed
+# immediately by `/`, so a lookalike host such as `douyin.com.attacker.com/x` does not match.
 DOUYIN_URL_RE = re.compile(
     r"https?://(?:[A-Za-z0-9-]+\.)*(?:douyin|iesdouyin)\.com/[A-Za-z0-9_.?=&%/-]*[A-Za-z0-9_/-]"
 )
@@ -571,9 +571,9 @@ class DouyinDownloader(BaseModel):
     def parse_metadata(self, url: str) -> DouyinPost:
         """Parses a Douyin URL into post metadata WITHOUT downloading any media.
 
-        The planned auto-expand path needs the caption and media URLs but no local files, so the
-        parse is kept separate from the download the same way `ThreadsDownloader.parse_metadata`
-        is split from `parse`.
+        The expansion cog and the reply pipeline both need the caption and media URLs before (or
+        without) any local file, so the parse is kept separate from the download the same way
+        `ThreadsDownloader.parse_metadata` is split from `parse`.
 
         Args:
             url: The raw Douyin URL.

--- a/src/discordbot/utils/downloader.py
+++ b/src/discordbot/utils/downloader.py
@@ -1,4 +1,9 @@
-"""yt-dlp wrapper utilities used by the video download command."""
+"""yt-dlp wrapper utilities shared by `/download_video` and the Bilibili link builder.
+
+The command calls `download` and nothing else; the metadata probe and the stop-signal
+half exist for the link builder, which has to decide whether to fetch at all and has to
+be able to abandon a download that outran the reply's budget.
+"""
 
 import types
 from typing import Any, ClassVar

--- a/src/discordbot/utils/images.py
+++ b/src/discordbot/utils/images.py
@@ -26,6 +26,9 @@ def get_pil_image(image_file: str) -> Image.Image:
     Raises:
         ValueError: `image_file` is neither an `http(s)://` URL nor a
             recognised image data URI.
+        requests.RequestException: The URL could not be fetched.
+        PIL.UnidentifiedImageError: What came back is not a decodable image, which is
+            what a 404 HTML body from a dead CDN arrives as.
     """
     if image_file.startswith(("http://", "https://")):
         # 10s caps the history-render I/O tail: a URL taking longer is almost always a
@@ -54,7 +57,8 @@ def shrink_image_bytes(payload: bytes, content_type: str) -> tuple[bytes, str]:
     bytes); images with transparency or an indexed palette stay PNG (alpha must
     survive, and JPEG artifacts are visible on flat-color palette graphics);
     GIFs and other animated images pass through untouched so motion context
-    survives. Anything PIL cannot decode passes through unchanged.
+    survives. Anything PIL cannot decode passes through unchanged, as does an
+    image already within the cap: those come back byte-identical, never re-encoded.
 
     Args:
         payload: The original encoded image bytes.

--- a/src/discordbot/utils/interaction_responses.py
+++ b/src/discordbot/utils/interaction_responses.py
@@ -1,4 +1,10 @@
-"""Shared send/edit helpers for interaction responses that clean themselves up."""
+"""Shared send/edit helpers for the economy and games interaction responses.
+
+Each helper pairs one response shape (public followup, loan-request followup, private
+followup, ephemeral response, edit) with the `embed_spacer_payload` call that keeps embed
+widths aligned. Only the plain public followup schedules its own deletion up front; the
+loan-request one hands that to the view, which schedules it at a terminal state.
+"""
 
 from typing import Protocol, cast
 
@@ -22,7 +28,7 @@ async def send_expiring_followup(
     view: View | None = None,
     file: File | None = None,
 ) -> None:
-    """Sends a game-related economy embed and schedules its cleanup."""
+    """Sends a public embed as an interaction followup and schedules its deletion."""
     extra_files = [file] if file is not None else None
     spacer = embed_spacer_payload(
         embeds=[embed], is_edit=False, target=interaction, extra_files=extra_files

--- a/src/discordbot/utils/llm.py
+++ b/src/discordbot/utils/llm.py
@@ -49,9 +49,10 @@ async def parse_responses_or_none[StructuredT: BaseModel](  # noqa: PLR0913 -- s
     """Runs one best-effort structured Responses.parse call, returning None on any failure.
 
     Owns the shared proxy call surface, the timeout, and the failure handling so each caller
-    only maps None to its own fallback: a timeout, an empty or refused output or a payload
-    that does not match `text_format` (both surface as `ValidationError`), an incomplete
-    (truncated) response, or any other error all degrade to None.
+    only maps None to its own fallback: a timeout, an empty output or a payload that does
+    not match `text_format` (both surface as `ValidationError`), a refusal (which simply
+    leaves `output_parsed` None), an incomplete (truncated) response, or any other error
+    all degrade to None.
     """
     try:
         async with asyncio.timeout(delay=timeout_seconds):

--- a/src/discordbot/utils/media_delivery.py
+++ b/src/discordbot/utils/media_delivery.py
@@ -10,7 +10,7 @@ decision and differs only in how it sends the result.
 This module also owns the two low-level concerns the decision needs: the destination's real
 upload ceiling (`upload_limit_for`) and the external static host that turns oversized media
 into a public URL (`MediaHostingService`, env-backed via `MediaHostingConfig`). The host is
-best-effort: every method returns None (never raises) when hosting is disabled, unconfigured,
+best-effort: a publish returns None rather than raising when hosting is disabled, unconfigured,
 handed a non-allowlisted suffix, or fails to write, so a `MEDIA_HOSTING_ENABLED=false` (or
 unconfigured) deployment degrades to its prior, host-free behavior at every call site.
 """
@@ -534,7 +534,7 @@ class MediaHostingService(BaseModel):
                     continue
 
     def run_maintenance(self, *, now: float) -> tuple[int, int]:
-        """One sweep for the cleanup loop: reap expired, enforce the cap, clear stale temps.
+        """One sweep for the cleanup loop: clear stale temps, reap expired, enforce the cap.
 
         Returns (deleted_count, freed_bytes). Age runs before size so the cap acts on what remains.
         """
@@ -701,9 +701,10 @@ class MediaDeliveryPlanner(BaseModel):
 def build_media_delivery_planner() -> MediaDeliveryPlanner:
     """Builds the default MediaDeliveryPlanner wired to the env-configured external media host.
 
-    The shared wiring used by every cog that delivers media (the streamer builds its own
-    test-friendly disabled planner instead). `MediaHostingConfig` self-disables when the host is
-    unconfigured, so this stays the byte-for-byte host-free path until hosting is set up.
+    The shared wiring used by every cog that delivers media, the QA streamer included: it is
+    handed this planner by `gen_reply/cog.py`, and its own field default is a disabled planner
+    so that a streamer built without one drops oversize media instead of hosting it. `MediaHostingConfig` self-disables when the host is unconfigured, so this stays
+    the byte-for-byte host-free path until hosting is set up.
     """
     return MediaDeliveryPlanner(media_hosting=MediaHostingService(config=MediaHostingConfig()))
 

--- a/src/discordbot/utils/message_cleanup.py
+++ b/src/discordbot/utils/message_cleanup.py
@@ -219,7 +219,12 @@ async def _fetch_tracked_message(bot: commands.Bot, record: PendingPublicMessage
 
 
 async def delete_public_message(message: Message, message_id: int | None = None) -> bool:
-    """Deletes a public message and removes its persisted cleanup record."""
+    """Deletes a public message and removes its persisted cleanup record.
+
+    Returns:
+        True when the message is gone, an already-deleted one included; False when Discord
+        refused the delete, which keeps the record for the next process's startup sweep.
+    """
     resolved_message_id = message_id if message_id is not None else getattr(message, "id", None)
     try:
         await message.delete()

--- a/src/discordbot/utils/model_pricing.py
+++ b/src/discordbot/utils/model_pricing.py
@@ -241,8 +241,9 @@ def load_model_info() -> dict[str, ModelPriceEntry]:
 def refresh_model_info() -> None:
     """Loads the price table, or re-checks upstream while what is held did not come from it.
 
-    `cli.py`'s `price_table_task` runs this off the event loop, so neither the first load
-    nor a retry is ever paid on a lookup's path. Once upstream has served this process
+    `cli.py`'s `price_table_task` runs this off the event loop, so no RETRY is ever paid on
+    a lookup's path. The first load still falls to whichever caller reaches it first, which
+    is why `_write_mirror` needs a unique temp name. Once upstream has served this process
     there is nothing left to recover and every later call returns on the second branch.
 
     A retry that fails keeps what is held: the mirrored table a degraded process is

--- a/src/discordbot/utils/owned_message_views.py
+++ b/src/discordbot/utils/owned_message_views.py
@@ -32,6 +32,9 @@ async def send_ephemeral_notice(
             await interaction.followup.send(content=content, ephemeral=True)
             return
         await interaction.response.send_message(content=content, ephemeral=True)
+    # Broad on purpose: the notice is advisory, and every way Discord can refuse it (an expired
+    # token, an already-answered response, a transient HTTP error) must leave the caller's own
+    # flow running, whether that is an ownership rejection or a button callback.
     except Exception:
         logfire.warn(log_message, _exc_info=True)
 
@@ -107,7 +110,13 @@ async def edit_owned_public_message(
     file: File | None = None,
     message: Message | None = None,
 ) -> None:
-    """Edits the panel's current message for a component or modal interaction."""
+    """Edits the panel's current message for a component or modal interaction.
+
+    Once the interaction has already been answered and the panel's own message is gone, this
+    degrades to a fresh followup: the deleted message's stale cleanup record is forgotten
+    first, and the followup is bound to the view and tracked for cleanup in its place, so the
+    panel keeps its idle deletion.
+    """
     target_message = message or interaction.message
     if view is not None:
         view.bind_message(message=target_message)

--- a/src/discordbot/utils/sqlite_config.py
+++ b/src/discordbot/utils/sqlite_config.py
@@ -1,9 +1,9 @@
 """Shared SQLite connection configuration for the project's DB engines.
 
-Economy, stock, message-log, and cleanup storage all open SQLite with the same
-WAL / synchronous / busy_timeout PRAGMA trade-off. This helper centralizes that
-setup so every engine configures connections the same way. `StoredInteger`
-engines additionally register the integer-aware UDFs.
+Every SQLite engine in the project opens connections with the same WAL /
+synchronous / busy_timeout PRAGMA trade-off. This helper centralizes that setup
+so every engine configures connections the same way. `StoredInteger` engines
+additionally register the integer-aware UDFs.
 """
 
 from typing import Any

--- a/src/discordbot/utils/stored_integer.py
+++ b/src/discordbot/utils/stored_integer.py
@@ -101,7 +101,14 @@ class StoredIntegerComparator(TypeDecorator.Comparator[int]):
 
 
 class StoredInteger(TypeDecorator[int]):
-    """Persists Python integers as decimal text in SQLite."""
+    """Persists Python integers as decimal text in SQLite.
+
+    Text rather than INTEGER because a balance can outgrow SQLite's 64-bit integer, which
+    Python's own int never does; the comparator keeps SQL arithmetic and comparisons
+    numeric. Ordering is NOT covered: SQLAlchemy exposes no `ORDER BY` hook here, so a bare
+    `order_by` on one of these columns sorts lexically, and every DB-side ranking builds its
+    own decimal-aware order terms instead.
+    """
 
     impl = Text
     cache_ok = True

--- a/src/discordbot/utils/threads.py
+++ b/src/discordbot/utils/threads.py
@@ -788,9 +788,11 @@ class ThreadsOutput(BaseModel):
     quote_count: int = Field(default=0, description="Number of quote posts")
     reshare_count: int = Field(default=0, description="Total reshare count")
     taken_at: datetime | None = Field(default=None, description="Post creation time")
-    # Its own media stays URL-only: `video_paths` is always empty here because neither caller
-    # downloads a quoted clip (the expansion links it, the reply pipeline uploads from the URL),
-    # which is also what keeps `parse` and `parse_metadata` producing equal trees.
+    # Its own media stays URL-only in this walk: `video_paths` is always empty here because
+    # `_build_output` never downloads for a quoted post, which is also what keeps `parse` and
+    # `parse_metadata` producing equal trees. The expansion links a quoted clip instead of
+    # attaching it; the reply pipeline fetches what it wants from these URLs itself, images
+    # straight to bytes and a clip into a scratch dir of its own.
     quoted: "ThreadsOutput | None" = Field(
         default=None,
         description="The post this one quotes, absent when it quotes nothing readable",
@@ -1095,7 +1097,9 @@ class ThreadsDownloader(BaseModel):
             The Path to the downloaded file.
 
         Raises:
-            RuntimeError: If the download fails.
+            RuntimeError: If the HTTP fetch fails.
+            OSError: If the file cannot be written. A caller that removed the scratch dir
+                mid-download gets `FileNotFoundError` here, deliberately: see below.
         """
         # Created before the request, never after: a caller that cancels mid-download cannot stop
         # the worker thread (`asyncio.to_thread` abandons it), so it may remove the scratch dir
@@ -1319,8 +1323,9 @@ class ThreadsDownloader(BaseModel):
         """Parses a Threads post URL into the conversation WITHOUT downloading media.
 
         Mirrors `parse` with `download=False`, so no video is written to disk and there is
-        nothing to clean up (not a context manager). The reply pipeline uses this: it fetches
-        the target's media itself, straight to the answer model.
+        nothing to clean up (not a context manager). The reply pipeline uses this: it fetches the
+        media it wants (the target's, plus that of the post it quotes) from the returned URLs
+        itself, straight to the answer model.
 
         Args:
             url: The Threads post URL.

--- a/src/discordbot/utils/timezone.py
+++ b/src/discordbot/utils/timezone.py
@@ -1,8 +1,10 @@
 """Shared Asia/Taipei timezone helpers for persisted timestamps.
 
-Economy and stock storage both stamp rows in Asia/Taipei and re-interpret
-stored datetimes in that zone. This module is the single source for those
-helpers so the two database layers stay aligned.
+The storage layers that reach for these stamp their rows in Asia/Taipei and
+re-interpret stored datetimes in that zone; this module is the single source so
+no layer grows its own copy. Not every table is in that zone — anything stamped
+by SQLite's own `CURRENT_TIMESTAMP` or by a Discord snowflake time is UTC and
+never comes through here.
 """
 
 from typing import Final


### PR DESCRIPTION
Closes #502.

Every comment and docstring under `src/` checked against the implementation it sits on. 164 tracked `.py` files, all accounted for: **101 changed, 63 read with nothing to correct.** 948 insertions, 523 deletions, re-derived from `git diff` rather than copied from any worker's ledger.

## How it ran

24 disjoint slices, verified mechanically to cover the tracked set exactly with no file in two slices. One subagent per slice, dispatched together, each carrying the `code-docs` rules, the doc recipe and its own file list. The precedence stated to every one of them: **the only irreversible failure here is deleting the sole copy of a reason**, so length is never on its own grounds for a cut, and what is hunted is false rather than long. An existing docstring that merely restates its own function name stays, per the ruling that settled the same question on #503.

Then three review passes, because they fail differently and only the first is visible in the diff:

1. **Deletions.** No issue number, date or measured quantity disappeared from any changed file (checked mechanically across all 101). The four riskiest whole-sentence removals were then read against the code by hand.
2. **Rewrites, refute-first.** Nine reviewers over the 101 changed files, each told to find what the sweep got wrong. They found **21 corrections the sweep itself introduced** — a rewritten sentence is a new factual claim nobody had reviewed, and this is where they surfaced. All fixed here.
3. **Files reported clean.** Five reviewers over the 63 files that never enter the diff, where a miss is structurally unreviewable. They found **11 more stale comments** the slices had all passed over.

## What was actually wrong

The drift clustered on features the tree dropped: `main.md` and the `v1` header (#408), the casino narrator and the LLM bot player (#303), mypy (#356), the deep-research escalation tiers (#447), `scripts/reset_economy.py` (#248), the fishing money-sink design (#351), Veo. A keyword grep finds almost none of it — every one of these came out of reading an implementation next to the prose describing it.

A few worth naming:

- `typings/stock.py` described **19** money fields as "in cents" that hold whole wallet cash. Only `*_cents` fields are cent-denominated; the rest are rounded out of cents by `cash_ceil` / `cash_floor` before they are stored. The module now says so once at the top.
- `typings/economy.py` documented the VIP purchase as a "10M debit". `VIP_PURCHASE_COST` is 50,000 — off by a factor of 200.
- `utils/stored_integer.py` claimed the comparator keeps SQL "arithmetic and ordering" numeric. It has no `ORDER BY` hook at all, which is exactly why every DB-side ranking hand-builds decimal-aware order terms. A reader trusting it writes `order_by(balance)` and gets `"9" > "10000"`.
- `cogs/feedback/github.py` said its comment paging drops "the oldest … the end nobody is looking at". GitHub lists comments oldest-first, so past the bound it drops the **newest** — precisely the end the panel renders.

## Scope

Documentation only, proved mechanically rather than asserted: every changed file's AST is identical to `main` once docstrings and `Field(description=...)` strings are normalised away, so no code token moved. `Field` descriptions are documentation and a false one was in scope, but they were corrected only where false, never swept for style — all 41 are listed in the check output.

Eight classes are passed as `text_format=` to the Responses API, which sends their class docstring and field descriptions to the model verbatim as JSON schema. Editing one is a prompt change, so they were frozen and are verified byte-identical: `RouteClassification`, `EffortGrade`, `RawMemoryDraft`, `MemoryObservation`, `ConsolidatedMemory`, `MemoryFactDelta`, `StockNewsDraft`, `ReportWriteUp`. One of them is carrying a falsehood to the model today; that is filed rather than fixed here, since changing it changes behaviour.

`uvx pre-commit run -a` clean, `uv run pytest` 1762 passed.

## Defects found, not fixed

This was the closest reading this code has had and it surfaced real bugs, filed separately per #501's constraint. None of them is touched by this diff.

---

Opened-by: Claude Opus 5
