### PR TITLE
fix(llm_errors): a flattened LiteLLM error leaks the whole wrapper chain into the failure embed

### DIFF
--- a/src/discordbot/utils/llm_errors.py
+++ b/src/discordbot/utils/llm_errors.py
@@ -16,6 +16,22 @@ from google.genai.errors import APIError as GenAIAPIError
 # where the provider's actual JSON body is embedded as a Python bytes literal.
 _BYTES_LITERAL_RE = re.compile(pattern=r"b'((?:[^'\\]|\\.)*)'", flags=re.DOTALL)
 
+# The same chain, read as the run of prefixes it is. Three sites build it, one segment each:
+# every LiteLLM exception class prepends `litellm.<ClassName>: ` (`exceptions.py`), the
+# provider mapping prepends `<Provider>Exception - ` and on some branches a second label with
+# it (`exception_mapping_utils.py`, `Timeout Error: ` and `...Exception BadRequestError - `),
+# and a failure that arrives once the stream is open prepends the provider's canonical status
+# (`_check_streaming_error`, `UNAVAILABLE - `). None of those names is written down here: a
+# segment is recognised by its shape alone -- a code-shaped word ending in `Error`, `Exception`
+# or `Timeout`, or an ALL-CAPS status -- so the wording upstream can move without this going
+# stale, and a provider's own sentence, which is prose, matches none of it. `Timeout` is there
+# because the run is anchored: it is the one exception class in `exceptions.py` named after
+# neither of the other two, so leaving it out costs not that segment but every segment behind
+# it, on the paths that already made the user wait longest.
+_WRAPPER_PREFIX_RE = re.compile(
+    pattern=r"^(?:(?:[A-Z][\w.]* )?[\w.]*(?:Error|Exception|Timeout)(?:: | - )|[A-Z][A-Z0-9_]+ - )+"
+)
+
 # Both SDKs keep the decoded error body on the exception, so it never has to be read back out
 # of the repr their `__str__` builds: `openai` as `.body` (already unwrapped to the `error`
 # object), `google.genai` as `.details` (the whole document).
@@ -54,30 +70,38 @@ def _provider_message(payload: object) -> str | None:
 def extract_friendly_error(exc: BaseException) -> str:
     """Surface the innermost provider error message from an SDK-wrapped APIError.
 
-    Two shapes reach here. A refusal the provider answered as a plain 400 keeps its
+    Three shapes reach here. A refusal the provider answered as a plain 400 keeps its
     body on the exception, but both SDKs render it into their `__str__` as a Python
     dict repr (`Error code: 400 - {'error': ...}`), which is why the decoded body is
     read off the exception instead of parsed back out of that text. A LiteLLM-wrapped
     one nests further: OpenAI's streaming layer constructs
     `APIError(message=error["message"], ...)` from the upstream SSE event, and that
-    `message` is the wrapped exception chain with the provider response stuffed inside
-    as a `b'...'` Python literal, so every embedded bytes literal is walked and parsed
-    as JSON too. Fall back to `str(exc)` when nothing parses, so we never lose the
-    original signal.
+    `message` is the wrapped exception chain. Which of the two remaining shapes it takes
+    records WHEN the request broke rather than what broke: a stream that never opened
+    carries the provider body along unparsed as a `b'...'` Python literal, while one that
+    broke after opening was parsed by LiteLLM and flattened into text, so the wrapper
+    chain is peeled off the front first and every embedded bytes literal is walked and
+    parsed as JSON after. Fall back to `str(exc)` when nothing parses, so we never lose
+    the original signal, and keep the chain rather than nothing at all when peeling it
+    leaves an empty message behind.
 
     Args:
         exc: The exception carrying a decoded error body, or whose string form may
-            contain embedded provider JSON.
+            contain a wrapper chain or embedded provider JSON.
 
     Returns:
-        The provider message from the decoded body or from an embedded JSON bytes
-        literal, or `str(exc)` if no provider message can be extracted.
+        The provider message from the decoded body, from an embedded JSON bytes literal
+        or from behind the wrapper chain, or `str(exc)` if none can be extracted.
     """
     raw = str(exc)
     for attribute in _DECODED_BODY_ATTRIBUTES:
         if (message := _provider_message(payload=getattr(exc, attribute, None))) is not None:
             raw = message
             break
+    if (prefix := _WRAPPER_PREFIX_RE.match(string=raw)) and (
+        peeled := raw[prefix.end() :].strip()
+    ):
+        raw = peeled
     for match in _BYTES_LITERAL_RE.finditer(string=raw):
         try:
             decoded = ast.literal_eval(node_or_string=match.group(0)).decode(

--- a/tests/test_gen_reply.py
+++ b/tests/test_gen_reply.py
@@ -3568,6 +3568,57 @@ def test_extract_friendly_error_reads_a_decoded_400_body() -> None:
     assert extract_friendly_error(exc=wrapped) == "quota"
 
 
+def test_extract_friendly_error_peels_a_flattened_litellm_wrapper_chain() -> None:
+    """The provider's own sentence reaches the embed whichever way LiteLLM rendered it.
+
+    Which of the two shapes arrives records WHEN the request broke, not what broke, so the same
+    provider message shows up in both and neither may bring the wrapper chain along with it.
+    """
+    request = httpx.Request(method="POST", url="http://proxy/v1/responses")
+    high_demand = (
+        "This model is currently experiencing high demand. Spikes in demand are usually "
+        "temporary. Please try again later."
+    )
+    chain = "litellm.MidStreamFallbackError: litellm.ServiceUnavailableError: Vertex_ai_beta"
+
+    def _mid_stream(message: str) -> APIError:
+        frame = {"message": message, "type": "None", "param": "None", "code": "503"}
+        return APIError(message=message, request=request, body=frame)
+
+    # The stream never opened, so the handler read the body as bytes and `str()` embedded their
+    # repr: the provider document rides along unparsed.
+    document = {"error": {"code": 503, "message": high_demand, "status": "UNAVAILABLE"}}
+    unopened = f"{chain}Exception - {json.dumps(obj=document).encode()!r}\n"
+    assert extract_friendly_error(exc=_mid_stream(message=unopened)) == high_demand
+
+    # The stream opened and a chunk carried the error object, so LiteLLM parsed it and re-rendered
+    # it as `<canonical status> - <message>`, leaving no bytes literal to find.
+    flattened = f"{chain}Exception - UNAVAILABLE - {high_demand}"
+    assert extract_friendly_error(exc=_mid_stream(message=flattened)) == high_demand
+
+    # The shapes are not per-message: a second message came through the same path in the same
+    # window, and its status is a different canonical one.
+    deadline = "Deadline expired before operation could complete."
+    expired = f"{chain}Exception - DEADLINE_EXCEEDED - {deadline}"
+    assert extract_friendly_error(exc=_mid_stream(message=expired)) == deadline
+
+    # A segment is a run of words rather than one token: the vertex mapping puts a second label
+    # inside the marker on some branches, and the openai one puts one in front of it.
+    blocked = "The response was blocked by the safety filter."
+    labelled = f"litellm.BadRequestError: Vertex_ai_betaException BadRequestError - {blocked}"
+    assert extract_friendly_error(exc=_mid_stream(message=labelled)) == blocked
+
+    # The run is anchored, so a class named after neither `Error` nor `Exception` would cost not
+    # its own segment but every segment behind it. `Timeout` is the only one.
+    timed_out = f"litellm.Timeout: Timeout Error: VertexAIException - {deadline}"
+    assert extract_friendly_error(exc=_mid_stream(message=timed_out)) == deadline
+
+    # Peeling that leaves nothing behind is discarded, since a chain still says more than an
+    # empty embed would.
+    bare = "litellm.APIConnectionError: Vertex_ai_betaException - "
+    assert extract_friendly_error(exc=_mid_stream(message=bare)) == bare
+
+
 def test_is_retryable_llm_error_reads_the_status_out_of_every_wrapper_shape() -> None:
     """A transient upstream failure is retried; a refusal and an unreadable one are not."""
     request = httpx.Request(method="POST", url="http://proxy/v1/responses")


### PR DESCRIPTION
A mid-stream provider failure reaches the user's failure embed in one of two shapes, and
`extract_friendly_error` only knew one of them. The other, which was the more common of the two in
the sampled window, showed the whole LiteLLM wrapper chain in front of the one sentence written
for the user.

## The rule

Read off the running proxy (litellm 1.98.0), the chain in front of a provider sentence is
assembled by three sites, each prepending one segment:

- `exceptions.py` — every LiteLLM exception class sets `self.message = f"litellm.{ClassName}: {message}"`.
- `litellm_core_utils/exception_mapping_utils.py` — the provider marker `f"{exception_provider} - {message}"`,
  where `exception_provider` is `<Provider>Exception`. Several branches carry a second label with
  it, either in front (`ContextWindowExceededError: `, `Timeout Error: `) or inside the marker
  (`Vertex_ai_betaException BadRequestError - `).
- `llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py::_check_streaming_error` —
  `f"{error_status} - {error_message}"`, the Google canonical status, which is the segment that
  distinguishes the shape this fixes.

So a segment is either a short run of code-shaped words whose last one ends in `Error`, `Exception`
or `Timeout`, followed by `: ` or ` - `, or a single ALL-CAPS status followed by ` - `. That run is
peeled off the left and the peel stops at the first thing that is not one.

The rule names no exception class, no provider and no status, only the shape all three sites share,
so LiteLLM's next wording change costs nothing. It is tight against a provider sentence, which is
prose and does not open with a word ending in `Error` followed by a separator. `Timeout` is in the
alternation because the run is anchored: it is the one class in `exceptions.py` named after neither
of the other two, so leaving it out would cost not that segment but every segment behind it.

## Changes

- `utils/llm_errors.py::extract_friendly_error` — the peel runs between the decoded-body read and
  the existing bytes-literal scan, so the shape that already worked is unchanged and the flattened
  one falls out of the same step. A peel that leaves nothing behind is discarded, so a failure
  whose whole message is a wrapper chain still shows the chain rather than an empty embed.
- `tests/test_gen_reply.py` — both shapes of the sampled 503, the second message that came through
  the same path in the same window under a different canonical status, the two-word label variant,
  the `litellm.Timeout` chain, and the empty-peel guard. Every case but the first fails against the
  previous function.

Scope is the displayed text only; `llm_status_code` and `is_retryable_llm_error` read the status
structurally and never off this text, so nothing about retry or classification moves.

Closes #564

---

Opened-by: Claude Opus 5
