### PR TITLE
chore(models): point slow_model at gemini-3.7-flash

### DIFF
--- a/scripts/batch_dev.py
+++ b/scripts/batch_dev.py
@@ -21,7 +21,7 @@ config = LLMConfig()
 
 # Mirror the @property value in typings/models.py. slow_model's time-of-day dispatch is
 # commented out there, so production answers on this one branch at every hour.
-SLOW_MODEL = ModelSettings(name="gemini-3.1-pro-preview", effort="low")
+SLOW_MODEL = ModelSettings(name="gemini-3.7-flash", effort="low")
 
 # Both are Literal in the Batch API signature, so they carry the same literal type here.
 BATCH_ENDPOINT: Literal["/v1/responses"] = "/v1/responses"

--- a/scripts/prompt_dev.py
+++ b/scripts/prompt_dev.py
@@ -47,7 +47,7 @@ config = LLMConfig()
 
 # Mirror the @property value in typings/models.py. slow_model's time-of-day dispatch is
 # commented out there, so production answers on this one branch at every hour.
-SLOW_MODEL = ModelSettings(name="gemini-3.1-pro-preview", effort="high")
+SLOW_MODEL = ModelSettings(name="gemini-3.7-flash", effort="high")
 
 
 def gen_reply(user_prompt: str) -> None:

--- a/src/discordbot/typings/models.py
+++ b/src/discordbot/typings/models.py
@@ -217,14 +217,18 @@ class RuntimeModelCatalog(BaseModel):
         # `medium` as well. The grade is binary since #490, so it no longer reaches the value
         # that lost whole replies through an alias in #459; the pinning stays because it is what
         # keeps the next vocabulary change from doing it again. Note `minimal` is still a 400 on
-        # the pro snapshot; it stays legal only because `EffortGrade` never emits it.
+        # this snapshot, for a different reason than the pro one it replaced: LiteLLM's
+        # `is_gemini3flash` match forwards it untouched as `thinkingLevel: minimal` for the model
+        # itself to reject (measured 2026-08-19, where low / medium / high all passed). It stays
+        # legal only because `EffortGrade` never emits it.
         # The peak split is commented out rather than deleted, and `is_peak` stays exposed for
-        # it: it sent peak hours to flash because Pro used to be the one that slowed down, and
-        # `gemini-3.7-flash` is now the one that queues (observed 2026-08-20). Restore it when
-        # that inverts back.
+        # it: it sent peak hours to flash because Pro used to be the one that slowed down. Now
+        # that every hour answers on flash it names the snapshot the live branch already returns,
+        # so uncommenting it as written would dispatch nothing new; the peak-hour mechanism is to
+        # be redesigned rather than restored.
         # if self.is_peak:
         #     return ModelSettings(name="gemini-3.7-flash", effort="high")
-        return ModelSettings(name="gemini-3.1-pro-preview", effort="high")
+        return ModelSettings(name="gemini-3.7-flash", effort="high")
 
     @property
     def memory_extractor_model(self) -> ModelSettings:

--- a/src/discordbot/typings/models.py
+++ b/src/discordbot/typings/models.py
@@ -206,7 +206,10 @@ class RuntimeModelCatalog(BaseModel):
         link-context builder's `answer_model_is_gemini` from it.
 
         Returns:
-            Slow-path model settings for reply generation and summaries.
+            Flash at `high`. This is the snapshot `fast_model` deliberately sits one back from,
+            so the answer tier takes that snapshot's queueing (observed 2026-08-20) where the
+            cheaper tier declines it. The split is intentional rather than one of the two
+            observations being stale.
         """
         # Both branches, the commented-out one included, are pinned to explicit snapshots and
         # never a `*-latest` alias. This is the
@@ -216,11 +219,13 @@ class RuntimeModelCatalog(BaseModel):
         # (flash / pro / flash-lite) accepts only low / high, while every pinned snapshot takes
         # `medium` as well. The grade is binary since #490, so it no longer reaches the value
         # that lost whole replies through an alias in #459; the pinning stays because it is what
-        # keeps the next vocabulary change from doing it again. Note `minimal` is still a 400 on
-        # this snapshot, for a different reason than the pro one it replaced: LiteLLM's
-        # `is_gemini3flash` match forwards it untouched as `thinkingLevel: minimal` for the model
-        # itself to reject (measured 2026-08-19, where low / medium / high all passed). It stays
-        # legal only because `EffortGrade` never emits it.
+        # keeps the next vocabulary change from doing it again. Note `minimal` is still refused
+        # on this snapshot, and both the reason and the shape differ from the pro one it
+        # replaced: LiteLLM's `is_gemini3flash` match forwards it untouched as
+        # `thinkingLevel: minimal` for the model itself to reject, and the proxy then answers
+        # from the fallback deployment, so the caller sees a 200 naming another model rather than
+        # an error (measured 2026-08-19; low / medium / high all passed under this name). It
+        # stays legal only because `EffortGrade` never emits it.
         # The peak split is commented out rather than deleted, and `is_peak` stays exposed for
         # it: it sent peak hours to flash because Pro used to be the one that slowed down. Now
         # that every hour answers on flash it names the snapshot the live branch already returns,


### PR DESCRIPTION
## What

Repoints `RuntimeModelCatalog.slow_model` from `gemini-3.1-pro-preview` to `gemini-3.7-flash`, keeping `high` effort. The two dev scripts that declare themselves mirrors of that property (`scripts/prompt_dev.py`, `scripts/batch_dev.py`) follow; each keeps its own effort.

## Why the pairing is safe

An effort's legality is decided by the pair (model string, surface), so both surfaces this tier reaches were checked against measurements already recorded in the tree rather than re-probed with billed inference:

- **Proxy (Responses API).** LiteLLM's `is_gemini3flash` match forwards the effort untouched as a `thinkingLevel`. `low` / `medium` / `high` all pass on this snapshot; only `minimal` is rejected, and `EffortGrade` never emits it. `write_up_report`, the one caller that does not override the effort, dispatches the catalog's `high`.
- **Native Interactions API** (the YouTube `watch_video` answer turn hands the effort straight through as a `thinking_level`). The narrowed vocabulary belongs to `*-latest` aliases; this is a pinned snapshot, so `low` / `medium` / `high` are all in its set.

## Other reads of this tier

Three callers read only the model name. `_supported_sources` gates attachment modalities on it: both the old and the new name carry `{text, image, audio, video}` in the cached LiteLLM price table, so no attachment type is dropped. `build_attachment_handler` and `answer_model_is_gemini` both branch on `"gemini" in name`, unchanged.

## The peak branch

Left commented out, and `is_peak` left exposed, as requested. Its comment now records that it names the snapshot the live branch already returns, so uncommenting it as written would dispatch nothing new; the peak-hour mechanism is to be redesigned rather than restored.

## Checks

`uv run pytest` (1603 passed, coverage gate met) and `uvx pre-commit run -a` are green locally. `tests/test_runtime_models.py` deliberately names no snapshot, so it needed no edit.

Opened-by: Claude Opus 5