### PR TITLE
fix(pytest): stop clearing the cache and namespace it per project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ addopts = [
     "--cov-report=term-missing:skip-covered",
     "--cov-report=xml:./.github/reports/coverage.xml",
     "--junitxml=./.github/reports/.coverage.pytest.xml",
-    "--cache-clear",
     "-n=auto",
     "--no-header",
     "--cov-fail-under=80",
@@ -31,7 +30,9 @@ markers = [
 minversion = "8.2"
 testpaths = "tests/"
 python_files = "test_*.py"
-cache_dir = "~/.cache/pytest"
+# Namespaced per project: pytest keys its cache by nodeid relative to rootdir, so a
+# shared directory lets one project's lastfailed select tests in another.
+cache_dir = "~/.cache/pytest/discordbot"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 


### PR DESCRIPTION
## Problem

Ported from `Mai0313/repo_template#435`, where this was found. Two lines in
`[tool.pytest.ini_options]` cancelled each other out:

- `--cache-clear` wiped the entire cache directory at the start of every run.
- `cache_dir = "~/.cache/pytest"` pointed that directory outside the repo.

Because the cache was cleared every run it never held anything, which silently
disabled `--lf`, `--ff` and `--stepwise`. On CI the flag is a no-op anyway, since
every runner starts with an empty cache.

Dropping `--cache-clear` alone is not enough. pytest keys its cache by nodeid
relative to rootdir, and `~/.cache/pytest` is one directory shared by every repo
inheriting this config, so `v/cache/lastfailed` is shared too. A stale entry from
another checkout makes `--lf` here run a subset of this suite rather than the tests
that actually failed. Since every template-derived repo uses `tests/test_*.py`,
those collisions are likely rather than theoretical.

ruff's `cache-dir` can be shared safely because ruff keys its cache by file content
hash. Copying that path shape to pytest was the original mistake.

## Change

- Drop `--cache-clear` from `addopts`.
- Namespace the cache directory as `~/.cache/pytest/discordbot`, with a comment
  recording why it must not be collapsed back to a shared path.

## Verification

- `uv run pytest`: 1762 passed.
- `uv run pre-commit run --files pyproject.toml` passes.

Opened-by: Claude Opus 5 (1M context)
