### PR TITLE
fix: find a URL typed flush against Chinese

### DIFF
--- a/src/discordbot/cogs/gen_reply/cog.py
+++ b/src/discordbot/cogs/gen_reply/cog.py
@@ -19,6 +19,7 @@ from openai.types.responses.response_input_file_param import ResponseInputFilePa
 from openai.types.responses.response_input_text_param import ResponseInputTextParam
 from openai.types.responses.response_input_image_param import ResponseInputImageParam
 
+from discordbot.utils.urls import URL_START_ANCHOR
 from discordbot.typings.llm import LLMConfig
 from discordbot.utils.douyin import DOUYIN_URL_RE, is_douyin_post_url
 from discordbot.utils.images import convert_base64_to_data_uri
@@ -158,7 +159,7 @@ if TYPE_CHECKING:
     from openai.types.responses import ResponseStreamEvent
 
 
-_MESSAGE_URL_RE = re.compile(pattern=r"(?i)\b(?:https?://|www\.)\S+")
+_MESSAGE_URL_RE = re.compile(pattern=rf"(?i){URL_START_ANCHOR}(?:https?://|www\.)\S+")
 
 # Preserve the existing eight-user context target for optional model-selected additions.
 # Deterministic participants are never displaced: if they fill or exceed the target, the
@@ -225,9 +226,9 @@ def _first_url_match(pattern: re.Pattern[str], texts: list[str]) -> re.Match[str
 def _carries_url(message: Message) -> bool:
     """Whether the message's own rendered text carries any URL.
 
-    Read by the SUMMARY -> QA reroute guard. `_MESSAGE_URL_RE` anchors on a word boundary, and
-    CJK is a word character, so a URL typed flush against Chinese ("看這篇https://...") is
-    missed; the reroute degrades softly on that and stays put.
+    Read by the SUMMARY -> QA reroute guard. `_MESSAGE_URL_RE` takes its head from
+    `URL_START_ANCHOR`, so a URL typed flush against Chinese ("看這篇https://...") counts here
+    the same as one with a space in front of it, and the two generic scanners agree on it.
     """
     return (
         _first_url_match(

--- a/src/discordbot/utils/urls.py
+++ b/src/discordbot/utils/urls.py
@@ -9,10 +9,19 @@ find the link rather than fail on it.
 import re
 from collections.abc import Sequence
 
+# Where a URL is allowed to start. `\b` is the natural spelling of "not glued to the end of
+# another token", but Python's `\w` counts every Unicode letter, so it also refuses the `h`
+# after a Chinese character: `看這篇https://example.com` read as no URL at all, which is how a
+# lot of people type (#492). Refusing only an ASCII word character keeps `xhttps://...` out and
+# lets the Chinese in, widening the pattern by one class of characters rather than by a class of
+# strings. Shared with `gen_reply/cog.py::_MESSAGE_URL_RE` so the two generic scanners cannot
+# drift on where a URL begins.
+URL_START_ANCHOR = r"(?<![A-Za-z0-9_])"
+
 # Generic fallback. `[^\s<>]` stops at whitespace and at the angle brackets Discord and
 # Markdown wrap links in; it deliberately does NOT stop at CJK, because a site-specific
 # pattern is the right tool for text that runs straight into the link with no space.
-URL_RE = re.compile(r"(?i)\bhttps?://[^\s<>]+")
+URL_RE = re.compile(rf"(?i){URL_START_ANCHOR}https?://[^\s<>]+")
 
 # Sentence punctuation a URL never really ends on, stripped from the tail of a generic match
 # so `see https://example.com/x.` does not carry the full stop into the URL.

--- a/src/discordbot/utils/urls.py
+++ b/src/discordbot/utils/urls.py
@@ -19,8 +19,9 @@ from collections.abc import Sequence
 URL_START_ANCHOR = r"(?<![A-Za-z0-9_])"
 
 # Generic fallback. `[^\s<>]` stops at whitespace and at the angle brackets Discord and
-# Markdown wrap links in; it deliberately does NOT stop at CJK, because a site-specific
-# pattern is the right tool for text that runs straight into the link with no space.
+# Markdown wrap links in; it deliberately does NOT stop at CJK, so Chinese written straight
+# after a link is carried into the match. Where a link ENDS is what a site-specific pattern is
+# the right tool for; where it starts is `URL_START_ANCHOR`'s job just above.
 URL_RE = re.compile(rf"(?i){URL_START_ANCHOR}https?://[^\s<>]+")
 
 # Sentence punctuation a URL never really ends on, stripped from the tail of a generic match

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -405,6 +405,21 @@ def test_download_video_drops_sentence_punctuation_after_a_link() -> None:
     )
 
 
+def test_download_video_finds_a_link_typed_flush_against_chinese() -> None:
+    r"""A link with no space in front of it is still a link, but only past a non-ASCII word.
+
+    The generic pattern used to head on `\b`, which counts CJK as a word character, so
+    `這個https://...` found nothing at all (#492). A link glued to the end of an ASCII word is
+    still refused, and falls through to the unchanged-passthrough behaviour below.
+    """
+    assert extract_first_url(text="幫我下載這個https://example.com/a/b", patterns=()) == (
+        "https://example.com/a/b"
+    )
+    assert extract_first_url(text="xhttps://example.com/a/b", patterns=()) == (
+        "xhttps://example.com/a/b"
+    )
+
+
 def test_download_video_passes_unparseable_input_through() -> None:
     """Text with no URL is handed on unchanged, so it fails downstream as it always did."""
     assert extract_first_url(text="  not a url  ", patterns=()) == "not a url"

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -4407,6 +4407,9 @@ async def test_handle_video_reply_single_image_sends_mime_no_aspect_ratio(
     argvalues=[
         "整理懶人包 https://example.test/post",
         "這裡面又在說啥 整理給我聽 https://example.test/post",
+        # No space in front of the link, which is how a lot of people type (#492). The old
+        # `\b` head counted the Chinese as a word character and found no URL here at all.
+        "整理懶人包https://example.test/post",
     ],
 )
 async def test_gen_reply_routes_url_summary_requests_to_qa(content: str) -> None:


### PR DESCRIPTION
`_MESSAGE_URL_RE` (`gen_reply/cog.py`) and `URL_RE` (`utils/urls.py`) both headed on `\b`.
Python's `\w` counts every Unicode letter, so `\b` also refuses the `h` after a Chinese
character, and `幫我看這篇https://example.com/post` — the way a lot of people type — read as no
URL at all. Nothing failed and nothing logged.

Both patterns now head on one shared `URL_START_ANCHOR` = `(?<![A-Za-z0-9_])`, which refuses only
an ASCII word character. `xhttps://...` stays out; the Chinese gets in. That widens the pattern
by one class of characters rather than by a class of strings, and keeps the two generic scanners
from drifting on where a URL may start.

Two things read a generic pattern, and both change the same way. `_carries_url` feeds the
SUMMARY -> QA reroute in `_route_classify`, which stayed on SUMMARY for a link recap typed with no
space. `extract_first_url` feeds `/download_video`, which handed yt-dlp the whole blob instead of
the link inside it.

Where a URL *ends* is untouched: `URL_RE`'s `[^\s<>]+` still swallows Chinese written straight
after a link, which its own docstring already owns and answers with "a site-specific pattern is
the right tool for that". The per-source patterns (`THREADS_URL_RE`, `DOUYIN_URL_RE`,
`YOUTUBE_URL_RE`, `BILIBILI_URL_RE`) carry no `\b` and were never affected.

## Re-measured 2026-08-20 against `data/database/messages.db`

- 315,442 URL-bearing rows; 560 missed by the old anchor (0.178%), consistent with the filing.
- The new anchor finds **509** of them. The remaining 51 are ASCII-glued (`xhttps://…`,
  `/playhttps://…`, `666https://…`) and stay out, which is the anchor still doing its job.
- It also corrects **244** rows the old anchor matched from the *middle* of the URL: with `https`
  glued to Chinese, `\bwww\.` still matched the `www.` inside `https://www.…`, so the scan
  reported a match starting mid-URL. Harmless for a boolean, wrong for anything reading the match.
- Newly matched `www.`-alternative spans: 2, both real domains inside Chinese sentences.
- The one false positive the `www.` alternative could gain is `www` written as laughter in CJK
  chat, where `草www.そうか` would match `www.そうか`. Of the 91,558 `www.` matches in the whole
  log, 2 have no second dot after `www.` and both are truncated real domains, so that shape does
  not occur here — and its spaced form (`草 www.そうか`) already matched under the old anchor, so
  it is not something this change introduces.

## Tests

Both new cases were checked red against the old `\b` before being taken as green:

- `test_gen_reply_routes_url_summary_requests_to_qa` gains the no-space form, so the SUMMARY -> QA
  reroute is pinned on it.
- `test_download_video_finds_a_link_typed_flush_against_chinese` pins both halves for
  `extract_first_url`: the CJK-glued link is found, the ASCII-glued one is still refused.

## Notes

- The filing says two decisions read the pattern. `_hides_content_from_the_grader` was deleted in
  #493, so today only the SUMMARY -> QA reroute in `_route_classify` does. The fix is unchanged;
  the second consumer is just already gone.
- No `capabilities.md` change: the document describes what the bot opens, never that a link needs
  a space in front of it, so no claim in it moves.

Closes #492

---

Opened-by: Claude Opus 5
