### PR TITLE
fix(llm_errors): read a provider 400 off the exception body

### DIFF
--- a/src/discordbot/utils/llm_errors.py
+++ b/src/discordbot/utils/llm_errors.py
@@ -1,4 +1,4 @@
-"""Unwraps a LiteLLM-wrapped provider error into the message a user should see."""
+"""Unwraps an SDK-wrapped provider error into the message a user should see."""
 
 import re
 import ast
@@ -9,25 +9,62 @@ import json
 # where the provider's actual JSON body is embedded as a Python bytes literal.
 _BYTES_LITERAL_RE = re.compile(pattern=r"b'((?:[^'\\]|\\.)*)'", flags=re.DOTALL)
 
+# Both SDKs keep the decoded error body on the exception, so it never has to be read back out
+# of the repr their `__str__` builds: `openai` as `.body` (already unwrapped to the `error`
+# object), `google.genai` as `.details` (the whole document).
+_DECODED_BODY_ATTRIBUTES = ("body", "details")
 
-def extract_friendly_error(exc: BaseException) -> str:
-    """Surface the innermost provider error message from a LiteLLM-wrapped APIError.
 
-    OpenAI's streaming layer constructs `APIError(message=error["message"], ...)`
-    from the upstream SSE event; when LiteLLM is the upstream, that `message` is
-    the wrapped exception chain with the provider response stuffed inside as a
-    `b'...'` Python literal. Walk every embedded bytes literal, parse it as
-    JSON, and return `error.message` (or top-level `message`). Fall back to
-    `str(exc)` when nothing parses, so we never lose the original signal.
+def _provider_message(payload: object) -> str | None:
+    """Read the provider's own message out of one decoded error body.
 
     Args:
-        exc: The exception whose string form may contain embedded provider JSON.
+        payload: A decoded JSON error body, either the whole document or the `error`
+            object an SDK already unwrapped out of it.
 
     Returns:
-        The first nested provider message found in an embedded JSON bytes literal,
-        or `str(exc)` if no provider message can be extracted.
+        The provider message, or None when `payload` carries none.
+    """
+    if not isinstance(payload, dict):
+        return None
+    error = payload.get("error")
+    if isinstance(error, dict):
+        inner = error.get("message")
+        if isinstance(inner, str) and inner:
+            return inner
+    top = payload.get("message")
+    if isinstance(top, str) and top:
+        return top
+    return None
+
+
+def extract_friendly_error(exc: BaseException) -> str:
+    """Surface the innermost provider error message from an SDK-wrapped APIError.
+
+    Two shapes reach here. A refusal the provider answered as a plain 400 keeps its
+    body on the exception, but both SDKs render it into their `__str__` as a Python
+    dict repr (`Error code: 400 - {'error': ...}`), which is why the decoded body is
+    read off the exception instead of parsed back out of that text. A LiteLLM-wrapped
+    one nests further: OpenAI's streaming layer constructs
+    `APIError(message=error["message"], ...)` from the upstream SSE event, and that
+    `message` is the wrapped exception chain with the provider response stuffed inside
+    as a `b'...'` Python literal, so every embedded bytes literal is walked and parsed
+    as JSON too. Fall back to `str(exc)` when nothing parses, so we never lose the
+    original signal.
+
+    Args:
+        exc: The exception carrying a decoded error body, or whose string form may
+            contain embedded provider JSON.
+
+    Returns:
+        The provider message from the decoded body or from an embedded JSON bytes
+        literal, or `str(exc)` if no provider message can be extracted.
     """
     raw = str(exc)
+    for attribute in _DECODED_BODY_ATTRIBUTES:
+        if (message := _provider_message(payload=getattr(exc, attribute, None))) is not None:
+            raw = message
+            break
     for match in _BYTES_LITERAL_RE.finditer(string=raw):
         try:
             decoded = ast.literal_eval(node_or_string=match.group(0)).decode(
@@ -36,13 +73,6 @@ def extract_friendly_error(exc: BaseException) -> str:
             data = json.loads(s=decoded)
         except (SyntaxError, ValueError, TypeError, AttributeError):
             continue
-        if isinstance(data, dict):
-            error = data.get("error")
-            if isinstance(error, dict):
-                inner = error.get("message")
-                if isinstance(inner, str) and inner:
-                    return inner
-            top = data.get("message")
-            if isinstance(top, str) and top:
-                return top
+        if (message := _provider_message(payload=data)) is not None:
+            return message
     return raw

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -15,13 +15,14 @@ from unittest.mock import MagicMock
 
 from PIL import Image
 import httpx
-from openai import APITimeoutError
+from openai import APITimeoutError, BadRequestError
 import pytest
 import nextcord
 from nextcord import File, Embed, Message
 import requests
 from xai_sdk.proto import files_pb2
 from google.genai.types import FileState
+from google.genai.errors import ClientError
 from openai.types.responses.response_input_param import EasyInputMessageParam
 from openai.types.responses.response_input_file_param import ResponseInputFileParam
 from openai.types.responses.response_input_text_param import ResponseInputTextParam
@@ -3159,6 +3160,22 @@ def test_extract_friendly_error_prefers_nested_provider_message() -> None:
     assert extract_friendly_error(exc=RuntimeError(raw)) == "quota exceeded"
     assert extract_friendly_error(exc=RuntimeError("plain failure")) == "plain failure"
     assert extract_friendly_error(exc=RuntimeError("bad b'not json'")) == "bad b'not json'"
+
+
+def test_extract_friendly_error_reads_a_decoded_400_body() -> None:
+    """A plain provider 400 is read off the exception, not out of its dict-repr string."""
+    refusal = "Input blocked: Sorry, we can't create videos with real people's names."
+    body = {"error": {"message": refusal, "code": "invalid_request"}}
+
+    # `_make_status_error` unwraps the `error` object into `.body` before raising, and renders
+    # the whole document into the message as a Python dict repr.
+    request = httpx.Request(method="POST", url="http://proxy/v1/images/generations")
+    response = httpx.Response(status_code=400, request=request, json=body)
+    proxied = BadRequestError(f"Error code: 400 - {body}", response=response, body=body["error"])
+    assert extract_friendly_error(exc=proxied) == refusal
+
+    # The direct-to-Google path keeps the whole document on `.details` instead.
+    assert extract_friendly_error(exc=ClientError(400, body, None)) == refusal
 
 
 def test_required_modality_gate_keeps_code_and_text() -> None:

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -3177,6 +3177,16 @@ def test_extract_friendly_error_reads_a_decoded_400_body() -> None:
     # The direct-to-Google path keeps the whole document on `.details` instead.
     assert extract_friendly_error(exc=ClientError(400, body, None)) == refusal
 
+    # A non-streaming LiteLLM 400 needs both steps: the dict repr escapes the wrapped chain's
+    # quotes to `b\'...\'`, so the bytes literal is only reachable once `.body` has replaced the
+    # text being scanned.
+    chain = """litellm.BadRequestError: VertexAIException - b'{"error": {"message": "quota"}}'"""
+    wrapped_body = {"error": {"message": chain, "code": "400"}}
+    wrapped = BadRequestError(
+        f"Error code: 400 - {wrapped_body}", response=response, body=wrapped_body["error"]
+    )
+    assert extract_friendly_error(exc=wrapped) == "quota"
+
 
 def test_required_modality_gate_keeps_code_and_text() -> None:
     """The MIME gate drops unknown binaries but keeps source-code / structured-text types."""


### PR DESCRIPTION
## Problem

A provider refusal that arrives as a plain 400 reached Discord as a raw dict repr:

```
Error code: 400 - {'error': {'message': "Input blocked: Sorry, we can't create videos with real people's names or likenesses. Please remove the reference and try again. If you think this was an error, [send feedback](https://ai.google.dev/gemini-api/docs/troubleshooting).", 'code': 'invalid_request'}}
```

`extract_friendly_error` only recognised one shape: the LiteLLM-wrapped chain that embeds the provider's JSON body as a `b'...'` Python bytes literal. This error has no bytes literal, so the regex found nothing and the whole `str(exc)` went into the error embed.

## Fix

The decoded body never had to be parsed back out of the repr — both SDKs keep it on the exception:

- `openai` on `.body`, already unwrapped to the `error` object by `_make_status_error`
- `google.genai` on `.details`, the whole document

Both are now read before falling back to `str(exc)`. Whatever comes out still goes through the existing bytes-literal scan, so a LiteLLM-wrapped body whose message nests one more level is still unwrapped to the innermost provider message.

Both paths are covered on purpose: the proxied routes raise the `openai` shape, while `VideoGenerator` is direct-to-Google and raises the `google.genai` one for the same class of refusal. Fixing only the first would leave an identical hole on the route the reported error actually names.

## Result

```
Input blocked: Sorry, we can't create videos with real people's names or likenesses. Please remove the reference and try again. If you think this was an error, [send feedback](https://ai.google.dev/gemini-api/docs/troubleshooting).
```

The embed footer still carries the exception type, so nothing is lost.

## Verification

`tests/test_gen_reply.py::test_extract_friendly_error_reads_a_decoded_400_body` builds real `BadRequestError` and `ClientError` instances, pinning where each SDK keeps the body. Replaying the pre-change logic against the same two exceptions returns the full repr, so the test fails without the fix.

`uvx pre-commit run -a` is clean; `tests/test_gen_reply.py` and `tests/test_research.py` pass (328).

Opened-by: Claude Opus 5