### PR TITLE
ci: gate the test suite on the diff instead of the branch name

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -161,7 +161,7 @@ The pytest configuration lives in `pyproject.toml`.
 uv run pytest
 ```
 
-Coverage must stay at or above 80%. CI runs tests on Python 3.12 and 3.13 for pushes and pull requests targeting `main`, `master`, or `release/*`, except for documentation, chore, and CI branch prefixes intentionally skipped by the test workflow.
+Coverage must stay at or above 80%. CI runs tests on Python 3.12 and 3.13 for pushes and pull requests targeting `main`, `master`, or `release/*`. What decides whether they run is the diff, not the branch name: the suite is skipped only when every changed file is Markdown, and `src/discordbot/cogs/gen_reply/capabilities.md` does not count as Markdown there because `tests/test_capabilities.py` reads it.
 
 Async tests that record nested test-double calls in a list must compare a stable invariant such as a mapping, set, `Counter`, or sorted value. An exact sequence assertion needs an adjacent `# order-contract: <reason>` explaining the production guarantee. When completion order is the behavior under test, control it with an event or barrier instead of relying on scheduler timing.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -161,7 +161,7 @@ The pytest configuration lives in `pyproject.toml`.
 uv run pytest
 ```
 
-Coverage must stay at or above 80%. CI runs tests on Python 3.12 and 3.13 for pushes and pull requests targeting `main`, `master`, or `release/*`. What decides whether they run is the diff, not the branch name: the suite is skipped only when every changed file is Markdown, and `src/discordbot/cogs/gen_reply/capabilities.md` does not count as Markdown there because `tests/test_capabilities.py` reads it.
+Coverage must stay at or above 80%. CI runs tests on Python 3.12 and 3.13 for pushes and pull requests targeting `main`, `master`, or `release/*`. What decides whether they run is the diff, never the branch name: the suite is skipped when every changed file is Markdown, and `src/discordbot/cogs/gen_reply/capabilities.md` does not count as Markdown there because `tests/test_capabilities.py` reads it.
 
 Async tests that record nested test-double calls in a list must compare a stable invariant such as a mapping, set, `Counter`, or sorted value. An exact sequence assertion needs an adjacent `# order-contract: <reason>` explaining the production guarantee. When completion order is the behavior under test, control it with an event or barrier instead of relying on scheduler timing.
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,20 +1,29 @@
 name: Tests
 
+# The diff decides whether the suite runs, never the branch name: a conventional-commits type says
+# what a change is for and nothing about what it touched, so `chore/`, `ci/` and `docs/` branches
+# have all carried Python here (#486). `**` first is what makes this fail safe, since a denylist
+# covers a file type the repository grows later while an allowlist quietly stops running as the tree
+# moves. `capabilities.md` is not prose: it is what `tests/test_capabilities.py` reads.
 on:
   push:
     branches:
       - main
       - master
       - release/*
-    paths-ignore:
-      - "**/*.md"
+    paths:
+      - "**"
+      - "!**/*.md"
+      - "src/discordbot/cogs/gen_reply/capabilities.md"
   pull_request:
     branches:
       - main
       - master
       - release/*
-    paths-ignore:
-      - "**/*.md"
+    paths:
+      - "**"
+      - "!**/*.md"
+      - "src/discordbot/cogs/gen_reply/capabilities.md"
 
 permissions: write-all
 
@@ -22,7 +31,6 @@ jobs:
   run_tests:
     name: Run Tests
     runs-on: ubuntu-latest
-    if: ${{ !(startsWith(github.head_ref, 'chore/') || startsWith(github.head_ref, 'ci/') || startsWith(github.head_ref, 'docs/')) }}
 
     strategy:
       fail-fast: false

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -599,6 +599,32 @@ def test_admin_description_check_reads_every_locale_it_has_to() -> None:
     assert not _names_an_unqualified_admin(text="Central banker forced collection.")
 
 
+def test_the_tests_workflow_reruns_on_an_edit_to_the_capability_document() -> None:
+    """The CI path filter names this document by literal path, and nothing else ties them.
+
+    `.github/workflows/test.yml` skips the suite on a diff that is nothing but Markdown, and
+    pulls this one file back past that rule because the suite reads it. Nothing derives the
+    path it writes down: `capabilities.py` resolves the document relative to itself, so moving
+    the pair would leave production and every other test green while CI quietly stopped running
+    on a Markdown-only edit to it. That is the wrong-signal skip #486 took off the branch name,
+    one door over, and its whole failure mode is a check that never appears.
+    """
+    repo_root = Path(__file__).resolve().parents[1]
+    document = repo_root / "src" / "discordbot" / "cogs" / "gen_reply" / "capabilities.md"
+    assert document.is_file(), (
+        f"{document} is gone, so the document moved; the re-include in "
+        ".github/workflows/test.yml has to move with it"
+    )
+    assert document.read_text(encoding="utf-8").strip() == CAPABILITIES_DOC, (
+        f"{document} is not the document the package loads any more"
+    )
+    workflow = (repo_root / ".github" / "workflows" / "test.yml").read_text(encoding="utf-8")
+    assert document.relative_to(repo_root).as_posix() in workflow, (
+        "an edit to the capability document can turn this module red, so "
+        ".github/workflows/test.yml must re-include it past its `!**/*.md` rule"
+    )
+
+
 def test_capabilities_block_is_a_low_authority_assistant_note() -> None:
     """The reference rides as the bot's own note, never as a rule that could outrank the user."""
     block = render_capabilities_block()


### PR DESCRIPTION
Closes #486

`Run Tests` decided from the head branch name whether it ran at all:

```yaml
if: ${{ !(startsWith(github.head_ref, 'chore/') || startsWith(github.head_ref, 'ci/') || startsWith(github.head_ref, 'docs/')) }}
```

## The decision

Skipping the suite on a change that cannot affect it is still worth having, so the exemption stays. What goes is the signal the rule reads.

A conventional-commits type states what a change is *for*. It says nothing about what the change *touched*, and those are the two different questions the gate was conflating. `chore` is this repository's own label for "Maintenance, CI, build and tooling", a category that regularly includes Python, and the record bears that out: #485 rewrote ~150 lines across `scripts/regen_memories.py` and its test, #511 touched 101 Python files under `src/`, and #546 / #547 / #548 deleted 17,014 lines across 86 files including four structural guard tests. Every one of them reported `skipping`, and every one merged on the strength of a local run alone.

Renaming those branches was never available: `.github/labeler.yml` reads the prefix and nothing else, so a correctly named chore branch is exactly the one that skipped.

The trigger's path filter already asks the right question and was already in the file. It just had the job taken off it by the `if:` underneath, so the fix is to delete the `if:` and let the filter answer.

## What changed

- The `if:` on `run_tests` is gone. The branch name goes back to meaning only what the labeler reads it for.
- `paths-ignore: ["**/*.md"]` becomes a `paths:` sequence, purely so one file can be pulled back in (GitHub forbids `paths` and `paths-ignore` on the same event):

  ```yaml
  paths:
    - "**"
    - "!**/*.md"
    - "src/discordbot/cogs/gen_reply/capabilities.md"
  ```

  `**` first is the load-bearing part. A denylist covers a file type the repository grows later on the day it arrives; an allowlist of `src/**`, `tests/**`, `pyproject.toml` and friends would read as tighter and fail the other way, quietly under-running as the tree moves. That is the same shape of bug as the one being fixed, just with a slower fuse.

- `src/discordbot/cogs/gen_reply/capabilities.md` is not prose here, so it is pulled back in. `capabilities.py` reads it into `CAPABILITIES_DOC` at import time and `tests/test_capabilities.py` scans it in both directions, so naming a `/command` that is not a runnable path turns the suite red. Under the old `**/*.md` ignore, an edit to that file alone ran no tests at all: the same wrong-signal failure one door over, in the same three lines. It is the only tracked Markdown file any test reads; the other eight are read by nothing.

- `test_the_tests_workflow_reruns_on_an_edit_to_the_capability_document` guards that re-include. Nothing derives the path the workflow writes down, and `capabilities.py` resolves the document relative to itself, so moving the pair would leave production and every other test green while CI silently stopped running on Markdown-only edits to it. The guard was run against a workflow with the re-include deleted and fails there.

- `.github/CONTRIBUTING.md` documented the old rule and now documents this one.

## Verifying it

The thing being changed *is* the CI config, so a green check set proves nothing by itself. The probe rides this PR: the branch is `ci/run-tests-gate-on-the-diff`, carrying one of the three prefixes the old gate skipped, so `Run Tests` reporting a real run instead of `skipping` is the fix demonstrating itself. For a `pull_request` event GitHub evaluates the workflow file from the merge commit, so it is this version of the gate being exercised. The diff reaches only `.github/**` and `tests/`, so a run at all also settles that `**` matches inside a dotted directory, which GitHub's filter-pattern documentation does not state either way.

The `capabilities.md` re-include is unverified end to end and stays that way after merge: a `pull_request` path filter is evaluated against the whole PR diff, and this one already carries non-Markdown files. It is a strict widening of what triggers, so its worst case is the behaviour that shipped before.

`uvx pre-commit run -a` and `uv run pytest` both pass locally.

## What this does not do

- **Running is not blocking.** `main` has no required status checks (the only ruleset carries `deletion` and `non_fast_forward`), so a Python PR now runs the suite and can still be merged red or mid-run. Closing that is a repository-settings decision rather than a workflow one, and it is not made here.
- **A broken filter fails silently.** A path-filtered workflow that does not match produces no check row at all, where the old `if:` produced a visible `Run Tests | skipping`. That was already true of `paths-ignore` for Markdown-only PRs, so it is not a regression, but it is why the filter's one hand-written path is now pinned by a test.
- **The pre-commit updater still merges itself untested**, filed as #555: `.github/workflows/pre-commit-updater.yml` runs `gh pr merge --squash` seconds after opening its PR, with no `--auto` and nothing to wait on, so `Run Tests` now starts on that branch and is cancelled by `delete-branch: true` before it can finish. Same requirement as this issue, through a door this change does not reach.

## Not in this change

`.github/workflows/test.yml` is template-managed. `repo_template`, `go_template` and `rust_template` all carry the same `if:` line, so the gate is live in every downstream repository and this fix does not reach them. Propagating it is a separate change against the templates, and the `capabilities.md` line is repo-specific and should not travel with it.

---

Filed-by: Claude Opus 5
Planned-by: Claude Opus 5
Opened-by: Claude Opus 5
