### PR TITLE
chore: rename ty strict-literal-narrowing to strict-equality-semantics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -536,4 +536,6 @@ possibly-missing-attribute = "warn"
 possibly-missing-import = "warn"
 
 [tool.ty.analysis]
-strict-literal-narrowing = true
+# Renamed from `strict-literal-narrowing` in ty 0.0.63. The old name still parses as an
+# alias, and the migration guide linked above has not caught up to the new one yet.
+strict-equality-semantics = true


### PR DESCRIPTION
## What

`[tool.ty.analysis]` still used `strict-literal-narrowing`. ty renamed that option to
`strict-equality-semantics` in 0.0.63; the old name survives only as a `serde` alias and
was dropped from the configuration reference at that same release.

Behaviour is unchanged: both spellings write the same field.

## Ported from

`Mai0313/repo_template` @ `19d2a26` (repo_template#453). Only the `[tool.ty.analysis]`
block was taken; this repo's own comment wording above it is left as it is.

## Version floor

This repo pins `astral-sh/ty-pre-commit` at `v0.0.63`, which is exactly the release that
introduced the new name, so it works but has no margin. Measured: 0.0.62 rejects
`strict-equality-semantics` with a TOML parse error before checking anything, 0.0.63
accepts it. The pinned hook was run locally against this change and passed.

Opened-by: Claude Opus 5 (1M context)