### PR TITLE
chore(models): point slow_model back at gemini-3.1-pro-preview

### DIFF
--- a/scripts/batch_dev.py
+++ b/scripts/batch_dev.py
@@ -21,7 +21,7 @@ config = LLMConfig()
 
 # Mirror the @property value in typings/models.py. slow_model's time-of-day dispatch is
 # commented out there, so production answers on this one branch at every hour.
-SLOW_MODEL = ModelSettings(name="gemini-3.7-flash", effort="low")
+SLOW_MODEL = ModelSettings(name="gemini-3.1-pro-preview", effort="low")
 
 # Both are Literal in the Batch API signature, so they carry the same literal type here.
 BATCH_ENDPOINT: Literal["/v1/responses"] = "/v1/responses"

--- a/scripts/prompt_dev.py
+++ b/scripts/prompt_dev.py
@@ -47,7 +47,7 @@ config = LLMConfig()
 
 # Mirror the @property value in typings/models.py. slow_model's time-of-day dispatch is
 # commented out there, so production answers on this one branch at every hour.
-SLOW_MODEL = ModelSettings(name="gemini-3.7-flash", effort="high")
+SLOW_MODEL = ModelSettings(name="gemini-3.1-pro-preview", effort="high")
 
 
 def gen_reply(user_prompt: str) -> None:

--- a/src/discordbot/typings/models.py
+++ b/src/discordbot/typings/models.py
@@ -206,10 +206,7 @@ class RuntimeModelCatalog(BaseModel):
         link-context builder's `answer_model_is_gemini` from it.
 
         Returns:
-            Flash at `high`. This is the snapshot `fast_model` deliberately sits one back from,
-            so the answer tier takes that snapshot's queueing (observed 2026-08-20) where the
-            cheaper tier declines it. The split is intentional rather than one of the two
-            observations being stale.
+            Slow-path model settings for reply generation and summaries.
         """
         # Both branches, the commented-out one included, are pinned to explicit snapshots and
         # never a `*-latest` alias. This is the
@@ -219,21 +216,15 @@ class RuntimeModelCatalog(BaseModel):
         # (flash / pro / flash-lite) accepts only low / high, while every pinned snapshot takes
         # `medium` as well. The grade is binary since #490, so it no longer reaches the value
         # that lost whole replies through an alias in #459; the pinning stays because it is what
-        # keeps the next vocabulary change from doing it again. Note `minimal` is still refused
-        # on this snapshot, and both the reason and the shape differ from the pro one it
-        # replaced: LiteLLM's `is_gemini3flash` match forwards it untouched as
-        # `thinkingLevel: minimal` for the model itself to reject, and the proxy then answers
-        # from the fallback deployment, so the caller sees a 200 naming another model rather than
-        # an error (measured 2026-08-19; low / medium / high all passed under this name). It
-        # stays legal only because `EffortGrade` never emits it.
+        # keeps the next vocabulary change from doing it again. Note `minimal` is still a 400 on
+        # the pro snapshot; it stays legal only because `EffortGrade` never emits it.
         # The peak split is commented out rather than deleted, and `is_peak` stays exposed for
-        # it: it sent peak hours to flash because Pro used to be the one that slowed down. Now
-        # that every hour answers on flash it names the snapshot the live branch already returns,
-        # so uncommenting it as written would dispatch nothing new; the peak-hour mechanism is to
-        # be redesigned rather than restored.
+        # it: it sent peak hours to flash because Pro used to be the one that slowed down, and
+        # `gemini-3.7-flash` is now the one that queues (observed 2026-08-20). Restore it when
+        # that inverts back.
         # if self.is_peak:
         #     return ModelSettings(name="gemini-3.7-flash", effort="high")
-        return ModelSettings(name="gemini-3.7-flash", effort="high")
+        return ModelSettings(name="gemini-3.1-pro-preview", effort="high")
 
     @property
     def memory_extractor_model(self) -> ModelSettings:


### PR DESCRIPTION
Reverts #563, putting the answer tier back on `gemini-3.1-pro-preview` at `high`.

`git revert` of 947ca91, so the three files it touched (`typings/models.py` plus the two dev scripts that mirror the tier) go back byte-for-byte to what they were before it. That restores the docstring and comment prose along with the model string: the `minimal` note goes back to describing the pro snapshot's hard 400 rather than the flash snapshot's forwarded-and-rejected 200, and the commented-out peak-hour branch goes back to being a branch worth restoring rather than one that would dispatch nothing new.

Nothing landed on `main` between #563 and this revert, so the restored state is exactly what `main` carried earlier today.

Checks: `uvx pre-commit run -a` and the full `uv run pytest` suite (1604 passed) are green locally.

Opened-by: Claude Opus 5