### PR TITLE
fix(economy): report the credit contracts /credit status cannot list

### DIFF
--- a/src/discordbot/cogs/economy/embeds.py
+++ b/src/discordbot/cogs/economy/embeds.py
@@ -45,6 +45,10 @@ CENTRAL_BANK_COLOR = 0x1ABC9C
 VIP_COLOR = 0xF1C40F
 ERROR_COLOR = DISCORD_RED
 
+# Embed description hard limit is 4096; the headroom is what lets the credit-status
+# remainder line be strictly additive, so closing the list can never cost a contract.
+_CREDIT_STATUS_DESCRIPTION_BUDGET = 3800
+
 
 class TransferParticipant(BaseModel):
     """Display identity for one side of a transfer embed."""
@@ -504,7 +508,13 @@ def build_credit_call_embed(
 
 
 def build_credit_status_embed(*, contracts: list[LoanContractView], viewer_id: int) -> Embed:
-    """Builds the caller's active personal credit contracts embed."""
+    """Builds the caller's active personal credit contracts embed.
+
+    Every contract is listed until the description budget runs out, and whatever did not
+    fit is then reported as a count rather than dropped: a debt the borrower cannot see is
+    one they will not repay while the interest keeps accruing. Contracts arrive oldest
+    first, so the ones held back are the newest.
+    """
     lines = [
         (
             f"{'欠 ' + contract.lender_name if contract.borrower_id == viewer_id else contract.borrower_name + ' 欠你'} "
@@ -512,8 +522,14 @@ def build_credit_status_embed(*, contracts: list[LoanContractView], viewer_id: i
             f"利息 {amount_code(amount=contract.interest_due, compact=True)} · "
             f"{rate_text(monthly_rate_bps=contract.monthly_rate_bps)}"
         )
-        for contract in contracts[:10]
+        for contract in contracts
     ]
+    unlisted = 0
+    while len(lines) > 1 and len("\n".join(lines)) > _CREDIT_STATUS_DESCRIPTION_BUDGET:
+        lines.pop()
+        unlisted += 1
+    if unlisted:
+        lines.append(f"-# 還有 {unlisted} 筆未顯示")
     return Embed(title="信貸狀態", description="\n".join(lines), color=BORROW_COLOR)
 
 

--- a/src/discordbot/cogs/gen_reply/capabilities.md
+++ b/src/discordbot/cogs/gen_reply/capabilities.md
@@ -61,7 +61,7 @@ Loans between members:
 - `/credit borrow` — ask another member for a loan; the lender accepts or rejects it with a button, and it is rejected automatically after 180 seconds
 - `/credit repay` — repay a lender
 - `/credit call` — collect from someone who borrowed from you
-- `/credit status` — your active personal contracts
+- `/credit status` — every active personal contract you are on, as borrower or lender
 
 Central bank:
 

--- a/tests/test_economy_embeds.py
+++ b/tests/test_economy_embeds.py
@@ -1,0 +1,56 @@
+"""Tests for economy command embeds."""
+
+from datetime import UTC, datetime
+
+from discordbot.typings.economy import LoanLenderType, LoanContractView, LoanContractStatus
+from discordbot.cogs.economy.embeds import build_credit_status_embed
+
+_EMBED_DESCRIPTION_LIMIT = 4096
+
+
+def _contract(*, contract_id: int, lender_name: str = "lender") -> LoanContractView:
+    """Builds one active personal contract owed by viewer 1 to `lender_name`."""
+    opened_at = datetime(2026, 1, 1, tzinfo=UTC)
+    return LoanContractView(
+        contract_id=contract_id,
+        lender_type=LoanLenderType.USER,
+        lender_id=2,
+        lender_name=lender_name,
+        borrower_id=1,
+        borrower_name="borrower",
+        principal_remaining=10_000,
+        interest_due=150,
+        monthly_rate_bps=150,
+        opened_at=opened_at,
+        last_interest_accrued_at=opened_at,
+        status=LoanContractStatus.ACTIVE,
+    )
+
+
+def test_credit_status_lists_every_contract_past_the_old_ten_cap() -> None:
+    """An eleventh contract is on the embed, and nothing claims anything was held back."""
+    contracts = [_contract(contract_id=index, lender_name=f"lender{index}") for index in range(11)]
+    embed = build_credit_status_embed(contracts=contracts, viewer_id=1)
+    description = embed.description or ""
+    for contract in contracts:
+        assert f"欠 {contract.lender_name} " in description
+    assert "未顯示" not in description
+
+
+def test_credit_status_reports_what_it_could_not_list() -> None:
+    """A list past the description budget states its remainder instead of dropping it."""
+    contracts = [
+        _contract(contract_id=index, lender_name="長名字測試借款人帳號" * 3)
+        for index in range(200)
+    ]
+    embed = build_credit_status_embed(contracts=contracts, viewer_id=1)
+    description = embed.description or ""
+    assert len(description) <= _EMBED_DESCRIPTION_LIMIT
+    listed = sum(1 for line in description.split("\n") if line.startswith("欠 "))
+    assert f"-# 還有 {len(contracts) - listed} 筆未顯示" in description
+
+
+def test_credit_status_labels_the_side_the_viewer_is_on() -> None:
+    """A contract the viewer lent on reads as owed to them, not by them."""
+    embed = build_credit_status_embed(contracts=[_contract(contract_id=1)], viewer_id=2)
+    assert "borrower 欠你 " in (embed.description or "")


### PR DESCRIPTION
Closes #513

`build_credit_status_embed` rendered `contracts[:10]` and said nothing about the rest, so
an eleventh active personal loan simply was not on the embed. Ten was never a Discord
limit — a contract line is roughly 40-60 characters against a 4096-character description —
and of all the rows to drop quietly, a debt list is the worst one: interest keeps accruing
on a loan the borrower cannot see.

The cap is now the embed's own budget, and whatever does not fit is reported rather than
dropped. `cogs/games/history_text.py::build_blackjack_history_embed` already does exactly
this for `/games blackjack_history`, so `/credit status` takes that shape instead of
inventing a third one. It also has the property #513 asks for from
`_omitted_post_notice_pages`: the closing line is strictly additive, here because the
budget sits far enough below 4096 that appending it can never push a contract off the list
it reports on. Contracts arrive oldest first, so the ones held back are the newest — the
same ones `[:10]` used to drop.

In practice nobody sees the notice; the point is that the ceiling is the real one and
announces itself when it is reached.

## Not done

Pagination or a PNG board. Both are options under the project rule, but a debt list that
fits in one embed needs neither, and a button view on an ephemeral follow-up is a lot of
machinery for a case no account in the store is near.

## Tests

`tests/test_economy_embeds.py` is new — `tests/test_economy.py` is being edited by a
sibling session on another issue in this batch. It covers the eleventh contract that used
to vanish, a worst-case list that stays inside 4096 while stating its remainder, and the
borrower/lender side label. Both new-behaviour tests were confirmed red against
`contracts[:10]` before the fix went back in.

`gen_reply/capabilities.md`'s `/credit status` line now says it covers every active
contract on both sides of the ledger, which is what the command does.

Opened-by: Claude Opus 5
