### PR TITLE
fix(gen_reply): space the answer-stream retries five seconds apart

### DIFF
--- a/src/discordbot/cogs/gen_reply/streaming.py
+++ b/src/discordbot/cogs/gen_reply/streaming.py
@@ -11,7 +11,7 @@ import logfire
 from nextcord import File, Embed, Message, NotFound, HTTPException, AllowedMentions
 from pydantic import Field, BaseModel, ConfigDict, PrivateAttr, SkipValidation
 from tenacity import AsyncRetrying, RetryCallState, retry_if_exception, stop_after_attempt
-from tenacity.wait import wait_exponential_jitter
+from tenacity.wait import wait_fixed, wait_random
 from nextcord.utils import escape_mentions
 from openai.types.responses import ResponseOutputItem, ResponseStreamEvent
 
@@ -62,17 +62,16 @@ CODED_MENTION_RE = re.compile(r"`(<(?:@[!&]?|#)\d+>)`")
 DISCORD_MESSAGE_LIMIT = 2000
 
 # Spacing between answer-stream attempts. A cadence rather than a bound, which is why it stays
-# here while `ANSWER_STREAM_MAX_ATTEMPTS` lives in `typings/timeouts.py`. Short on purpose: the
-# user spends it watching a thinking preview that has already stalled once, so it only has to
-# outlast a burst. The jitter is spelled rather than left to tenacity's default because it is
-# the half that stops a busy channel's replies retrying in lockstep, and because it is ADDITIVE
-# and independent of the base -- a test zeroing the base alone still sleeps.
-ANSWER_RETRY_BACKOFF_SECONDS = 2.0
+# here while `ANSWER_STREAM_MAX_ATTEMPTS` lives in `typings/timeouts.py`. Flat rather than
+# doubling, and wide enough that the wait is the point: a provider 5xx burst is what this retry
+# exists for, and re-opening the stream a second or two after one started reaches the same
+# unhealthy deployment, so the attempts are spent rather than spaced. Every attempt costs the
+# same, so the worst case for one reply is (`ANSWER_STREAM_MAX_ATTEMPTS` - 1) of these. The
+# jitter is spelled rather than left to tenacity's default because it is the half that stops a
+# busy channel's replies retrying in lockstep, and because it is ADDITIVE and independent of the
+# interval -- a test zeroing the interval alone still sleeps.
+ANSWER_RETRY_INTERVAL_SECONDS = 5.0
 ANSWER_RETRY_JITTER_SECONDS = 1.0
-# Ceiling on one wait. At three attempts it never binds (the waits are ~2s then ~4s); it is
-# here so that raising the attempt count cannot silently turn the doubling into a 30s stall in
-# front of a user who is already waiting.
-ANSWER_RETRY_BACKOFF_MAX_SECONDS = 10.0
 
 # Shown on both retry surfaces, so the reaction on the source message and the notice on the
 # reply read as the same event rather than two unrelated hints.
@@ -1191,11 +1190,8 @@ async def stream_answer_with_retry(
 
     retrying = AsyncRetrying(
         retry=retry_if_exception(is_retryable_llm_error),
-        wait=wait_exponential_jitter(
-            initial=ANSWER_RETRY_BACKOFF_SECONDS,
-            max=ANSWER_RETRY_BACKOFF_MAX_SECONDS,
-            jitter=ANSWER_RETRY_JITTER_SECONDS,
-        ),
+        wait=wait_fixed(wait=ANSWER_RETRY_INTERVAL_SECONDS)
+        + wait_random(min=0, max=ANSWER_RETRY_JITTER_SECONDS),
         stop=stop_after_attempt(ANSWER_STREAM_MAX_ATTEMPTS),
         before_sleep=_before_retry,
         reraise=True,

--- a/src/discordbot/cogs/gen_reply/streaming.py
+++ b/src/discordbot/cogs/gen_reply/streaming.py
@@ -66,10 +66,11 @@ DISCORD_MESSAGE_LIMIT = 2000
 # doubling, and wide enough that the wait is the point: a provider 5xx burst is what this retry
 # exists for, and re-opening the stream a second or two after one started reaches the same
 # unhealthy deployment, so the attempts are spent rather than spaced. Every attempt costs the
-# same, so the worst case for one reply is (`ANSWER_STREAM_MAX_ATTEMPTS` - 1) of these. The
-# jitter is spelled rather than left to tenacity's default because it is the half that stops a
-# busy channel's replies retrying in lockstep, and because it is ADDITIVE and independent of the
-# interval -- a test zeroing the interval alone still sleeps.
+# same, so the worst case for one reply is (`ANSWER_STREAM_MAX_ATTEMPTS` - 1) of these. The jitter
+# is a whole `wait_random` added beside the interval rather than a parameter of it, so dropping
+# that half removes jitter outright rather than falling back to a library default: it is what
+# stops a busy channel's replies retrying in lockstep, and being ADDITIVE and independent of the
+# interval is why a test zeroing the interval alone still sleeps.
 ANSWER_RETRY_INTERVAL_SECONDS = 5.0
 ANSWER_RETRY_JITTER_SECONDS = 1.0
 

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -3341,11 +3341,11 @@ def _paced_stream_events(
 def _no_retry_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
     """Makes the answer retry sleepless.
 
-    Both halves are needed: `wait_exponential_jitter` adds `random.uniform(0, jitter)` on top
-    of the base, independent of it, so zeroing the base alone still sleeps up to a second per
-    attempt and the test only looks instant.
+    Both halves are needed: the jitter is a `wait_random` added on top of the fixed interval,
+    independent of it, so zeroing the interval alone still sleeps up to a second per attempt
+    and the test only looks instant.
     """
-    monkeypatch.setattr(streaming_module, "ANSWER_RETRY_BACKOFF_SECONDS", 0.0)
+    monkeypatch.setattr(streaming_module, "ANSWER_RETRY_INTERVAL_SECONDS", 0.0)
     monkeypatch.setattr(streaming_module, "ANSWER_RETRY_JITTER_SECONDS", 0.0)
 
 


### PR DESCRIPTION
## What

The answer-stream retry (#586) waited `wait_exponential_jitter(initial=2, max=10, jitter=1)`, so the two waits were ~2-3s and then ~4-5s. This flattens that to a fixed interval: `wait_fixed(5) + wait_random(0, 1)`, making both waits ~5-6s.

## Why

The failure this retry exists for is a provider 5xx burst on the streaming answer turn. Re-opening the stream a second or two after one started reaches the same unhealthy deployment, so an attempt spent that soon buys nothing but a wasted attempt out of the three the turn gets.

## Notes

- `ANSWER_RETRY_BACKOFF_SECONDS` is now `ANSWER_RETRY_INTERVAL_SECONDS`, since it is no longer the base of a doubling.
- `ANSWER_RETRY_BACKOFF_MAX_SECONDS` is gone. It existed so that raising `ANSWER_STREAM_MAX_ATTEMPTS` could not silently turn the doubling into a long stall; a flat interval has no such ceiling to guard.
- The jitter stays, and stays additive, so the test helper still has to zero both constants to make a retry test sleepless.
- `ANSWER_STREAM_MAX_ATTEMPTS` is unchanged at 3, so the worst case for one reply moves from ~6-8s of waiting to ~10-12s. The user watches that behind the existing `Retrying... (n/N)` notice and the 🔁 reaction, not a stalled preview.

Opened-by: Claude Opus 5
