### PR TITLE
chore: enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,11 @@
+# Normalize every text file to LF, in the repo and in the working tree, so a
+# Windows checkout cannot introduce CRLF.
+* text=auto eol=lf
+
+# cmd.exe needs CRLF in batch files.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
 # *.md linguist-detectable=false
 # *.sh linguist-detectable=false
 # Makefile linguist-detectable=false


### PR DESCRIPTION
## What this does

Adds a repo-level line-ending rule at the top of `.gitattributes`:

- `* text=auto eol=lf` normalizes every text file to LF both in the repository and in the working tree, so a Windows checkout cannot introduce CRLF.
- `*.bat` and `*.cmd` stay CRLF, because `cmd.exe` needs it.

The existing `linguist-detectable` lines are untouched and kept below the new block.

## Why

On Windows, VS Code writes files with CRLF. Git's `autocrlf=input` only normalizes on the way *into* the repository, so the working tree keeps CRLF and pre-commit's `mixed-line-ending` hook rewrites those files on every run. An `eol=lf` rule in `.gitattributes` fixes it for everyone, including CI and contributors whose git has no such configuration.

## Notes

This is a fan-out from the Mai0313 templates, applied to this repository.

`git add --renormalize .` produced no changes, so no already-committed blobs needed rewriting and this PR is the `.gitattributes` change alone.

Opened-by: claude-opus-5[1m]