### PR TITLE
fix(feedback): keep the newest comments inside the comment page bound

### DIFF
--- a/src/discordbot/cogs/feedback/github.py
+++ b/src/discordbot/cogs/feedback/github.py
@@ -13,6 +13,7 @@ A fresh `AsyncClient` per call is deliberate. The volume is a handful of request
 panel open, and a client held on the cog would outlive the event loop it was built on.
 """
 
+import re
 from typing import Any, Final, Literal
 
 import httpx
@@ -40,8 +41,16 @@ _UNPROCESSABLE = 422
 
 # The comments endpoint answers 30 per page by default; 100 is its maximum, and three
 # pages is far past any report thread while keeping a slow issue from stalling the panel.
+# Which three pages is the load-bearing part; `read_conversation` has it, along with why
+# a thread deeper than the bound costs a fourth request the panel waits on.
 _COMMENTS_PER_PAGE = 100
 _MAX_COMMENT_PAGES = 3
+
+# GitHub numbers its pages in the `Link` header rather than counting them in the body, so
+# the entry marked `rel="last"` is where a paged read learns how deep a thread is. The
+# page number is matched anywhere inside that entry's URL rather than at its end, since
+# nothing promises which query parameter comes last.
+_LAST_PAGE_RE: Final[re.Pattern[str]] = re.compile(r'<[^>]*[?&]page=(\d+)[^>]*>;\s*rel="last"')
 
 
 class GitHubIssuesError(RuntimeError):
@@ -159,19 +168,18 @@ class GitHubIssues(BaseModel):
             "X-GitHub-Api-Version": _API_VERSION,
         }
 
-    async def _request(
+    async def _send(
         self, *, method: str, path: str, payload: dict[str, Any] | None = None
-    ) -> Any:  # noqa: ANN401 -- the GitHub REST payload shape differs per endpoint
-        """Runs one REST call and returns its decoded body.
+    ) -> httpx.Response:
+        """Runs one REST call and hands back the answer GitHub gave.
 
-        Decoding is inside the contract, not next to it: every caller treats
-        `GitHubIssuesError` as the one thing this module raises, so a 2xx carrying an
-        HTML error page from something in front of GitHub has to arrive as that too,
-        rather than as a `JSONDecodeError` nobody upstream is catching.
+        Split out of `_request` for the one reader that needs something off the response
+        that is not in its body: the paged comment read, whose `Link` header is where
+        GitHub says how many pages a thread has.
 
         Raises:
-            GitHubIssuesError: The request never reached GitHub, GitHub answered with a
-                non-2xx status, or the answer was not decodable JSON.
+            GitHubIssuesError: The request never reached GitHub, or GitHub answered with
+                a non-2xx status.
         """
         url = f"{_API_ROOT}/repos/{self.repository}{path}"
         headers = await self._authorized_headers()
@@ -187,6 +195,23 @@ class GitHubIssues(BaseModel):
                 f"{method} {path} answered {response.status_code}: {response.text[:500]}",
                 response.status_code,
             )
+        return response
+
+    async def _request(
+        self, *, method: str, path: str, payload: dict[str, Any] | None = None
+    ) -> Any:  # noqa: ANN401 -- the GitHub REST payload shape differs per endpoint
+        """Runs one REST call and returns its decoded body.
+
+        Decoding is inside the contract, not next to it: every caller treats
+        `GitHubIssuesError` as the one thing this module raises, so a 2xx carrying an
+        HTML error page from something in front of GitHub has to arrive as that too,
+        rather than as a `JSONDecodeError` nobody upstream is catching.
+
+        Raises:
+            GitHubIssuesError: The request never reached GitHub, GitHub answered with a
+                non-2xx status, or the answer was not decodable JSON.
+        """
+        response = await self._send(method=method, path=path, payload=payload)
         try:
             return response.json()
         except ValueError as exc:
@@ -268,29 +293,65 @@ class GitHubIssues(BaseModel):
         except (KeyError, TypeError, ValueError, ValidationError) as exc:
             raise GitHubIssuesError(f"GET /issues/{number} answered an unreadable issue") from exc
 
+    async def _read_comment_page(self, *, number: int, page: int) -> tuple[list[Any], int]:
+        """Reads one page of an issue's comments, and how many pages there are.
+
+        The page count comes off the `Link` header rather than the body, which is why
+        this goes through `_send`. GitHub leaves `rel="last"` off the last page, so its
+        absence means the page in hand is that one, and the answer is the page asked for.
+
+        Raises:
+            GitHubIssuesError: The page could not be read, or was not a list of comments.
+        """
+        response = await self._send(
+            method="GET",
+            path=f"/issues/{number}/comments?per_page={_COMMENTS_PER_PAGE}&page={page}",
+        )
+        try:
+            comments = response.json()
+        except ValueError as exc:
+            raise GitHubIssuesError(
+                f"GET /issues/{number}/comments answered undecodable content: "
+                f"{response.text[:200]}",
+                response.status_code,
+            ) from exc
+        if not isinstance(comments, list):
+            raise GitHubIssuesError(f"GET /issues/{number}/comments answered a non-list body")
+        last = _LAST_PAGE_RE.search(response.headers.get("link", ""))
+        return comments, int(last.group(1)) if last else page
+
     async def read_conversation(self, *, number: int) -> list[IssueComment]:
         """Reads the comments that belong in the reporter's view of their own report.
 
         Paged rather than one call: the endpoint answers 30 at a time by default, and the
         panel shows the *newest* replies, so a thread past the first page would hide the
         very answer the reporter came to read while the status still said someone had
-        replied. `_MAX_COMMENT_PAGES` bounds it at the first 300 comments; the endpoint
-        orders oldest first, so past that the newest replies are the ones left unread.
+        replied.
+
+        `_MAX_COMMENT_PAGES` bounds that walk, and it is applied at the END of the thread:
+        the endpoint answers oldest first, so a bound counted from page 1 would drop
+        precisely the replies the panel renders. Asking for the other order is not an
+        option — measured 2026-08-20 against api.github.com, this endpoint ignores both
+        `sort` and `direction` and answers ascending whatever it is passed — so the walk
+        starts `_MAX_COMMENT_PAGES` back from the last page instead. A thread inside the
+        bound is read whole in the same requests as before; only a deeper one pays for a
+        fourth, since page 1's body is thrown away and the page is asked for anyway to
+        reach its `Link` header. The issue's own comment count would answer the same
+        question for free — the panel holds one two statements earlier — but it is read
+        before the walk, so one comment landing in between puts the newest on a page the
+        arithmetic then never asks for, which is this bug again through a narrower door.
 
         Raises:
             GitHubIssuesError: The comments could not be read.
         """
+        first, last_page = await self._read_comment_page(number=number, page=1)
+        start = max(1, last_page - _MAX_COMMENT_PAGES + 1)
         collected: list[dict[str, Any]] = []
-        for page in range(1, _MAX_COMMENT_PAGES + 1):
-            comments = await self._request(
-                method="GET",
-                path=f"/issues/{number}/comments?per_page={_COMMENTS_PER_PAGE}&page={page}",
-            )
-            if not isinstance(comments, list):
-                raise GitHubIssuesError(f"GET /issues/{number}/comments answered a non-list body")
+        if start == 1:
+            collected.extend(first)
+        for page in range(max(start, 2), last_page + 1):
+            comments, _ = await self._read_comment_page(number=number, page=page)
             collected.extend(comments)
-            if len(comments) < _COMMENTS_PER_PAGE:
-                break
         return select_conversation(comments=collected)
 
     async def add_comment(self, *, number: int, body: str) -> None:

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -11,6 +11,7 @@ import asyncio
 from pathlib import Path
 from datetime import UTC, datetime, timedelta
 
+import httpx
 from openai import AsyncOpenAI
 import pytest
 from nextcord import Interaction
@@ -34,6 +35,7 @@ from discordbot.cogs.feedback.views import (
     build_detail_embed,
 )
 from discordbot.cogs.feedback.github import (
+    _COMMENTS_PER_PAGE,
     REPORTER_COMMENT_MARKER,
     GitHubIssues,
     IssueComment,
@@ -861,23 +863,61 @@ def _scripted(*, fail_status: int = 0) -> "_ScriptedIssues":
 
 
 class _PagingIssues(GitHubIssues):
-    """A client whose scripted transport answers a conversation longer than one page."""
+    """A client whose scripted transport answers a conversation longer than one page.
 
-    async def _request(
+    Scripted after the endpoint rather than after what the reader wants from it: the
+    comments come back oldest first however they are asked for, and how deep the thread
+    goes is only in the `Link` header, whose `rel="last"` entry sits behind a `rel="next"`
+    pointing at a different page and is absent on the last page altogether. All of it was
+    measured against api.github.com, and each part earns its place — a fake answering the
+    newest first would let the bug this file pins go unnoticed, and one emitting a lone
+    `rel="last"` would never exercise the entry the header parser has to pick it out of.
+
+    Attributes:
+        total: How many comments the scripted thread holds.
+        requested: The pages the reader asked for, in order.
+    """
+
+    total: int = Field(default=120, description="How many comments the scripted thread holds.")
+    requested: list[int] = Field(
+        default_factory=list, description="The pages the reader asked for, in order."
+    )
+
+    async def _send(
         self, *, method: str, path: str, payload: dict[str, Any] | None = None
-    ) -> Any:  # noqa: ANN401 -- mirrors the signature it overrides
-        """Answers 100 comments on the first page and 20 on the second."""
+    ) -> httpx.Response:
+        """Answers one page of the thread, with the header that says how many there are."""
         page = int(path.rsplit("page=", maxsplit=1)[1])
-        start, count = ((0, 100) if page == 1 else (100, 20)) if page <= 2 else (0, 0)
-        return [
+        self.requested.append(page)
+        last_page = max(1, -(-self.total // _COMMENTS_PER_PAGE))
+        start = (page - 1) * _COMMENTS_PER_PAGE
+        body = [
             {
                 "user": {"login": "mai", "type": "User"},
                 "author_association": "OWNER",
-                "body": f"第 {start + index} 則",
+                "body": f"第 {index} 則",
                 "created_at": "2026-02-04T10:00:00Z",
             }
-            for index in range(count)
+            for index in range(start, min(start + _COMMENTS_PER_PAGE, self.total))
         ]
+        entries = (
+            ([(page - 1, "prev")] if page > 1 else [])
+            + ([(page + 1, "next"), (last_page, "last")] if page < last_page else [])
+            + ([(1, "first")] if page > 1 else [])
+        )
+        link = ", ".join(
+            f"<https://api.github.com/repositories/1/issues/460/comments"
+            f'?per_page={_COMMENTS_PER_PAGE}&page={target}>; rel="{relation}"'
+            for target, relation in entries
+        )
+        return httpx.Response(status_code=200, json=body, headers={"Link": link} if link else {})
+
+
+def _paging(*, total: int) -> _PagingIssues:
+    """Builds a paging client over a scripted thread of `total` comments."""
+    return _PagingIssues(
+        credentials=TokenCredentials(token=_FAKE_TOKEN), repository="owner/name", total=total
+    )
 
 
 # ---------------------------------------------------------------------- view wiring
@@ -1112,12 +1152,65 @@ async def test_nobody_can_read_someone_elses_report(feedback_isolated_db: None) 
 
 async def test_every_comment_page_is_read() -> None:
     """The newest reply is the one being looked for, and it is on the last page."""
-    client = _PagingIssues(
-        credentials=TokenCredentials(token=_FAKE_TOKEN), repository="owner/name"
-    )
+    client = _paging(total=120)
     conversation = await client.read_conversation(number=460)
     assert len(conversation) == 120
     assert conversation[-1].body == "第 119 則"
+    assert client.requested == [1, 2]
+
+
+async def test_the_comment_bound_drops_the_oldest_end_and_not_the_newest() -> None:
+    """A thread past the bound has to lose something, and it must not be what is shown.
+
+    The endpoint answers oldest first and ignores `direction`, so a bound counted from
+    page 1 keeps the opening of the thread and drops the reply the reporter came back to
+    read — while the status line beside it, derived from the issue's own comment count,
+    still says someone answered.
+    """
+    client = _paging(total=450)
+    conversation = await client.read_conversation(number=460)
+    assert conversation[-1].body == "第 449 則"
+    assert conversation[0].body == "第 200 則"
+    assert client.requested == [1, 3, 4, 5]
+
+
+async def test_the_panel_shows_the_newest_end_of_what_was_read(feedback_isolated_db: None) -> None:
+    """Which end the screen takes is why the read has to keep that end, so it is pinned.
+
+    This is the panel half alone: the conversation is handed to the cog rather than
+    fetched, so nothing here can go red over the page bound. What it fixes in place is
+    the premise that bound is chosen for — `build_detail_embed` renders the LAST few
+    comments, so a reader that dropped the newest ones would be dropping the screen.
+    """
+    issues = FakeIssues()
+    issues.conversation = [
+        IssueComment(
+            author="mai",
+            body=f"第 {index} 則",
+            created_at="2026-02-04T10:00:00Z",
+            from_reporter=False,
+        )
+        for index in range(9)
+    ]
+    ticket = await create_ticket(
+        user_id=7,
+        user_name="alice",
+        display_name="Alice",
+        guild_id=None,
+        guild_name="",
+        channel_id=None,
+        locale="",
+        raw_text="壞掉了",
+    )
+    await attach_issue_number(ticket_id=ticket.ticket_id, issue_number=460)
+    detail = await _cog(issues=issues).load_detail(ticket_id=ticket.ticket_id, viewer_id=7)
+    assert detail is not None
+    assert detail.comments == issues.conversation
+    embed = build_detail_embed(detail=detail)
+    values = [str(field.value) for field in embed.fields]
+    assert "第 8 則" in values
+    assert "第 3 則" not in values
+    assert "上面還有 4 則比較早的對話" in [str(field.name) for field in embed.fields]
 
 
 # ------------------------------------------------------------- before a token exists


### PR DESCRIPTION
Closes #514.

The plan is here rather than on the issue: issue writes were refused in this session.

## The issue's premise holds; its implied fix does not

`read_conversation` walked pages 1..3 of an issue's comments, and the endpoint answers
oldest first, so past 300 comments the ones never fetched were the newest — exactly the
end `build_detail_embed` renders (`views.py:250`, `detail.comments[-MAX_DETAIL_REPLIES:]`).
A reporter checking back after a maintainer answered would have seen the old conversation
while the status line, derived from the issue's comment count, still said 處理中.

Asking GitHub for the other order does not fix it. Measured 2026-08-20 against
`api.github.com`: `GET /repos/{owner}/{repo}/issues/{n}/comments` **ignores both `sort` and
`direction`**. Checked on `cli/cli#14107` (8 comments, one page) and `cli/cli#13840` (140
comments, two pages), with `sort=created&direction=desc`, `sort=updated&direction=desc` and
`direction=desc` alone: every one answers the same ascending list, and page 1 is still the
oldest 100.

So the walk starts from the end instead, and page 1's `Link` header is what says where the
end is: `rel="last"` rides behind `rel="next"` on a multi-page thread and is absent on the
last page, both measured on the same two threads.

## Change

`src/discordbot/cogs/feedback/github.py`

- `_send` is split out of `_request`: it does the transport and the status check and hands
  back the response, `_request` keeps the JSON decode on top of it. The other five callers
  are untouched. The paged reader needs the `Link` header, which is the one thing on a
  response that is not in its body.
- `_read_comment_page` reads one page plus the number of the last page, parsed out of
  `rel="last"`; its absence means the page in hand is the last one.
- `read_conversation` reads page 1, then walks the last `_MAX_COMMENT_PAGES` pages. A
  thread inside the bound is read whole in the same requests as before; a deeper one pays
  a fourth request, because page 1's body is discarded and the page is fetched anyway to
  reach its header.
- The docstring records the measurement, so nobody folds it back to `direction=desc`.

`tests/test_feedback.py`

- `_PagingIssues` moves from overriding `_request` to overriding `_send`, so the header
  parsing is under test rather than around it, and models the endpoint: a thread of `total`
  comments oldest first, with the real multi-entry `Link` shape. Mutating the bound back to
  a page-1 walk turns the new test red with `第 299 則 != 第 449 則`, which is the bug.
- A cog-level test populates `FakeIssues.conversation`, the hook nothing read before, and
  pins the panel half: the screen shows the newest end of what the read returned, which is
  why the read has to keep that end.

## Not changed

`capabilities.md` names no bound and nothing a user can name changes. `MAX_DETAIL_REPLIES`
and `select_conversation` are correct as they stand.

One thing this leaves standing, deliberately: `views.py:245` counts the hidden replies
against what was fetched, so past the bound it still under-reports how much earlier
conversation there is. Fixing that needs a count of *conversation* comments, which nothing
on the wire gives — the issue's `comments` field counts bots and strangers too.

## Checks

`uvx pre-commit run -a` clean, `uv run pytest` 1594 passed locally, and the branch is
rebased onto `main` at 2375305 so CI runs the suite over it as well.

---

Opened-by: Claude Opus 5
